### PR TITLE
fix: -fno-sanitize-recover so sanitizer errors fail the build

### DIFF
--- a/mama/cmake_configure.py
+++ b/mama/cmake_configure.py
@@ -223,6 +223,7 @@ def _default_options(target:BuildTarget):
             console(f'Enabling sanitizers: {config.sanitize}', color=Color.MAGENTA)
             ld_sanitize = f'-fsanitize={config.sanitize}'
             add_flag('-fsanitize', config.sanitize)
+            add_flag('-fno-sanitize-recover', config.sanitize) # fail the build on the first sanitizer error (UBSan recovers by default)
             add_flag('-fno-omit-frame-pointer')
             add_flag('-fPIE')
             add_ldflag('-pie') # -pie is a linker flag


### PR DESCRIPTION
## What

UBSan recovers by default — it prints the error, continues, and **exits 0**. So a `sanitize=undefined` build passes green despite real UB. This adds `-fno-sanitize-recover` (matching the enabled sanitizer set) for gcc/clang, so the first sanitizer error aborts the build.

## Verified

`mama ubsan build test` on a target with a misaligned read:

- **before:** `runtime error: load of misaligned address …` printed, **exit 0** (green)
- **after:** same error, **exit 1** (build fails)

Harmless for `address`/`thread`/`leak` — all accept the flag (tested). One line, mirrors the existing `-fsanitize` injection just above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
