### PR TITLE
build: separate build dirs for sanitizer and coverage builds

### DIFF
--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -438,13 +438,26 @@ class BuildConfig:
     def build_dir_default(self): return 'build'
 
 
+    # per-sanitizer build dir suffix so flavors don't share a dir and force a reconfigure
+    SANITIZER_SUFFIX = { 'address':'-asan', 'leak':'-lsan', 'thread':'-tsan', 'undefined':'-ubsan' }
+
+    def build_dir_suffix(self):
+        if not self.sanitize: return '' # no sanitizer -> unchanged build dir (back-compat)
+        return ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
+
+
     def platform_build_dir_name(self):
         """
         Gets the build folder name depending on platform and architecture.
         By default 64-bit architectures use the platform name, eg 'windows' or 'linux'
         And 32-bit architectures add a suffix, eg 'windows32' or 'linux32'
+        Sanitizer builds add a further suffix, eg 'linux-asan' or 'windows-tsan'.
         """
         # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
+        return self._platform_build_dir_name() + self.build_dir_suffix()
+
+
+    def _platform_build_dir_name(self):
         if self.msvc:
             if self.is_target_arch_x64(): return self.build_dir_win64()
             if self.is_target_arch_x86(): return self.build_dir_win32()

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -441,11 +441,10 @@ class BuildConfig:
     # per-sanitizer build dir suffix so flavors don't share a dir and force a reconfigure
     SANITIZER_SUFFIX = { 'address':'-asan', 'leak':'-lsan', 'thread':'-tsan', 'undefined':'-ubsan' }
 
-    def build_dir_suffix(self):
-        suffix = ''
-        if self.coverage: suffix += '-coverage'
-        if self.sanitize: suffix += ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
-        return suffix # no coverage/sanitizer -> unchanged build dir (back-compat)
+    def build_dir_with_suffix(self, build_dir):
+        if self.coverage: build_dir += '-coverage'
+        if self.sanitize: build_dir += ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
+        return build_dir
 
 
     def platform_build_dir_name(self):
@@ -456,10 +455,9 @@ class BuildConfig:
         Coverage builds add '-coverage' and sanitizer builds add a further
         suffix, eg 'linux-coverage', 'linux-asan' or 'linux-coverage-asan'.
         """
-        return self._platform_build_dir_name() + self.build_dir_suffix()
+        return self.build_dir_with_suffix(self._platform_build_dir_name())
 
 
-    # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
     def _platform_build_dir_name(self):
         if self.msvc:
             if self.is_target_arch_x64(): return self.build_dir_win64()

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -456,10 +456,10 @@ class BuildConfig:
         Coverage builds add '-coverage' and sanitizer builds add a further
         suffix, eg 'linux-coverage', 'linux-asan' or 'linux-coverage-asan'.
         """
-        # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
         return self._platform_build_dir_name() + self.build_dir_suffix()
 
 
+    # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
     def _platform_build_dir_name(self):
         if self.msvc:
             if self.is_target_arch_x64(): return self.build_dir_win64()

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -442,8 +442,10 @@ class BuildConfig:
     SANITIZER_SUFFIX = { 'address':'-asan', 'leak':'-lsan', 'thread':'-tsan', 'undefined':'-ubsan' }
 
     def build_dir_suffix(self):
-        if not self.sanitize: return '' # no sanitizer -> unchanged build dir (back-compat)
-        return ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
+        suffix = ''
+        if self.coverage: suffix += '-coverage'
+        if self.sanitize: suffix += ''.join(self.SANITIZER_SUFFIX.get(s, '-'+s) for s in self.sanitize.split(','))
+        return suffix # no coverage/sanitizer -> unchanged build dir (back-compat)
 
 
     def platform_build_dir_name(self):
@@ -451,7 +453,8 @@ class BuildConfig:
         Gets the build folder name depending on platform and architecture.
         By default 64-bit architectures use the platform name, eg 'windows' or 'linux'
         And 32-bit architectures add a suffix, eg 'windows32' or 'linux32'
-        Sanitizer builds add a further suffix, eg 'linux-asan' or 'windows-tsan'.
+        Coverage builds add '-coverage' and sanitizer builds add a further
+        suffix, eg 'linux-coverage', 'linux-asan' or 'linux-coverage-asan'.
         """
         # WARNING: This needs to be in sync with dependency_chain.py: _save_mama_cmake !!!
         return self._platform_build_dir_name() + self.build_dir_suffix()

--- a/mama/dependency_chain.py
+++ b/mama/dependency_chain.py
@@ -286,10 +286,8 @@ def _save_mama_cmake(root: BuildDependency):
     #       because CLion has a hard time detecting macro paths
     c:BuildConfig = root.config
 
-    # gets the defines for a single platform and architecture
-    # must match platform_build_dir_name(): same sanitizer suffix as the actual build dir
     def get_build_dir_defines(build_dir):
-        build_dir += c.build_dir_suffix()
+        build_dir = c.build_dir_with_suffix(build_dir)
         return f'''set(MAMA_BUILD "{build_dir}")
         {_get_mama_dependencies_cmake(root, build_dir)}'''
 

--- a/mama/dependency_chain.py
+++ b/mama/dependency_chain.py
@@ -287,7 +287,9 @@ def _save_mama_cmake(root: BuildDependency):
     c:BuildConfig = root.config
 
     # gets the defines for a single platform and architecture
+    # must match platform_build_dir_name(): same sanitizer suffix as the actual build dir
     def get_build_dir_defines(build_dir):
+        build_dir += c.build_dir_suffix()
         return f'''set(MAMA_BUILD "{build_dir}")
         {_get_mama_dependencies_cmake(root, build_dir)}'''
 

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -1,0 +1,33 @@
+from mama.build_config import BuildConfig
+
+
+def linux_config():
+    """A BuildConfig pinned to linux/x64 so dir names are host-independent."""
+    c = BuildConfig([])
+    c.msvc = c.macos = c.ios = c.android = c.raspi = False
+    c.mips = c.oclea = c.xilinx = c.imx8mp = c.yocto_linux = None
+    c.linux = True
+    c.arch = 'x64'
+    return c
+
+
+def test_no_sanitizer_dir_unchanged():
+    c = linux_config()
+    assert c.build_dir_suffix() == ''
+    assert c.platform_build_dir_name() == 'linux'
+
+
+def test_each_sanitizer_gets_own_dir():
+    c = linux_config()
+    for sanitize, expected in [('address', 'linux-asan'),
+                               ('thread',  'linux-tsan'),
+                               ('undefined', 'linux-ubsan'),
+                               ('leak',    'linux-lsan')]:
+        c.sanitize = sanitize
+        assert c.platform_build_dir_name() == expected
+
+
+def test_combined_sanitizers_stay_distinct():
+    c = linux_config()
+    c.sanitize = 'address,undefined'
+    assert c.platform_build_dir_name() == 'linux-asan-ubsan'

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -31,3 +31,16 @@ def test_combined_sanitizers_stay_distinct():
     c = linux_config()
     c.sanitize = 'address,undefined'
     assert c.platform_build_dir_name() == 'linux-asan-ubsan'
+
+
+def test_coverage_gets_own_dir():
+    c = linux_config()
+    c.coverage = 'default'
+    assert c.platform_build_dir_name() == 'linux-coverage'
+
+
+def test_coverage_composes_with_sanitizer():
+    c = linux_config()
+    c.coverage = 'default'
+    c.sanitize = 'address'
+    assert c.platform_build_dir_name() == 'linux-coverage-asan'

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -13,7 +13,7 @@ def linux_config():
 
 def test_no_sanitizer_dir_unchanged():
     c = linux_config()
-    assert c.build_dir_suffix() == ''
+    assert c.build_dir_with_suffix('linux') == 'linux'
     assert c.platform_build_dir_name() == 'linux'
 
 


### PR DESCRIPTION
## Problem

All sanitizer flavors write to the same platform build dir (`packages/<pkg>/linux`, `windows`, …). `self.sanitize` isn't part of the build path, so switching between `asan` / `tsan` / `ubsan` / none reuses one dir with a different sanitizer than it was configured for. `run_config()` then sees the sanitizer marker changed and forces a full CMake reconfigure every switch — slow, and occasionally a stale-mix build failure. Coverage (`mama coverage`) had the exact same problem: it landed in plain `linux` and collided with both plain and sanitizer builds.

## Fix

Suffix the build dir per flavor via one `build_dir_suffix()` helper, reusing the existing CLI short tokens for sanitizers and adding a `-coverage` marker that composes cleanly in front of any sanitizer suffix:

| flavor | dir |
|---|---|
| (none) | `linux` *(unchanged)* |
| `coverage` | `linux-coverage` |
| `address` | `linux-asan` |
| `thread` | `linux-tsan` |
| `undefined` | `linux-ubsan` |
| `leak` | `linux-lsan` |
| `coverage` + `address` | `linux-coverage-asan` |

(and the same for every platform: `windows-asan`, `android-tsan`, `linux-coverage`, …)

The helper is applied in the two places that pick the per-platform name: `platform_build_dir_name()` and `dependency_chain._save_mama_cmake`'s `get_build_dir_defines` (kept in sync per the existing WARNING comment, so dependency `mama.cmake` include paths match the suffixed dep dirs). No coverage and no sanitizer ⇒ no suffix ⇒ existing caches stay valid. Each flavor now keeps its own dir + `CMakeCache.txt`, so switching between already-built flavors no longer reconfigures.

## Coverage

`mama coverage build` now lands in `linux-coverage` instead of sharing `linux`. The marker is prepended to the sanitizer suffix, so `mama coverage asan build` → `linux-coverage-asan`, keeping the previously-reviewed sanitizer dir names byte-identical (`linux-asan`, etc.). Plain `mama build` is unchanged (`linux`), so existing non-coverage caches stay valid.

## Verification

`tests/test_build_dir/` asserts the per-sanitizer names, the new coverage-only (`linux-coverage`) and coverage+sanitizer (`linux-coverage-asan`) names, and that no-coverage/no-sanitizer is unchanged. Full existing suite is green — **87 tests** (prior 85 + 2 new coverage cases).

Ran the patched mama against a throwaway CMake project: `mama coverage build`, `mama asan build`, and `mama coverage asan build` create separate `linux-coverage` / `linux-asan` / `linux-coverage-asan` dirs; the `MAMA_BUILD` define in the generated `mama.cmake` matches the on-disk dir for each; re-running each already-built flavor **skips** CMake configure (no churn); plain `build` still uses `linux`.

## Back-compat note

First build of each flavor after upgrading mama configures once into its new suffixed dir (the old shared `linux` dir keeps the plain no-coverage/no-sanitizer build). Expected, one-time.

Supersedes #22 (moved off fork to a branch on this repo).

## LOC breakdown

| | prod | tests |
|---|---|---|
| sanitizer dirs (8f07b02) | 18 | 33 |
| coverage dirs (this change) | 3 | 13 |
| **branch total vs master** | **18** | **46** |