### PR TITLE
fix: validate zip contents against papa.txt before uploading

### DIFF
--- a/mama/papa_upload.py
+++ b/mama/papa_upload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
+from collections import Counter
 import os, zipfile, shutil
 
 from .artifactory import artifactory_archive_name, artifactory_upload_ftp
@@ -25,6 +26,50 @@ def _append_files_recursive(zip: zipfile.ZipFile, rel_path:str, full_path:str):
                 zip.write(src_file, rel_file)
     else:
         zip.write(full_path, rel_path)
+
+
+def _zip_path(path: str):
+    return path.replace('\\', '/')
+
+
+def validate_archive(package_full_path: str, papa: PapaFileInfo, archive_path: str):
+    expected = Counter(['papa.txt'])
+
+    for include in papa.includes:
+        if os.path.isdir(include):
+            for full_dir, _, files in os.walk(include):
+                for file in files:
+                    src_file = os.path.join(full_dir, file)
+                    rel_file = os.path.relpath(src_file, package_full_path)
+                    expected[_zip_path(rel_file)] += 1
+        else:
+            rel_path = os.path.relpath(include, package_full_path)
+            expected[_zip_path(rel_path)] += 1
+
+    for lib in papa.libs:
+        rel_path = os.path.relpath(lib, package_full_path)
+        expected[_zip_path(rel_path)] += 1
+
+    for asset in papa.assets:
+        expected[_zip_path(asset.outpath)] += 1
+
+    with zipfile.ZipFile(archive_path) as zip:
+        actual = Counter(
+            _zip_path(info.filename)
+            for info in zip.infolist()
+            if not info.is_dir()
+        )
+
+    missing = sorted((expected - actual).elements())
+    unexpected = sorted((actual - expected).elements())
+    if missing or unexpected:
+        preview_missing = missing[:20]
+        preview_unexpected = unexpected[:20]
+        raise RuntimeError(
+            f'PAPA archive validation failed for {archive_path}\n'
+            f'missing={preview_missing}\n'
+            f'unexpected={preview_unexpected}'
+        )
 
 
 def papa_upload_to(target:BuildTarget, package_full_path:str):
@@ -76,6 +121,7 @@ def papa_upload_to(target:BuildTarget, package_full_path:str):
     if os.path.exists(archive_path):
         os.remove(archive_path)
     shutil.move(temp_archive, archive_path)
+    validate_archive(package_full_path, papa, archive_path)
 
     if config.print:
         size = os.path.getsize(archive_path)

--- a/tests/test_papa_upload/test_papa_upload.py
+++ b/tests/test_papa_upload/test_papa_upload.py
@@ -4,7 +4,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from mama.papa_upload import papa_upload_to
+import pytest
+
+from mama.papa_deploy import PapaFileInfo
+from mama.papa_upload import papa_upload_to, validate_archive
 from mama.util import normalized_path
 
 
@@ -20,17 +23,50 @@ class FakeTarget:
         return normalized_path(os.path.join(self._build_root, path))
 
 
-def test_papa_upload_preserves_nested_include_prefix(tmp_path: Path):
-    package_root = tmp_path / 'deploy' / 'nested_include_pkg'
-    include_root = Path('include/opencv4')
-    header_rel = Path('opencv2/core/mat.hpp')
-    include_dir = package_root / include_root / header_rel.parent
-    include_dir.mkdir(parents=True)
-    (include_dir / header_rel.name).write_text('// dummy header\n')
-    (package_root / 'papa.txt').write_text('P nested_include_pkg\nI include/opencv4\n')
+def create_sample_package(tmp_path: Path):
+    package_root = tmp_path / 'deploy' / 'sample_pkg'
+    files = {
+        'include/public_headers/sample/header.hpp': '// dummy header\n',
+        'include/version.h': '#define SAMPLE_VERSION 1\n',
+        'lib/libsample.a': 'archive\n',
+        'bin/tool': 'tool\n',
+    }
 
+    for relpath, content in files.items():
+        full_path = package_root / relpath
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(content)
+
+    (package_root / 'papa.txt').write_text(
+        'P sample_pkg\n'
+        'I include/public_headers\n'
+        'I include/version.h\n'
+        'L lib/libsample.a\n'
+        'A bin/tool\n'
+    )
+    return package_root, PapaFileInfo(str(package_root / 'papa.txt'))
+
+
+def build_archive(archive_path: Path, entries: dict[str, Path]):
+    with zipfile.ZipFile(archive_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
+        for archive_name, source in entries.items():
+            zf.write(source, archive_name)
+
+
+def expected_archive_entries(package_root: Path):
+    return {
+        'papa.txt': package_root / 'papa.txt',
+        'include/public_headers/sample/header.hpp': package_root / 'include/public_headers/sample/header.hpp',
+        'include/version.h': package_root / 'include/version.h',
+        'lib/libsample.a': package_root / 'lib/libsample.a',
+        'bin/tool': package_root / 'bin/tool',
+    }
+
+
+def test_papa_upload_preserves_declared_paths_for_supported_content_types(tmp_path: Path):
+    package_root, _ = create_sample_package(tmp_path)
     target = FakeTarget(tmp_path / 'linux')
-    archive_name = 'nested-include-pkg-test-archive'
+    archive_name = 'sample-pkg-test-archive'
 
     with patch('mama.papa_upload.artifactory_archive_name', return_value=archive_name), \
          patch('mama.papa_upload.artifactory_upload_ftp', return_value=False):
@@ -40,11 +76,32 @@ def test_papa_upload_preserves_nested_include_prefix(tmp_path: Path):
     assert archive_path.exists()
 
     with zipfile.ZipFile(archive_path) as zf:
-        names = set(zf.namelist())
+        names = {
+            info.filename
+            for info in zf.infolist()
+            if not info.is_dir()
+        }
 
-    expected_path = f'{include_root}/{header_rel}'
-    flattened_path = f'{include_root.name}/{header_rel}'
+    assert names == set(expected_archive_entries(package_root))
 
-    assert 'papa.txt' in names
-    assert expected_path in names
-    assert flattened_path not in names
+
+def test_validate_archive_rejects_missing_content(tmp_path: Path):
+    package_root, papa = create_sample_package(tmp_path / 'missing')
+    entries = expected_archive_entries(package_root)
+    entries.pop('lib/libsample.a')
+    archive_path = tmp_path / 'missing.zip'
+    build_archive(archive_path, entries)
+
+    with pytest.raises(RuntimeError, match='missing='):
+        validate_archive(str(package_root), papa, str(archive_path))
+
+
+def test_validate_archive_rejects_unexpected_content(tmp_path: Path):
+    package_root, papa = create_sample_package(tmp_path / 'unexpected')
+    entries = expected_archive_entries(package_root)
+    entries['share/extra.txt'] = package_root / 'bin/tool'
+    archive_path = tmp_path / 'unexpected.zip'
+    build_archive(archive_path, entries)
+
+    with pytest.raises(RuntimeError, match='unexpected='):
+        validate_archive(str(package_root), papa, str(archive_path))


### PR DESCRIPTION
Fail hard if to be uploaded zip does not match it's papa.txt. Avoids invalid artifacts in artifactory.