### PR TITLE
fix: disable ssh multiplex on native Windows

### DIFF
--- a/mama/_version.py
+++ b/mama/_version.py
@@ -1,2 +1,2 @@
 # this is parsed by pyproject.toml and defines current mamabuild version
-__version__ = "0.11.29"
+__version__ = "0.11.30"

--- a/mama/utils/ssh_multiplex.py
+++ b/mama/utils/ssh_multiplex.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import atexit
 import contextlib
-import functools
 import os
 import re
 import shlex
@@ -35,7 +34,6 @@ import sys
 import threading
 from urllib.parse import urlparse
 
-from .sub_process import execute_piped
 from .system import System
 
 
@@ -141,18 +139,14 @@ def is_multiplex_configured(probe: dict[str, str]) -> bool:
     return cm not in ('no', 'false', '') and cp not in ('none', '', 'no')
 
 
-@functools.cache
 def multiplex_known_broken() -> bool:
-    """True iff the active ssh is Microsoft's OpenSSH for Windows, whose
-    ControlMaster is flaky (master drops, stale socket blocks reattach).
-    Detected via the `OpenSSH_for_Windows_<ver>` banner; Cygwin/MSYS/Git-Bash
-    on Windows report the standard banner and work fine."""
-    if not System.windows:
-        return False
-    out = execute_piped(['ssh', '-V'], timeout=5, throw=False, merge_stderr=True)
-    if out is None:
-        return True  # ssh missing or failed — be safe
-    return 'for_windows' in out.lower()
+    """Native Windows: skip multiplex entirely. Microsoft OpenSSH's
+    ControlMaster is unreliable in practice — `mux_client_request_session:
+    read from master failed: Connection reset by peer` mid-fetch and stale
+    `ControlSocket ... already exists, disabling multiplexing` after a master
+    drops. WSL/Cygwin/Git-Bash run as Linux from Python's POV
+    (`System.windows == False`) and keep multiplex."""
+    return System.windows
 
 
 def options_to_add(probe: dict[str, str]) -> tuple[list[str], bool]:

--- a/mama/utils/sub_process.py
+++ b/mama/utils/sub_process.py
@@ -224,24 +224,19 @@ def execute(command, echo=False, throw=True):
 
 
 # TODO: use new SubProcess.run instead
-def execute_piped(command, cwd=None, timeout=None, throw=True, merge_stderr=False):
+def execute_piped(command, cwd=None, timeout=None, throw=True):
     """
     Executes a command and returns the piped outout string
     - command: command string
     - cwd: working dir for the subprocess
     - timeout: timeout in seconds
     - throw: if True, throws exception on status_code != 0
-    - merge_stderr: if True, stderr is captured into the returned string too.
-                    Useful for tools like `ssh -V` that emit to stderr.
     - returns: output string or None if throw=False
     """
     if not isinstance(command, list):
         command = shlex.split(command)
     try:
-        cp = subprocess.run(command,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT if merge_stderr else None,
-                            cwd=cwd, timeout=timeout)
+        cp = subprocess.run(command, stdout=subprocess.PIPE, cwd=cwd, timeout=timeout)
         return cp.stdout.decode('utf-8').rstrip()
     except Exception as e:
         if throw:

--- a/tests/test_ssh_multiplex/test_ssh_multiplex.py
+++ b/tests/test_ssh_multiplex/test_ssh_multiplex.py
@@ -144,11 +144,10 @@ class TestOptionsToAdd:
         assert not any(o.startswith('-oControlPath=') for o in opts)
         assert any(o.startswith('-oServerAliveInterval=') for o in opts)
 
-    def test_windows_microsoft_ssh_skips_multiplex_keeps_keepalives(self, monkeypatch, tmp_path):
-        # Microsoft OpenSSH on Windows has unreliable ControlMaster — the
-        # master drops mid-session and leaves the socket file behind. We
-        # detect it via the "for_Windows" banner string and skip multiplex.
-        monkeypatch.setattr(sm, 'multiplex_known_broken', lambda: True)
+    def test_windows_skips_multiplex_keeps_keepalives(self, monkeypatch, tmp_path):
+        # Native Windows: Microsoft OpenSSH ControlMaster is unreliable in
+        # practice, so we skip multiplex entirely. Keepalives still help.
+        monkeypatch.setattr(sm.System, 'windows', True)
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
         monkeypatch.setattr(sm, '_OUR_CONTROL_PATH', str(tmp_path / 'cm' / '%C'))
         probe = {'controlmaster': 'no', 'controlpath': 'none',
@@ -161,24 +160,11 @@ class TestOptionsToAdd:
         assert any(o.startswith('-oServerAliveInterval=') for o in opts)
         assert any(o.startswith('-oServerAliveCountMax=') for o in opts)
 
-    def test_windows_cygwin_ssh_keeps_multiplex(self, monkeypatch, tmp_path):
-        # Cygwin/Git-Bash ssh on Windows reports the standard banner and has
-        # working ControlMaster — so we DO add multiplex even though we're
-        # on Windows. (Equivalent to "non-buggy ssh" in detection terms.)
-        monkeypatch.setattr(sm, 'multiplex_known_broken', lambda: False)
-        monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
-        monkeypatch.setattr(sm, '_OUR_CONTROL_PATH', str(tmp_path / 'cm' / '%C'))
-        probe = {'controlmaster': 'no', 'controlpath': 'none',
-                 'serveraliveinterval': '0'}
-        opts, we_own = sm.options_to_add(probe)
-        assert we_own is True
-        assert any(o.startswith('-oControlMaster=') for o in opts)
-
     def test_windows_user_configured_multiplex_respected(self, monkeypatch):
-        # Even when the active ssh is the buggy one, if the user has multiplex
-        # explicitly configured (e.g. via ~/.ssh/config pointing at Cygwin ssh)
-        # we must respect their config, not override it.
-        monkeypatch.setattr(sm, 'multiplex_known_broken', lambda: True)
+        # If the user has multiplex explicitly configured (e.g. via
+        # ~/.ssh/config pointing at Cygwin ssh) we respect their config and
+        # don't add anything — even on Windows.
+        monkeypatch.setattr(sm.System, 'windows', True)
         probe = {
             'controlmaster': 'auto', 'controlpath': '~/.ssh/sockets/%C',
             'serveraliveinterval': '30', 'serveralivecountmax': '5',
@@ -189,50 +175,15 @@ class TestOptionsToAdd:
 
 
 class TestMultiplexKnownBroken:
-    """`ssh -V` banner parsing for known-buggy clients."""
+    """Multiplex is disabled on native Windows; everywhere else it's fine.
+    WSL/Cygwin/Git-Bash run as Linux from Python's POV (System.windows=False)."""
 
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        sm.multiplex_known_broken.cache_clear()
-        yield
-        sm.multiplex_known_broken.cache_clear()
-
-    def test_non_windows_never_broken(self, monkeypatch):
-        # On Linux/macOS we don't even probe — multiplex always works.
+    def test_non_windows_not_broken(self, monkeypatch):
         monkeypatch.setattr(sm.System, 'windows', False)
-        ep = mock.Mock()
-        monkeypatch.setattr(sm, 'execute_piped', ep)
-        assert sm.multiplex_known_broken() is False
-        ep.assert_not_called()
-
-    def test_microsoft_for_windows_banner_detected(self, monkeypatch):
-        monkeypatch.setattr(sm.System, 'windows', True)
-        monkeypatch.setattr(sm, 'execute_piped',
-                            lambda *a, **k: 'OpenSSH_for_Windows_8.6p1, LibreSSL 3.4.3')
-        assert sm.multiplex_known_broken() is True
-
-    def test_cygwin_banner_not_broken(self, monkeypatch):
-        monkeypatch.setattr(sm.System, 'windows', True)
-        monkeypatch.setattr(sm, 'execute_piped',
-                            lambda *a, **k: 'OpenSSH_9.6p1, OpenSSL 3.0.13 30 Jan 2024')
         assert sm.multiplex_known_broken() is False
 
-    def test_result_is_cached(self, monkeypatch):
+    def test_windows_is_broken(self, monkeypatch):
         monkeypatch.setattr(sm.System, 'windows', True)
-        ep = mock.Mock(return_value='OpenSSH_for_Windows_8.6p1')
-        monkeypatch.setattr(sm, 'execute_piped', ep)
-        sm.multiplex_known_broken()
-        sm.multiplex_known_broken()
-        sm.multiplex_known_broken()
-        assert ep.call_count == 1
-
-    def test_ssh_missing_treated_as_broken_on_windows(self, monkeypatch):
-        # Conservative default: if we can't even invoke ssh, don't risk
-        # configuring multiplex on Windows.
-        monkeypatch.setattr(sm.System, 'windows', True)
-        # execute_piped(throw=False) returns None on failure; we treat that as
-        # the conservative "skip mux" default.
-        monkeypatch.setattr(sm, 'execute_piped', lambda *a, **k: None)
         assert sm.multiplex_known_broken() is True
 
 


### PR DESCRIPTION
## Summary
- Drop banner-based "Microsoft OpenSSH" detection from #19; just disable multiplex on native Windows entirely (`System.windows == True`)
- WSL/Cygwin/Git-Bash keep multiplex (they report `System.windows == False`)
- Drop now-unused `merge_stderr` parameter from `execute_piped`

## Why
After #19 / v0.11.29, Jorma still saw on Windows:
```
mux_client_request_session: read from master failed: Connection reset by peer
ControlSocket C:\Users\jorma/.ssh/cm\... already exists, disabling multiplexing
```
The `OpenSSH_for_Windows_<ver>` banner heuristic isn't catching every broken-mux configuration in practice. Per Jorma's instruction: "If you can't figure this out, just disable ssh mux entirely on Windows (natively only, wsl is probably fine)."

## Test plan
- [x] `pytest tests/test_ssh_multiplex/` — 38 passed
- [x] Bumped `_version.py` to 0.11.30 to trigger deploy on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)