### PR TITLE
build: per-sanitizer build dirs to avoid reconfigure churn

### DIFF
--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -438,13 +438,26 @@ class BuildConfig:
     def build_dir_default(self): return 'build'
 
 
+    # per-sanitizer build dir suffix so flavors don't share a dir and force a reconfigure
+    SANITIZER_SUFFIX = { 'address':'-asan', 'leak':'-lsan', 'thread':'-tsan', 'undefined':'-ubsan' }
+
+    def build_dir_suffix(self):
+        if not self.sanitize: return '' # no sanitizer -> unchanged build dir (back-compat)
+        return ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
+
+
     def platform_build_dir_name(self):
         """
         Gets the build folder name depending on platform and architecture.
         By default 64-bit architectures use the platform name, eg 'windows' or 'linux'
         And 32-bit architectures add a suffix, eg 'windows32' or 'linux32'
+        Sanitizer builds add a further suffix, eg 'linux-asan' or 'windows-tsan'.
         """
         # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
+        return self._platform_build_dir_name() + self.build_dir_suffix()
+
+
+    def _platform_build_dir_name(self):
         if self.msvc:
             if self.is_target_arch_x64(): return self.build_dir_win64()
             if self.is_target_arch_x86(): return self.build_dir_win32()

--- a/mama/dependency_chain.py
+++ b/mama/dependency_chain.py
@@ -287,7 +287,9 @@ def _save_mama_cmake(root: BuildDependency):
     c:BuildConfig = root.config
 
     # gets the defines for a single platform and architecture
+    # must match platform_build_dir_name(): same sanitizer suffix as the actual build dir
     def get_build_dir_defines(build_dir):
+        build_dir += c.build_dir_suffix()
         return f'''set(MAMA_BUILD "{build_dir}")
         {_get_mama_dependencies_cmake(root, build_dir)}'''
 

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -1,0 +1,33 @@
+from mama.build_config import BuildConfig
+
+
+def linux_config():
+    """A BuildConfig pinned to linux/x64 so dir names are host-independent."""
+    c = BuildConfig([])
+    c.msvc = c.macos = c.ios = c.android = c.raspi = False
+    c.mips = c.oclea = c.xilinx = c.imx8mp = c.yocto_linux = None
+    c.linux = True
+    c.arch = 'x64'
+    return c
+
+
+def test_no_sanitizer_dir_unchanged():
+    c = linux_config()
+    assert c.build_dir_suffix() == ''
+    assert c.platform_build_dir_name() == 'linux'
+
+
+def test_each_sanitizer_gets_own_dir():
+    c = linux_config()
+    for sanitize, expected in [('address', 'linux-asan'),
+                               ('thread',  'linux-tsan'),
+                               ('undefined', 'linux-ubsan'),
+                               ('leak',    'linux-lsan')]:
+        c.sanitize = sanitize
+        assert c.platform_build_dir_name() == expected
+
+
+def test_combined_sanitizers_stay_distinct():
+    c = linux_config()
+    c.sanitize = 'address,undefined'
+    assert c.platform_build_dir_name() == 'linux-asan-ubsan'


### PR DESCRIPTION
## Problem

All sanitizer flavors write to the same platform build dir (`packages/<pkg>/linux`, `windows`, …). `self.sanitize` isn't part of the build path, so switching between `asan` / `tsan` / `ubsan` / none reuses one dir with a different sanitizer than it was configured for. `run_config()` then sees the sanitizer marker changed and forces a full CMake reconfigure every switch — slow, and occasionally a stale-mix build failure.

## Fix

Suffix the build dir per sanitizer, reusing the existing CLI short tokens:

| `--sanitize` | dir |
|---|---|
| (none) | `linux` *(unchanged)* |
| `address` | `linux-asan` |
| `thread` | `linux-tsan` |
| `undefined` | `linux-ubsan` |
| `leak` | `linux-lsan` |

(and the same for every platform: `windows-asan`, `android-tsan`, …)

One `build_dir_suffix()` helper, applied in the two places that pick the per-platform name: `platform_build_dir_name()` and `dependency_chain._save_mama_cmake`'s `get_build_dir_defines` (kept in sync per the existing WARNING comment, so dependency `mama.cmake` include paths match the suffixed dep dirs). No sanitizer ⇒ no suffix ⇒ existing caches stay valid. Each flavor now keeps its own dir + `CMakeCache.txt`, so switching between already-built flavors no longer reconfigures.

## Verification

Added `tests/test_build_dir/` asserting the per-sanitizer names and that no-sanitizer is unchanged. Full existing suite (85 tests) green.

Ran the patched mama against a throwaway CMake project: `build asan` then `build tsan` create separate `linux-asan` / `linux-tsan` dirs with the right `enabled_sanitizers`; re-running each already-built flavor **skips** CMake configure (no churn); plain `build` still uses `linux`.

## Back-compat note

First build of each sanitizer flavor after upgrading mama configures once into its new suffixed dir (the old shared `linux` dir keeps the no-sanitizer build). Expected, one-time.
