### PR TITLE
fix: Deploy files with no extensions, fixes using qcoro with artifactory

### DIFF
--- a/mama/papa_deploy.py
+++ b/mama/papa_deploy.py
@@ -77,7 +77,7 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
     config = target.config
     includes_root = package_full_path + '/include'
     # TODO: should we include .cpp files for easier debugging?
-    includes_filter = ['.h','.hpp','.hxx','.hh','.c','.cpp','.cxx']
+    includes_filter = ['.h','.hpp','.hxx','.hh','.c','.cpp','.cxx', '']
 
     # set the default include
     descr.append(f'I include')
@@ -108,7 +108,7 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
 
 
 def papa_deploy_to(target:BuildTarget, package_full_path:str,
-                   r_includes:bool, r_dylibs:bool, 
+                   r_includes:bool, r_dylibs:bool,
                    r_syslibs:bool, r_assets:bool):
     config = target.config
     detail_echo = config.print and target.is_current_target() and (not config.test)

--- a/mama/util.py
+++ b/mama/util.py
@@ -393,15 +393,14 @@ def _should_copy(src: str, dst: str):
     return False
 
 
-def _passes_filter(src_file: str, filter: list) -> bool:
-    if not filter:
+def _passes_extension_filter(src_file: str, extensions: list) -> bool:
+    if not extensions:
         return True
-    if isinstance(filter, str):
-        return src_file.endswith(filter)
-    for f in filter:
-        if src_file.endswith(f):
-            return True
-    return False
+    _, ext = os.path.splitext(src_file)
+    if ext:
+        return ext in extensions
+    else:
+        return '' in extensions
 
 
 def copy_file(src: str, dst: str, filter: list = None) -> bool:
@@ -410,7 +409,7 @@ def copy_file(src: str, dst: str, filter: list = None) -> bool:
         if it has changed, returns TRUE if copied.
         The filter can be a string suffix or a list of string suffixes.
     """
-    if _passes_filter(src, filter):
+    if _passes_extension_filter(src, filter):
         if os.path.isdir(dst):
             dst = os.path.join(dst, os.path.basename(src))
         if _should_copy(src, dst):


### PR DESCRIPTION
Currently files with no extensions get filtered out. This makes papa create a broken artifactory cache for qcoro. 
QCoro headers are included like this: ``#include <QCoro/QCoroTask>``
They are expressed via an extensionless file in the include folder, e.g include/qcoro6/qcoro/QCoroTimer containing ``#include "qcorotimer.h"`` (Same pattern as in Qt)