### PR TITLE
docs: improve clarity and consistency of comments and docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,10 @@ it as unsafe in a multi-threaded program, and mama runs many threads in parallel
 
 ## SSH multiplex / parallel loading
 
-- `mama update` auto-enables `parallel_load`. The `fetch_slot` semaphore caps the
-  concurrent git fetches at `parallel_max`, which defaults to 20. This is
-  independent of the worker thread count.
+- Parallel load is the default for every run, and `serial` opts out. The
+  `fetch_slot` semaphore caps the concurrent git fetches at 8
+  (`DEFAULT_MAX_CONCURRENT_FETCHES`), whatever `parallel_max` asks for. `parallel_max` (default 20) sizes the scheduler's LOAD
+  pool. Both are independent of the worker thread count.
 - The `SubProcess.run` calls of the shim probe also go through `fetch_slot`. Count
   the slot acquisitions per probe: one for the clone, and one more for `git show`.
 - `ensure_master_for_url` is idempotent and serialized per host.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,11 @@ that gets committed.
 - **One-liner `if` for a single short statement.** Use `if cond: do_thing()` on
   one line when the body is a single short call.
 - **No em-dashes (U+2014) in code, comments, or docs.** Use a regular ASCII dash
-  `-` instead. An em-dash looks fancy in prose, but it is noise in a source file
-  and hard to grep for. The same applies to any other non-ASCII punctuation, such
-  as the arrow `→`. Write `->`.
+  `-` instead. Non-ASCII punctuation is noise in a source file and hard to grep
+  for. The same applies to the Unicode arrow (U+2192). Write `->`.
 - **Yellow output goes through `warning(text)`** (from `mama.utils.system`),
-  not `console(text, color=Color.YELLOW)`. The helper exists so every warning
-  passes through one function and looks the same.
+  not `console(text, color=Color.YELLOW)`. One function, one look for every
+  warning.
 - **Cache a repeated or invariant calculation.** Never compute the same value
   twice. A `sum()`, probe, `.encode()` or `stat` evaluated twice in one
   expression (for example in a filter AND in the value it builds) is a finding.
@@ -150,10 +149,10 @@ it as unsafe in a multi-threaded program, and mama runs many threads in parallel
 
 ## SSH multiplex / parallel loading
 
-- Parallel load is the default for every run, and `serial` opts out. The
-  `fetch_slot` semaphore caps the concurrent git fetches at 8
-  (`DEFAULT_MAX_CONCURRENT_FETCHES`), whatever `parallel_max` asks for. `parallel_max` (default 20) sizes the scheduler's LOAD
-  pool. Both are independent of the worker thread count.
+- Parallel load is the default for every run, and `serial` opts out. The `fetch_slot`
+  semaphore caps concurrent git fetches at 8 (`DEFAULT_MAX_CONCURRENT_FETCHES`),
+  whatever `parallel_max` asks for. `parallel_max` (default 20) sizes the scheduler's
+  LOAD pool. Both are independent of the worker thread count.
 - The `SubProcess.run` calls of the shim probe also go through `fetch_slot`. Count
   the slot acquisitions per probe: one for the clone, and one more for `git show`.
 - `ensure_master_for_url` is idempotent and serialized per host.
@@ -171,23 +170,21 @@ it as unsafe in a multi-threaded program, and mama runs many threads in parallel
 
 ### Test code style
 
-The same brevity and DRY rules that apply to `mama/` apply to `tests/`. The old
-habit was "tests are throwaway, verbosity is fine". In this repo that habit added
-about 13% removable noise to the new test suite. Do not repeat it.
+The same brevity and DRY rules that apply to `mama/` apply to `tests/`. Tests are
+not throwaway code, so verbosity is not fine there either.
 
 - **Shared stub-builders live in `tests/testutils.py`**, not duplicated per file.
   A second `def _make_dep(tmpdir): config = Mock(); ...` in a new test file is
   duplication. Check `testutils.py` first. Extend or parameterize the existing
-  helper. The current `_make_dep` and `_make_target_with_status` duplication across
-  6 shim/probe/noart/404 test files is the largest case.
+  helper.
 - **Use the pytest `tmp_path` fixture**, not `tempfile.mkdtemp()` with a
-  `try / shutil.rmtree() finally`. `tmp_path` is function-scoped, it cleans itself
-  up, and it is a `pathlib.Path`. Shorter, no boilerplate, no chance of a leak.
+  `try / shutil.rmtree() finally`. `tmp_path` is a function-scoped `pathlib.Path`
+  that removes itself. Shorter, no boilerplate, no chance of a leak.
 - **No `sys.path.insert(...)` boilerplate** in a test file. `tests/conftest.py` is
   the right place for any test-bootstrap path manipulation.
-- **Module docstring: 1-2 lines max, "what this file pins".** The bug background,
-  the fix design and the why-this-was-tricky belong in the commit message. Do not
-  copy them into the test file docstring. The copy goes stale faster there.
+- **Module docstring: 1-2 lines max, "what this file pins".** The bug background
+  and the fix design belong in the commit message, not in the docstring, where
+  the copy goes stale faster.
 - **No class docstring that paraphrases what every test in the class checks.** The
   test method names and their assertions already say it.
 - **Per-test docstrings only when an unusual invariant needs an explanation.** Do
@@ -207,15 +204,14 @@ Edit -> Review -> Refactor -> Test -> (Edit) -> Review  [until 0 issues]
 ```
 
 **This loop is the default behavior, not an option.** Every change set goes through
-it: a one-line fix, a doc edit, an "obviously trivial" diff. The skill exists
-because verbosity and duplication appear most often in the changes that looked fine
-on first write.
+it: a one-line fix, a doc edit, an "obviously trivial" diff. Verbosity and duplication
+appear most often in the changes that looked fine on first write.
 
 **Run the review at every hand-off, not only at the end of a task.** Before you answer
 the user with work in the tree, and while the test suite runs. Its step 0 re-reads
-`ste-writing` and `output-style` from disk. Both drift out of a long session, and a rule
-you cannot see is a rule you do not apply. A `Stop` hook in `.claude/settings.json` says
-the same thing when the tree holds uncommitted changes.
+`ste-writing` and `output-style` from disk, because both drift out of a long session.
+A `Stop` hook in `.claude/settings.json` says the same thing when the tree holds
+uncommitted changes.
 
 Every task ends with these steps:
 1. Implement the change, then start the test suite **in the background**. The suite takes about
@@ -228,11 +224,10 @@ Every task ends with these steps:
    addressed".
 4. Re-run the suite and re-run the review. Loop until `REVIEW PASSED - 0 issues`.
 5. **Never commit until a human has reviewed the diff and approved it.** A green
-   suite and a passed review are necessary but NOT sufficient. A small quirk, such
-   as a wrong guard clause or an over-broad `and not ...` condition, can pass every
-   test and still break the feature. Tests do not catch that class of bug, because
-   the test carries the same wrong assumption as the code. Present the diff, wait
-   for the approval of the human, then commit.
+   suite and a passed review are necessary but NOT sufficient. A wrong guard clause
+   or an over-broad `and not ...` condition can pass every test and still break the
+   feature. The test carries the same wrong assumption as the code. Present
+   the diff, wait for the approval of the human, then commit.
 
 The skill checks: the 130-column limit, no 3+ line single expressions, no break
 after `(`, one-liner `if`, no em-dashes, `warning()` instead of `Color.YELLOW`,
@@ -247,9 +242,9 @@ first, no preamble, no recap, no closing pleasantry, lists capped at five.
 It also runs the `ste-writing` lint over the prose the diff adds - every
 docstring, comment, console string and exception message: no contractions, no
 semicolon in prose, no non-ASCII punctuation, sentences under 20 words, active
-voice, plain verbs, no idiom, one name for one thing. A code comment is held to
-the same standard as an error string, because it ships with the code. This is
-the rule set that slips most often, so the greps in the skill are not optional.
+voice, plain verbs, no idiom, one name for one thing. A code comment gets the
+same standard as an error string, because it ships with the code. This rule set
+slips most often, so the greps in the skill are not optional.
 
 **Less code means fewer bugs.** A reduction of 30-60% on a refactored file is
 normal under these rules. A refactor that does not reduce the line count was too

--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # Mama Build Tool
 Mama - A modular C++ build tool so simple even your mama can use it
 
-Mama turns a tree of C++ libraries - your own and third-party - into a single
-`mama build`. It clones the sources, configures them, and builds them in the right order
-for every platform and compiler you target. The results link into your project.
-No central package repository, no Docker containers, no hand-written toolchain glue -
-just git repos, a minimal set of system libs, and the compilers you already have.
+Mama turns a tree of C++ libraries, your own and third-party, into a single `mama build`.
+It clones, configures and builds them in dependency order for every platform and compiler
+you target, then links the results into your project. No central package repository, no
+Docker, no hand-written toolchain glue: only git repos, a minimal set of system libs, and
+the compilers you already have.
 
 Building is one command: `mama build windows`. Mama picks up trivial CMake projects and
-header-only or stand-alone C libraries automatically. Larger projects add a
-small `mamafile.py` to declare their dependencies and build steps.
+header-only or stand-alone C libraries automatically. Larger projects add a small
+`mamafile.py` to declare their dependencies and build steps.
 
 ![mama build demo](docs/demo.gif)
 
 ## Why Mama
 
-- **One command, the whole DAG.** Mama resolves C++ dependencies into a build graph and drives
-  it end to end - clone, configure, compile, in dependency order. `mama build <target>` does just
-  that target's subtree, nothing more.
-- **Everything parallel.** Clones, configures and compiles all run at once under one scheduler - a
-  leaf builds while a deeper dep still clones. The slowest subtrees launch first, and the core budget
-  is RAM-capped so a wide build cannot OOM the box.
-- **Multi-platform, multi-compiler - no Docker.** Toolchains used as designed: `linux`, `linux-clang`,
-  `windows`, `android` and other cross-builds land side by side, never clobbering. Three platforms at once? Run
-  three builds, `mama build <platform>` each. Sanitizers (asan/lsan/tsan/ubsan) and coverage are plain flags.
-- **Any build system.** CMake, GNU Make, MSBuild, or a custom `build()` step - all through the
+- **One command, the whole DAG.** Mama resolves C++ dependencies into a build graph and drives it
+  end to end: clone, configure, compile, in dependency order. `mama build <target>` does only that
+  target's subtree.
+- **Everything parallel.** Clones, configures and compiles run at once under one scheduler, so a
+  leaf builds while a deeper dep still clones. The slowest subtrees launch first, and the core
+  budget is RAM-capped so a wide build cannot OOM the box.
+- **Multi-platform, multi-compiler, no Docker.** `linux`, `linux-clang`, `windows`, `android` and
+  other cross-builds land side by side, never clobbering. For three platforms, run three builds,
+  `mama build <platform>` each. Sanitizers (asan/lsan/tsan/ubsan) and coverage are plain flags.
+- **Any build system.** CMake, GNU Make, MSBuild, or a custom `build()` step, all through the
   same scheduler and live display.
 - **Faster CMake configures.** Compiler detection (~5s of a ~6.5s cold configure) runs once per
   toolchain, and every fresh build dir reuses the result.
 - **In-source, project-scoped, reproducible.** Dependencies pull from git (pinned by
   tag/branch/commit) or local folders. Heavy libs like OpenCV and FFmpeg build from source, so a
-  fresh checkout builds identically - only a minimal set of system libs is assumed.
-- **Resilient & cached.** Fail-fast Ctrl+C, self-healing build dirs after an interrupted
+  fresh checkout builds identically with only a minimal set of system libs assumed.
+- **Resilient and cached.** Fail-fast Ctrl+C, self-healing build dirs after an interrupted
   configure, and `mama upload` to a private artifactory server so matching commits are fetched
   instead of rebuilt.
 - **Build stats.** `mama build buildstats` prints per-package timing bars plus a
-  frontend/backend/link breakdown (MSVC vcperf, Clang `-ftime-trace`) - the slowest TUs, costliest
+  frontend/backend/link breakdown (MSVC vcperf, Clang `-ftime-trace`): the slowest TUs, costliest
   headers, heaviest codegen.
 - **Also included.** Correct-order linking via `MAMA_INCLUDES`/`MAMA_LIBS`, `clang-tidy` and
   coverage as flags, and `mama init` to adopt an existing CMake project in one step.
@@ -44,13 +44,11 @@ For additional documentation explore: [build_target.py](mama/build_target.py)
 
 
 ## Who is this FOR?
-Anyone who develops cross-platform C++ libraries or applications which
-target any combination of [Windows, Linux, macOS, iOS, Android, Raspberry, Oclea, Xilinx, MIPS, i.MX8MP].
-And anyone who is not satisfied with system-wide dependencies and linker
-bugs caused by incompatible system-wide libraries on Linux.
-
-If you require an easy to use, reproducible project/namespace scoped package+build system, this is for you.
-Your builds do not rely on hard-to-configure system packages. All you need to type is `mama build`.
+Anyone who develops cross-platform C++ libraries or applications for any combination of
+[Windows, Linux, macOS, iOS, Android, Raspberry, Oclea, Xilinx, MIPS, i.MX8MP]. And anyone
+who wants a reproducible, project-scoped package and build system instead of incompatible
+system-wide libraries and the linker bugs they cause. Your builds do not rely on
+hard-to-configure system packages. All you need to type is `mama build`.
 
 ### Supported platforms ###
 - Windows (64-bit x86_64, 32-bit x86, 64-bit arm64, 32-bit armv7) default is latest MSVC
@@ -65,8 +63,8 @@ Your builds do not rely on hard-to-configure system packages. All you need to ty
 - Xilinx (64-bit arm64 Zynq UltraScale+ MPSoC) via config.set_xilinx_toolchain() or env XILINX_HOME
 
 ## Who is this NOT for?
-Single platform projects with platform specific build configuration and system wide dependency management
-such as Linux exclusive G++ projects using apt-get libraries or iOS-only apps using cocoapods.
+Single-platform projects with platform-specific build configuration and system-wide dependency
+management, such as Linux-only G++ projects using apt-get libraries or iOS-only apps using cocoapods.
 
 
 ## Artifactory
@@ -151,13 +149,12 @@ Call `mama help` for more usage information.
 ```
 
 The `https-override` / `ssh-override` flags rewrite the git access protocol of every
-`add_git()` dependency at build time, without editing any mamafile. Use them when an
-environment can only reach git over one protocol: `https-override` for hosts that only
-allow https access tokens (no ssh keys), `ssh-override` for hosts where https is blocked
-and ssh keys are required. They work for GitHub, GitLab (including nested groups),
-Bitbucket and self-hosted/custom-port servers. Local paths (`/srv/..`, `file://`, `C:/..`)
-stay untouched. The conversion drops embedded https credentials and ssh custom ports,
-and re-points an existing clone's `origin` remote so `fetch`/`pull` follow
+`add_git()` dependency at build time, without editing any mamafile. Use `https-override`
+for hosts that only allow https access tokens (no ssh keys), and `ssh-override` for hosts
+where https is blocked and ssh keys are required. They work for GitHub, GitLab (including
+nested groups), Bitbucket and self-hosted/custom-port servers. Local paths (`/srv/..`,
+`file://`, `C:/..`) stay untouched. The conversion drops embedded https credentials and ssh
+custom ports, and re-points an existing clone's `origin` remote so `fetch`/`pull` follow
 the chosen protocol.
 
 ```
@@ -169,7 +166,7 @@ the chosen protocol.
 ```
   if_needed                      Only upload if package does not already exist on server.
   art                            Always fetch packages from artifactory; failure will throw.
-  noart                          Temporarily ignore artifactory package fetching, however CACHE will still be used and fetches check for git staleness.
+  noart                          Skip artifactory fetching. The local CACHE is still used and fetches check git staleness.
 ```
 
 ### Sanitizer and coverage flags
@@ -195,9 +192,9 @@ mama build buildstats opencv      # scope the deep breakdown to a single target
 
 **Stage 1 - per-package bars.** One normalized horizontal bar per package, slowest first,
 segmented into load (git/artifactory), configure (CMake) and build (compile+link), with the
-package's total wall time on the right. Bar length scales against the slowest package, so the
-long poles are obvious at a glance. Packages faster than 0.33s are omitted as noise. On UTF-8
-terminals the segments use block shades, on legacy Windows code pages they fall back to ASCII.
+package's total wall time on the right. Bar length scales against the slowest package.
+Packages faster than 0.33s are omitted as noise. UTF-8 terminals get block shades, legacy
+Windows code pages fall back to ASCII.
 
 ```
   Build times     ░ load  ▒ configure  ▓ build
@@ -205,28 +202,28 @@ terminals the segments use block shades, on legacy Windows code pages they fall 
   ReCpp           ░▒▒▓▓▓▓▓▓                       31.4s
 ```
 
-**Stage 2 - deep compiler breakdown.** Where the compile time actually went: frontend (parse)
-vs backend (codegen) vs link, the achieved build parallelism, the slowest translation units,
-the costliest headers (total parse time and include count) and the costliest codegen symbols.
-This stage is compiler-specific:
+**Stage 2 - deep compiler breakdown.** Where the compile time went: frontend (parse) vs
+backend (codegen) vs link, the achieved build parallelism, the slowest translation units,
+the costliest headers (total parse time and include count) and the costliest codegen
+symbols. This stage is compiler-specific:
 
-- **MSVC** - the build is wrapped in a [vcperf](https://learn.microsoft.com/en-us/cpp/build-insights/)
-  `/timetrace` session and the trace is written to `packages/<project>/<platform>/mama_timetrace.json`.
+- **MSVC** - mama wraps the build in a [vcperf](https://learn.microsoft.com/en-us/cpp/build-insights/)
+  `/timetrace` session and writes the trace to `packages/<project>/<platform>/mama_timetrace.json`.
   vcperf must be on `PATH`, in the MSVC toolset, or pointed at by the `VCPERF` env var. A one-time
-  elevated `vcperf /grantusercontrol` is the prerequisite for capturing without admin rights.
-  Without vcperf, Stage 1 still prints and mama skips Stage 2 with a warning.
-- **Clang** - the build is instrumented with `-ftime-trace` and the per-TU JSONs written during
-  this run are collected from the build dirs. Use `mama build clang buildstats` on Linux.
+  elevated `vcperf /grantusercontrol` enables capture without admin rights. Without vcperf,
+  Stage 1 still prints and mama skips Stage 2 with a warning.
+- **Clang** - mama instruments the build with `-ftime-trace` and collects the per-TU JSONs
+  written during this run from the build dirs. Use `mama build clang buildstats` on Linux.
 - **GCC** - no per-file trace exists, so only Stage 1 prints.
 
-Both stages only see what was actually compiled. An up-to-date incremental build reports
-`no compiler activity captured` - use `rebuild` when you want to profile a full build.
+Both stages only see what this run compiled. An up-to-date incremental build reports
+`no compiler activity captured`, so use `rebuild` to profile a full build.
 
 ### Clang-Tidy static analysis
 
 Mama runs [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) static analysis during the build.
-When enabled, CMake sets `CMAKE_C_CLANG_TIDY` and `CMAKE_CXX_CLANG_TIDY` so that clang-tidy runs on
-every compiled source file.
+When enabled, CMake sets `CMAKE_C_CLANG_TIDY` and `CMAKE_CXX_CLANG_TIDY` so clang-tidy runs
+on every compiled source file.
 
 ```
 mama build clang-tidy             # Run clang-tidy analysis during build
@@ -264,15 +261,15 @@ def settings(self):
   install-clang-<ver>            Install Clang <ver> for Ubuntu. Ex: install-clang-18
   install-gcc-<ver>              Install GCC <ver> for Linux. Ex: install-gcc-13
   install-msbuild                Install MSBuild for Linux.
-  install-ndk-<ver>              Install Android NDK <ver> for Linux or Windows. Ex: install-ndk-25c. Use install-ndk- to list available versions.
+  install-ndk-<ver>              Install Android NDK <ver> for Linux/Windows. Ex: install-ndk-25c. install-ndk- lists versions.
 ```
 
 ## Mamafile Reference
 
 ### Requiring a minimum mamabuild version
 
-When a mamafile relies on newer mamabuild features, declare the minimum version. The build aborts
-during target load - before any configure/build work - with an upgrade hint if mama is too old:
+When a mamafile relies on newer mamabuild features, declare the minimum version. If mama is
+too old, the build aborts during target load, before any configure or build work:
 
 ```py
 def settings(self):
@@ -283,12 +280,11 @@ def settings(self):
 Target myapp requires mamabuild >= 0.13.01, but this is 0.12.5. Upgrade with:  pip install --upgrade mama
 ```
 
-Versions compare segment-wise as numbers, so `0.13.01` correctly outranks `0.9.5` and a shorter
+Versions compare segment-wise as numbers, so `0.13.01` outranks `0.9.5` and a shorter
 version zero-pads (`0.13` < `0.13.01`).
 
-> Note: `requires_version` itself exists only from 0.13.01 onward. On an older mama the mamafile
-> fails with `AttributeError: ... has no attribute 'requires_version'` - which is still the signal
-> to upgrade.
+> Note: `requires_version` itself exists only from 0.13.01 onward. An older mama fails with
+> `AttributeError: ... has no attribute 'requires_version'`, which is still the signal to upgrade.
 
 ### Adding dependencies
 
@@ -323,9 +319,8 @@ class MyLib(mama.BuildTarget):
             self.add_cmake_options('BUILD_SHARED_LIBS=ON')
 ```
 
-**Mamafile discovery**: When a dependency has no explicit `mamafile=` path, mama first
-checks `mama/{name}.py` in the parent project, then falls back to `mamafile.py` in the
-dependency's own source root.
+**Mamafile discovery**: Without an explicit `mamafile=` path, mama first checks
+`mama/{name}.py` in the parent project, then `mamafile.py` in the dependency's source root.
 
 ### Inter-dependency configuration
 
@@ -377,8 +372,8 @@ Mamafile classes extend `mama.BuildTarget` and can override these methods:
 | `enable_cxx_build` | `True` | Enable C++ compiler |
 | `enable_multiprocess_build` | `True` | Enable parallel compilation |
 | `clean_intermediate_files` | `False` | Clean intermediate build files after build |
-| `version` | `''` | Pins the archive name's last field instead of the commit hash. Must be one raw string literal - see [Pinning a version](#pinning-a-version-selfversion) |
-| `args` | `[]` | Arguments passed from parent via `add_git(args=)` / `add_local(args=)`. Also name the archive and the build dir |
+| `version` | `''` | Replaces the commit hash in the archive name, see [Pinning a version](#pinning-a-version-selfversion) |
+| `args` | `[]` | Arguments from the parent's `add_git(args=)` / `add_local(args=)`. Also name the archive and the build dir |
 
 ### Platform detection properties
 
@@ -572,8 +567,8 @@ class AlphaGL(mama.BuildTarget):
         self.gdb(f'bin/AlphaGLTests {args}')
 ```
 
-If a dependency is non-trivial (it has dependencies and configuration),
-you can simply place a target mamafile at: `mama/{DependencyName}.py`
+If a dependency is non-trivial (it has dependencies and configuration), place a target
+mamafile at `mama/{DependencyName}.py`.
 
 Example dependency config `AlphaGL/mama/libpng.py`
 ```py
@@ -597,8 +592,8 @@ class libpng_static(mama.BuildTarget):
 ```
 
 ### Clean include deployment with `as_includes_root`
-When developing a library where source and headers live together (e.g. `src/mylib/mylib.h`),
-you can use `as_includes_root='mylib'` to deploy headers with a clean namespace:
+When source and headers live together (e.g. `src/mylib/mylib.h`), use
+`as_includes_root='mylib'` to deploy headers with a clean namespace:
 ```py
 def package(self):
     self.export_libs('.', ['.lib', '.a'])
@@ -607,11 +602,10 @@ def package(self):
     self.export_include('src', as_includes_root='mylib')
 ```
 
-During development, mama sets the actual include path to `src/` so that IDE navigation
-and error messages point to the real source files. `papa deploy` exports only headers
-to `include/mylib/`, so consumers get clean `#include <mylib/mylib.h>` paths.
-
-This is also the default behavior of `default_package_includes()` when only a `src/` folder exists.
+During development, mama sets the include path to `src/` so IDE navigation and error
+messages point to the real source files. `papa deploy` exports only headers to
+`include/mylib/`, so consumers get clean `#include <mylib/mylib.h>` paths. This is also the
+default behavior of `default_package_includes()` when only a `src/` folder exists.
 
 ## Example output from Mama Build
 ```
@@ -680,13 +674,13 @@ Example: `opencv-ubuntu-22-gcc11.3-x64-release-df76b66`.
 | no pin | the commit | `qcoro-...-release-a1b2c3d` |
 
 A tag names the package on its own, because a tag is immutable by convention. A **branch keeps the
-commit**, because a branch moves: the branch name alone would serve every commit ever pushed to it
-under one archive name. Mama keeps a pin verbatim except for characters a file name cannot hold, so
-`release/1.0` becomes `release-1.0`. It never strips a leading `v` and never changes case, because
-`v1.0`, `V1.0` and `1.0` may be three different tags in one repo.
+commit**, because a branch moves and its name alone would serve every commit ever pushed to it.
+Mama keeps a pin verbatim except for characters a file name cannot hold, so `release/1.0` becomes
+`release-1.0`. It never strips a leading `v` and never changes case, because `v1.0`, `V1.0` and
+`1.0` may be three different tags in one repo.
 
 `[-variant]` is every axis that makes this build different from a plain one, coarsest first. It is
-empty for a plain release build, so those names never change. The same string also names the build
+empty for a plain release build, so those names never change. The same string names the build
 directory (`linux-cov-asan-lgpl`), so a build and the package it uploads can never disagree:
 
 | axis | token | comes from |
@@ -695,10 +689,9 @@ directory (`linux-cov-asan-lgpl`), so a build and the package it uploads can nev
 | sanitizers | `-asan` `-tsan` `-lsan` `-ubsan` `-msan` | `sanitize=address` / `asan` / ... |
 | dep args | `-lgpl` `-cpp20` | `add_git(..., args=['LGPL'])` in the consumer |
 
-Mama normalizes every dep arg, so one set of args always spells one name. It lowercases the arg, turns
-`+` into `p` (`C++20` -> `cpp20`) and drops every other non-alphanumeric character (`NEWMATH=1` ->
-`newmath1`). It then sorts the tokens and removes the duplicates. The call order and the letter case
-therefore never change a name.
+Mama normalizes every dep arg so one set of args always spells one name: lowercase, `+` to `p`
+(`C++20` -> `cpp20`), drop every other non-alphanumeric character (`NEWMATH=1` -> `newmath1`),
+then sort the tokens and remove duplicates. Call order and letter case never change a name.
 
 ### Pinning a version: `self.version`
 
@@ -714,11 +707,11 @@ Use it when the dep's own mamafile should decide the version, whatever tag a con
 tag-pinned dep already names itself after the tag (see the table above), so most deps need nothing
 here.
 
-**It must be a single raw string literal.** To download a package, mama needs the archive name *before*
-it clones anything. So it never runs the mamafile. It reads the file as text and takes the first
-`self.version = '<literal>'` it finds. Pre-clone that text comes from `git show HEAD:mamafile.py` on the
-remote. Post-clone it comes from the file on disk. The upload side does the opposite: it runs the
-mamafile and uses the value in memory. Three rules follow:
+**It must be a single raw string literal.** Mama needs the archive name *before* it clones anything,
+so it never runs the mamafile. It reads the file as text and takes the first
+`self.version = '<literal>'` it finds. Pre-clone that text comes from `git show HEAD:mamafile.py` on
+the remote, post-clone from the file on disk. The upload side runs the mamafile and uses the value
+in memory. Three rules follow:
 
 1. **A literal, in any method.** `init()`, `settings()` and `configure()` all work: the method does not
    matter, the assignment does. A module-level constant assigned once (`V = '8.0.1'` then
@@ -742,7 +735,7 @@ class ffmpeg(mama.BuildTarget):
         self.version = '8.1.0'    # ffmpeg-ubuntu-24-gcc14.3-x64-release-8.1.0
 ```
 
-To build one repo two ways, do not branch the version - pass args from the consumer:
+To build one repo two ways, do not branch the version. Pass args from the consumer:
 
 ```python
 # in the consumer's mamafile, NOT in a conditional self.version
@@ -839,10 +832,8 @@ We are open for any improvements and feedback via pull requests.
 
 ### Development Setup
 Mama requires `setuptools>=77.0`, because `pyproject.toml` declares the license as a PEP 639
-expression. Check the version with `pip3 show setuptools`.
-
-You can configure local development with `$ pip3 install -e . --no-cache-dir` but make sure you have
-setuptools (>=77.0) and latest pip3 (>22.3). This command will fail with older toolkits.
+expression. Check the version with `pip3 show setuptools`. Configure local development with
+`$ pip3 install -e . --no-cache-dir`. The command fails with setuptools < 77.0 or pip3 <= 22.3.
 
 ### Running Tests
 
@@ -863,7 +854,7 @@ Uploading a source distribution:
 2. Build sdist: `python -m build`
 3. Verify the metadata: `twine check dist/*`
 4. Upload with twine: `twine upload --skip-existing dist/*`
-It will prompt for Username and Password, unless you set up ~/.pypirc file:
+Twine prompts for Username and Password, unless a ~/.pypirc file exists:
 ```
 [distutils]
 index-servers = pypi

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 Mama - A modular C++ build tool so simple even your mama can use it
 
 Mama turns a tree of C++ libraries - your own and third-party - into a single
-`mama build`. It clones the sources, configures them, builds them in the right order
-across every platform and compiler you target, and links the results into your project.
+`mama build`. It clones the sources, configures them, and builds them in the right order
+for every platform and compiler you target. The results link into your project.
 No central package repository, no Docker containers, no hand-written toolchain glue -
 just git repos, a minimal set of system libs, and the compilers you already have.
 
-Building is as simple as `mama build windows` - no ceremony~! Trivial CMake projects and
-header-only or stand-alone C libraries are picked up automatically; larger projects add a
+Building is one command: `mama build windows`. Mama picks up trivial CMake projects and
+header-only or stand-alone C libraries automatically. Larger projects add a
 small `mamafile.py` to declare their dependencies and build steps.
 
 ![mama build demo](docs/demo.gif)
@@ -19,25 +19,25 @@ small `mamafile.py` to declare their dependencies and build steps.
   it end to end - clone, configure, compile, in dependency order. `mama build <target>` does just
   that target's subtree, nothing more.
 - **Everything parallel.** Clones, configures and compiles all run at once under one scheduler - a
-  leaf builds while a deeper dep still clones. Longest poles launch first; the core budget is
-  RAM-capped so a wide build can't OOM the box.
+  leaf builds while a deeper dep still clones. The slowest subtrees launch first, and the core budget
+  is RAM-capped so a wide build cannot OOM the box.
 - **Multi-platform, multi-compiler - no Docker.** Toolchains used as designed: `linux`, `linux-clang`,
   `windows`, `android` and other cross-builds land side by side, never clobbering. Three platforms at once? Run
   three builds, `mama build <platform>` each. Sanitizers (asan/lsan/tsan/ubsan) and coverage are plain flags.
 - **Any build system.** CMake, GNU Make, MSBuild, or a custom `build()` step - all through the
   same scheduler and live display.
 - **Faster CMake configures.** Compiler detection (~5s of a ~6.5s cold configure) runs once per
-  toolchain and is reused across every fresh build dir, cutting it down to almost nothing.
+  toolchain, and every fresh build dir reuses the result.
 - **In-source, project-scoped, reproducible.** Dependencies pull from git (pinned by
-  tag/branch/commit) or local folders; heavy libs like OpenCV and FFmpeg build easily from source, so a
+  tag/branch/commit) or local folders. Heavy libs like OpenCV and FFmpeg build from source, so a
   fresh checkout builds identically - only a minimal set of system libs is assumed.
 - **Resilient & cached.** Fail-fast Ctrl+C, self-healing build dirs after an interrupted
   configure, and `mama upload` to a private artifactory server so matching commits are fetched
   instead of rebuilt.
-- **Rich build stats.** `mama build buildstats` prints per-package timing bars plus a
+- **Build stats.** `mama build buildstats` prints per-package timing bars plus a
   frontend/backend/link breakdown (MSVC vcperf, Clang `-ftime-trace`) - the slowest TUs, costliest
   headers, heaviest codegen.
-- **Batteries included.** Correct-order linking via `MAMA_INCLUDES`/`MAMA_LIBS`, `clang-tidy` and
+- **Also included.** Correct-order linking via `MAMA_INCLUDES`/`MAMA_LIBS`, `clang-tidy` and
   coverage as flags, and `mama init` to adopt an existing CMake project in one step.
 
 For additional documentation explore: [build_target.py](mama/build_target.py)
@@ -50,7 +50,7 @@ And anyone who is not satisfied with system-wide dependencies and linker
 bugs caused by incompatible system-wide libraries on Linux.
 
 If you require an easy to use, reproducible project/namespace scoped package+build system, this is for you.
-Your builds will not rely on hard to setup system packages, all you need to do is type `mama build`.
+Your builds do not rely on hard-to-configure system packages. All you need to type is `mama build`.
 
 ### Supported platforms ###
 - Windows (64-bit x86_64, 32-bit x86, 64-bit arm64, 32-bit armv7) default is latest MSVC
@@ -70,7 +70,8 @@ such as Linux exclusive G++ projects using apt-get libraries or iOS-only apps us
 
 
 ## Artifactory
-Provides a mechanism to upload pre-built packages to a private artifactory server through `mama upload mypackage`. These packages will be automatically used if a git:package commit hash matches.
+`mama upload mypackage` uploads a prebuilt package to a private artifactory server. A build then
+uses the package automatically when the git dependency's commit hash matches.
 
 
 ## Setup For Users
@@ -84,7 +85,7 @@ include(mama.cmake)
 include_directories(${MAMA_INCLUDES})
 target_link_libraries(YourProject PRIVATE ${MAMA_LIBS})
 ```
-6. `$ mama build` and enjoy!
+6. `$ mama build`
 7. `$ mama open` to open your project in an IDE / VSCode
 
 
@@ -94,7 +95,7 @@ target_link_libraries(YourProject PRIVATE ${MAMA_LIBS})
   mama build                     Build main project only. Clones missing deps, but does not git pull.
   mama build x86 opencv          Cross compile build target opencv to x86 architecture
   mama build android             Cross compile to arm64 android NDK (default API level 29)
-  mama build android-31           Cross compile to arm64 with Android API level 31
+  mama build android-31          Cross compile to arm64 with Android API level 31
   mama build android-26 arm      Cross compile to armv7 android NDK API level 26
   mama update                    Update all dependencies by doing git pull and build.
   mama clean                     Cleans main project only.
@@ -107,7 +108,7 @@ target_link_libraries(YourProject PRIVATE ${MAMA_LIBS})
   mama configure deps_only       Re-runs CMake configure on all dependencies, but not the main project.
   mama build dep1                Build dep1 only. Clones if missing, but does not git pull.
   mama update dep1               Update and build the specified target.
-  mama serve android             Update, build and deploy for Android.
+  mama serve android             Update, rebuild, deploy and upload for Android.
   mama deploy                    Runs PAPA deploy stage.
   mama configure                 Run CMake configure on dependencies to reconfigure and build
   mama configure tsan            CMake Reconfigure dependencies with thread sanitizer enabled
@@ -154,9 +155,9 @@ The `https-override` / `ssh-override` flags rewrite the git access protocol of e
 environment can only reach git over one protocol: `https-override` for hosts that only
 allow https access tokens (no ssh keys), `ssh-override` for hosts where https is blocked
 and ssh keys are required. They work for GitHub, GitLab (including nested groups),
-Bitbucket and self-hosted/custom-port servers; local paths (`/srv/..`, `file://`, `C:/..`)
-are left untouched. Embedded https credentials and ssh custom ports are dropped on
-conversion, and an existing clone's `origin` remote is re-pointed so `fetch`/`pull` follow
+Bitbucket and self-hosted/custom-port servers. Local paths (`/srv/..`, `file://`, `C:/..`)
+stay untouched. The conversion drops embedded https credentials and ssh custom ports,
+and re-points an existing clone's `origin` remote so `fetch`/`pull` follow
 the chosen protocol.
 
 ```
@@ -211,9 +212,9 @@ This stage is compiler-specific:
 
 - **MSVC** - the build is wrapped in a [vcperf](https://learn.microsoft.com/en-us/cpp/build-insights/)
   `/timetrace` session and the trace is written to `packages/<project>/<platform>/mama_timetrace.json`.
-  vcperf must be on `PATH`, in the MSVC toolset, or pointed at by the `VCPERF` env var; a one-time
+  vcperf must be on `PATH`, in the MSVC toolset, or pointed at by the `VCPERF` env var. A one-time
   elevated `vcperf /grantusercontrol` is the prerequisite for capturing without admin rights.
-  If vcperf isn't found, Stage 1 still prints and Stage 2 is skipped with a warning.
+  Without vcperf, Stage 1 still prints and mama skips Stage 2 with a warning.
 - **Clang** - the build is instrumented with `-ftime-trace` and the per-TU JSONs written during
   this run are collected from the build dirs. Use `mama build clang buildstats` on Linux.
 - **GCC** - no per-file trace exists, so only Stage 1 prints.
@@ -223,16 +224,19 @@ Both stages only see what was actually compiled. An up-to-date incremental build
 
 ### Clang-Tidy static analysis
 
-Mama supports running [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) static analysis during the build. When enabled, CMake sets `CMAKE_C_CLANG_TIDY` and `CMAKE_CXX_CLANG_TIDY` so that clang-tidy runs on every compiled source file.
+Mama runs [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) static analysis during the build.
+When enabled, CMake sets `CMAKE_C_CLANG_TIDY` and `CMAKE_CXX_CLANG_TIDY` so that clang-tidy runs on
+every compiled source file.
 
 ```
 mama build clang-tidy             # Run clang-tidy analysis during build
 mama build clang-tidy debug       # Combine with other flags
 ```
 
-Clang-tidy is resolved in this order:
-1. System `PATH` lookup
-2. `CLANG_TIDY` environment variable
+Mama resolves clang-tidy in this order:
+1. The `CLANG_TIDY` environment variable (`ANDROID_CLANG_TIDY` for Android builds)
+2. The Android NDK bin directory, for Android builds
+3. System `PATH` lookup
 
 If clang-tidy is not found, a warning is printed and the build proceeds without static analysis.
 
@@ -319,8 +323,9 @@ class MyLib(mama.BuildTarget):
             self.add_cmake_options('BUILD_SHARED_LIBS=ON')
 ```
 
-**Mamafile discovery**: When adding a dependency without an explicit `mamafile=` path,
-mama automatically checks for `{src}/mamafile.py` in the parent project.
+**Mamafile discovery**: When a dependency has no explicit `mamafile=` path, mama first
+checks `mama/{name}.py` in the parent project, then falls back to `mamafile.py` in the
+dependency's own source root.
 
 ### Inter-dependency configuration
 
@@ -475,9 +480,9 @@ def build(self):
         build_products=[         # files to deploy
             BuildProduct('{{installed}}/lib/libz.a', '{{build}}/lib/libz.a'),
         ])
-    gp.build(options=['--static'], prefix='/usr/local')
+    gp.build(options='--static', prefix='--prefix /usr/local')
     # Or call steps individually:
-    # gp.configure(options=['--static'])
+    # gp.configure(options='--static')
     # gp.make(multithreaded=True)
     # gp.install()
 ```
@@ -602,9 +607,9 @@ def package(self):
     self.export_include('src', as_includes_root='mylib')
 ```
 
-During development, the actual include path is set to `src/` so that IDE navigation
-and error messages point to the real source files. After `papa deploy`, only headers
-are exported to `include/mylib/`, giving consumers clean `#include <mylib/mylib.h>` paths.
+During development, mama sets the actual include path to `src/` so that IDE navigation
+and error messages point to the real source files. `papa deploy` exports only headers
+to `include/mylib/`, so consumers get clean `#include <mylib/mylib.h>` paths.
 
 This is also the default behavior of `default_package_includes()` when only a `src/` folder exists.
 
@@ -652,7 +657,8 @@ $ mama upload googletest
 ## Artifactory Details
 
 ### Authentication
-- **`auth='store'`** (default): Credentials are stored in system keyring (uses `keyrings.cryptfile` on Linux). Stored per-URL; failed logins clear stored credentials automatically.
+- **`auth='store'`** (default): mama stores credentials in the system keyring (`keyrings.cryptfile`
+  on Linux), one entry per URL. A failed login clears the stored credentials.
 - **`auth='prompt'`**: Always prompts for username and password.
 - **Environment variables** `MAMA_ARTIFACTORY_USER` / `MAMA_ARTIFACTORY_PASS` always take priority over both modes.
 
@@ -750,10 +756,10 @@ Args are known before the clone, so they name the archive and the build director
 ## `mama open` behavior
 
 - **Windows**: Opens `.slnx` or `.sln` from build dir, newest first. Falls back to VSCode
-- **macOS/iOS**: Opens `.xcodeproj` from build dir; falls back to VSCode
+- **macOS/iOS**: Opens `.xcodeproj` from build dir. Falls back to VSCode
 - **Linux/Android**: Opens VSCode
 
-Syntax: `mama open` (root project) or `mama open=dep1` (specific dependency)
+Syntax: `mama open` (root project) or `mama open dep1` (specific dependency)
 
 
 ## Android configuration
@@ -824,16 +830,19 @@ The platform-named aliases still work: `set_yocto_toolchain()`, `set_oclea_toolc
 
 ## VSCode Integration
 
-Mama automatically generates `compile_commands.json` (via `CMAKE_EXPORT_COMPILE_COMMANDS=ON`) and updates `.vscode/c_cpp_properties.json` with the correct `compileCommands` path for IntelliSense support.
+Mama generates `compile_commands.json` (via `CMAKE_EXPORT_COMPILE_COMMANDS=ON`) and updates
+`.vscode/c_cpp_properties.json` with the correct `compileCommands` path for IntelliSense support.
 
 
 ## For Mama Contributors
 We are open for any improvements and feedback via pull requests.
 
 ### Development Setup
-Mama requires `setuptools>=77.0`, because `pyproject.toml` declares the license as a PEP 639 expression. Check the version with `pip3 show setuptools`.
+Mama requires `setuptools>=77.0`, because `pyproject.toml` declares the license as a PEP 639
+expression. Check the version with `pip3 show setuptools`.
 
-You can set up local development with `$ pip3 install -e . --no-cache-dir` but make sure you have setuptools (>=77.0) and latest pip3 (>22.3). This command will fail with older toolkits.
+You can configure local development with `$ pip3 install -e . --no-cache-dir` but make sure you have
+setuptools (>=77.0) and latest pip3 (>22.3). This command will fail with older toolkits.
 
 ### Running Tests
 
@@ -862,6 +871,9 @@ index-servers = pypi
 username=__token__
 password=<pypi-api-token>
 ```
-Use `packaging>=24.2`. setuptools>=77 writes Metadata 2.4, which adds the `license-expression` and `license-file` fields. An older `packaging` does not know those fields, so twine refuses the upload with `InvalidDistribution: unrecognized or malformed field 'license-expression'`. Upgrade `packaging` and build again.
+Use `packaging>=24.2`. setuptools>=77 writes Metadata 2.4, which adds the `license-expression` and
+`license-file` fields. An older `packaging` does not know those fields, so twine refuses the upload
+with `InvalidDistribution: unrecognized or malformed field 'license-expression'`. Upgrade `packaging`
+and build again.
 
 Quick build & upload: `./deploy.sh`

--- a/docs/build_behavior.md
+++ b/docs/build_behavior.md
@@ -1,8 +1,8 @@
-# mama build vs update: dependency-loading behaviour
+# mama build vs update: dependency-loading behavior
 
 Reference spec for what the dependency loader must and must NOT do under each
 top-level command. Captures invariants that the build-target/shim plumbing has
-to honour. Update this file when the contract changes; the code is the truth,
+to honor. Update this file when the contract changes. The code is the truth,
 but this document is the intent.
 
 ## The two commands
@@ -13,9 +13,9 @@ For deps with a valid shim: no network, no re-unzip, no ls-remote.
 **`mama update`** - refresh all deps then build. ls-remote per dep,
 artifactory cache zip may be re-fetched, shim build_dirs are re-extracted.
 
-**`mama build noart`** - no artifactory fetches. ls-remote is still allowed
-on shimmed deps so upstream-advanced shims can be detected and dropped;
-that triggers a clone+build-from-source fallback.
+**`mama build noart`** - no artifactory fetches. mama still allows ls-remote
+on shimmed deps, so it detects and drops an upstream-advanced shim.
+That triggers a clone+build-from-source fallback.
 
 `mama build` is the hot path. It runs many times per developer per day. It
 MUST be cheap.
@@ -30,7 +30,7 @@ For a non-root git dep, the loader sees one of these on-disk states:
    shimmed deps.
 2. **Stale shim** - marker exists but the upstream commit advanced (only
    detectable via ls-remote).
-3. **Real clone** - a `.git` directory exists; the dep is built from source.
+3. **Real clone** - a `.git` directory exists. The dep is built from source.
 4. **Empty** - first-time load. Nothing yet on disk.
 
 ## What `mama build` MUST do per state
@@ -44,27 +44,27 @@ For a non-root git dep, the loader sees one of these on-disk states:
 
 Printed line:
 ```
-  - Target opencv           OK (shim cached)
+  - Target opencv           SHIM CACHED <archive>
 ```
-or similar. Specifically **not** `SHIM FETCHED` (misleading - nothing was
-fetched), and **not** `Artifactory cache /path/to.zip` (no zip was touched).
+Specifically **not** `SHIM FETCHED` (misleading - mama fetched nothing), and
+**not** `Artifactory cache /path/to.zip` (mama touched no zip).
 
 ### State 2: stale shim (rare, but must not silently miss it)
 
 - Without `update`: trust the shim. Do NOT auto-detect staleness on every
-  `mama build`. The user opted into a fast build; the cost of an ls-remote
+  `mama build`. The user opted into a fast build. The cost of an ls-remote
   per shim across N deps is exactly the wasted work this doc exists to
   prevent.
 - With `update`: ls-remote, detect mismatch, drop marker, fall through to
   the regular clone+probe path.
-- Edge case: under `noart`, ls-remote IS still performed (it's cheap, and
+- Edge case: under `noart`, ls-remote IS still performed (it is cheap, and
   noart already trades the artifactory fetch for a build-from-source if
   upstream advanced).
 
 ### State 3: real clone
 
 - Regular `dependency_checkout` path runs (`fetch + reset` only with
-  `update`; with `build` only verify HEAD).
+  `update`, with `build` only verify HEAD).
 - Post-clone artifactory load only if `should_load_artifactory()` says so
   (a previous papa.txt exists, first-time build, or `is_pkg`).
 
@@ -87,17 +87,17 @@ The opposite intent: refresh everything.
 
 The `target.config.update and target.is_current_target()` guard in
 `artifactory_fetch_and_reconfigure` is the chokepoint that bypasses the
-local cache check. It is correct for `update`; it must NOT be reached
-under plain `build`.
+local cache check. It is correct for `update`. A plain `build` must NOT
+reach it.
 
 ## Implementation
 
-`BuildDependency._try_artifactory_shim` honours `try_load_cached_shim` when a
+`BuildDependency._try_artifactory_shim` honors `try_load_cached_shim` when a
 shim marker exists and `config.update` is False. The cached path's
 `check_staleness` parameter gates the ls-remote probe: True under noart, False
 under plain build. Update bypasses the cached path entirely so the regular
 probe re-extracts.
 
-Tests pinning the behaviour:
+Tests pinning the behavior:
 - `tests/test_build_shim_cache/` - plain `mama build` cached fast path
 - `tests/test_noart_shim_cache/` - noart cached-with-staleness-check path

--- a/docs/build_behavior.md
+++ b/docs/build_behavior.md
@@ -1,9 +1,8 @@
 # mama build vs update: dependency-loading behavior
 
 Reference spec for what the dependency loader must and must NOT do under each
-top-level command. Captures invariants that the build-target/shim plumbing has
-to honor. Update this file when the contract changes. The code is the truth,
-but this document is the intent.
+top-level command. The code is the truth, but this document is the intent.
+Update this file when the contract changes.
 
 ## The two commands
 
@@ -14,8 +13,8 @@ For deps with a valid shim: no network, no re-unzip, no ls-remote.
 artifactory cache zip may be re-fetched, shim build_dirs are re-extracted.
 
 **`mama build noart`** - no artifactory fetches. mama still allows ls-remote
-on shimmed deps, so it detects and drops an upstream-advanced shim.
-That triggers a clone+build-from-source fallback.
+on shimmed deps, so it detects an upstream-advanced shim, drops it, and falls
+back to clone+build-from-source.
 
 `mama build` is the hot path. It runs many times per developer per day. It
 MUST be cheap.
@@ -24,10 +23,9 @@ MUST be cheap.
 
 For a non-root git dep, the loader sees one of these on-disk states:
 
-1. **Valid shim, papa.txt present** - the dep has been previously satisfied
-   from artifactory. `mama_shim` marker exists, `papa.txt` exists in the
-   build_dir, build products are extracted. This is the steady state of
-   shimmed deps.
+1. **Valid shim, papa.txt present** - the steady state of a dep satisfied from
+   artifactory. The `mama_shim` marker and `papa.txt` exist in the build_dir,
+   and the build products are extracted.
 2. **Stale shim** - marker exists but the upstream commit advanced (only
    detectable via ls-remote).
 3. **Real clone** - a `.git` directory exists. The dep is built from source.
@@ -52,14 +50,13 @@ Specifically **not** `SHIM FETCHED` (misleading - mama fetched nothing), and
 ### State 2: stale shim (rare, but must not silently miss it)
 
 - Without `update`: trust the shim. Do NOT auto-detect staleness on every
-  `mama build`. The user opted into a fast build. The cost of an ls-remote
-  per shim across N deps is exactly the wasted work this doc exists to
-  prevent.
+  `mama build`. The user opted into a fast build, and an ls-remote per shim
+  across N deps is exactly the wasted work a fast build must avoid.
 - With `update`: ls-remote, detect mismatch, drop marker, fall through to
   the regular clone+probe path.
-- Edge case: under `noart`, ls-remote IS still performed (it is cheap, and
-  noart already trades the artifactory fetch for a build-from-source if
-  upstream advanced).
+- Edge case: under `noart`, ls-remote IS still performed. It is cheap, and
+  noart already trades the artifactory fetch for a build-from-source when
+  upstream advanced.
 
 ### State 3: real clone
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,6 +1,6 @@
 # How mama handles platforms
 
-A platform is what mama builds FOR: `linux`, `android`, `imx8mp`, and eight more. This is the shape
+A platform is what mama builds FOR: `linux`, `android`, `imx8mp`, and seven more. This is the shape
 of that support. For the mamafile-facing API, see the README.
 
 ## Three layers
@@ -66,14 +66,15 @@ Then add `NewBoard` to `PLATFORMS` in `registry.py` and a guard to `_GUARDS` in 
 tests are all parametrized over `PLATFORMS`.
 
 A platform that needs real behavior overrides a method instead of declaring an attribute. `Android`
-overrides the most (NDK discovery, ABI naming, its own make program). `Linux` overrides three things.
+overrides the most (NDK discovery, ABI naming, its own make program). `Linux` overrides only a few.
 
 ## Invariants the tests enforce
 
 1. No `if/elif` chain over platform names outside `mama/platforms/`. A consumer that needs
    per-platform behavior declares it on `Platform`.
 2. No platform imports `mama.buildsys` or writes a `CMAKE_` name. `Toolchain.extra_opts` is the
-   documented escape hatch, and iOS is its only user (Xcode SDK selection has no neutral form).
+   documented escape hatch, used by iOS (Xcode SDK selection has no neutral form) and by Android
+   (variables only the NDK's own toolchain file understands).
 3. Every `(platform, arch)` pair gets its own build dir. A shared one means two builds clobber each
    other's cache and libraries.
 4. Every platform answers the same method names with the same parameters.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,7 +1,7 @@
 # How mama handles platforms
 
-A platform is what mama builds FOR: `linux`, `android`, `imx8mp`, and seven more. This is the shape
-of that support. For the mamafile-facing API, see the README.
+A platform is what mama builds FOR: `linux`, `android`, `imx8mp`, and seven more. For the
+mamafile-facing API, see the README.
 
 ## Three layers
 

--- a/docs/roadmap-load-and-config-hardening.md
+++ b/docs/roadmap-load-and-config-hardening.md
@@ -1,6 +1,6 @@
 # Roadmap: load-phase and config hardening (and possible scoped discovery)
 
-**Status:** planning only. No code in this roadmap has been written. Items 1+ are proposals.
+**Status:** Item 0 has landed (section 2). Items 1+ are unbuilt proposals.
 **Audience:** an engineer or model picking this up cold. This document is self-contained.
 **Repo:** `RedFox20/Mama` (`mama/` package).
 **Consumer that triggered the work:** a downstream ground-control project, generalized here as `GCS`.
@@ -19,9 +19,9 @@ Evidence is tagged so you know how much to trust it:
 - **[R]** - reported by a sub-audit with a file:line citation, but not independently re-read.
   **Re-verify before acting on it.**
 
-`file.py:NN` line numbers were accurate at commit `3b0c654`. `mama/build_dependency.py` is
-under active concurrent development (see section 2), so **line numbers drift - always grep for the
-quoted code, never trust the number alone.**
+The commit hashes quoted below predate a squash of the branch history, so they no longer
+resolve on `master`. Verify a claim by the quoted code and the named test suite, never by the
+hash. **Line numbers drift too - always grep for the quoted code, never trust the number alone.**
 
 ---
 
@@ -51,13 +51,13 @@ on its own merit regardless of whether Item 4 ever happens.
 
 ### Landed on `master`
 
-| Commit | What |
+| Change | Verify by |
 |---|---|
-| `9b31fac` | `fix:` wipe build dirs whose toolchain moved instead of soft-reconfiguring. Records a toolchain fingerprint per build dir, wipes on mismatch. Fixed Android `-march=x86-64-v3` leaking into arm64 after a nix NDK path change. |
-| `0a3f149` | `feature:` `build_host_binary()` - `config.host_platform_name()`, `BuildTarget.host_build_dir()`, `BuildTarget.build_host_binary(relpath, auto_build=True)`, `config.root_source_dir`. Cheap-checks the host build dir, else bootstraps `mama <host> build target=<name>`. |
-| `3b0c654` | `fix:` cross-process dep lock. `mama/utils/dir_lock.py` (`flock`/`msvcrt`, sidecar kept **outside** `dep_dir` so a reclone-wipe cannot unlink a held lock, OS-released so it cannot hang). Wraps shim+checkout in `_load`. |
+| `fix:` wipe build dirs whose toolchain moved instead of soft-reconfiguring. Records a toolchain fingerprint per build dir, wipes on mismatch. Fixed Android `-march=x86-64-v3` leaking into arm64 after a nix NDK path change. | `tests/test_toolchain_change_wipe/` |
+| `feature:` `build_host_binary()` - `config.host_platform_name()`, `BuildTarget.host_build_dir()`, `BuildTarget.build_host_binary(relpath, auto_build=True)`, `config.root_source_dir`. Cheap-checks the host build dir, else bootstraps `mama <host> build target=<name>`. | `tests/test_host_binary/` |
+| `fix:` cross-process dep lock. `mama/utils/dir_lock.py` (`flock`/`msvcrt`, sidecar kept **outside** `dep_dir` so a reclone-wipe cannot unlink a held lock, OS-released so it cannot hang). Wraps shim+checkout in `_load`. | `tests/test_dep_dir_lock/` |
 
-`2d8f54b` (`guard package() on having artifacts...`) landed from another source between two of
+A `guard package() on having artifacts` change landed from another source between two of
 these. **Expect more concurrent commits in `build_dependency.py`.**
 
 ### Not landed - consumer-side rewire (uncommitted, deliberate)
@@ -70,36 +70,19 @@ That rewire requires mama >= `0a3f149`, but the consumer still pins an older rev
 consumer-side commit must wait for the pin bump or its CI breaks.
 `requires_version('0.13.01')` accepts newer, so a `0.13.02` release satisfies it.
 
-### Inbound from another model - **Item 0**
+### Landed - **Item 0**: `settings()` under the parallel loader
 
-A patch is being written for: *`settings()` is not loaded correctly under the parallel loader.*
+The fix landed. `execute_unified` loads the ROOT up front, before the display and before any
+parallel job starts **[V]** (`mama/dependency_chain.py`, `root.load()` before
+`_make_scheduler`). Root `settings()` therefore picks the compiler and the toolchain first.
+Right after root
+`settings()`, `_load` runs `lock_compiler()` and `init_platform_toolchain()`, so a root
+`set_*_toolchain()` beats the default SDK probe **[V]**. `tests/test_root_settings_order/`
+pins the order on both execution paths.
 
-Relevant code, unchanged as of `3b0c654` **[V]**:
-
-```python
-# mama/build_dependency.py  (in _load)
-target.settings() ## customization point for project settings
-if self.is_root:
-    conf.lock_compiler()  # root settings() is the last prefer_clang/gcc; lock before any dep loads
-    self._update_dep_name_and_dirs(self.name)  # build_dir was computed pre-flip, re-resolve it
-target.dependencies() ## customization point for additional dependencies
-```
-
-```python
-# mama/dependency_chain.py  (in load_dependency_chain)
-changed = dep.load()
-if dep.config.parallel_load:
-    futures = []
-    for child in dep.get_children():
-        futures.append(e.submit(load_dependency, child))
-```
-
-Sibling `settings()` therefore run **concurrently on different threads**, so any global
-`config` mutation from a non-root `settings()` is a data race with nondeterministic ordering. **[V]**
-
-**This is the same surface as Item 2.** Whoever lands Item 2 must rebase onto the settings()
-patch and re-check that the two do not double-guard or contradict each other. Item 2 may
-shrink to a subset once the settings() patch lands - that is a good outcome, not a conflict.
+Sibling non-root `settings()` still run **concurrently on different threads**, so any global
+`config` mutation from a non-root `settings()` is still a data race **[V]**. The landed fix
+serializes only the root load and guards no setter, so Item 2 keeps its full scope.
 
 ---
 
@@ -109,16 +92,18 @@ Facts an auditor needs before touching anything.
 
 ### 3.1 Two execution paths
 
-`_can_unify(config)` **[R]** (`mama/main.py:191-197`) picks the engine:
+`_can_unify(config)` **[V]** (`mama/main.py`) picks the engine:
 
 ```python
 return (not config.serial_load and (config.build or config.update)
-        and config.no_specific_target() and not config.list and not config.deps_only
+        and (config.no_specific_target() or config.deps_only) and not config.list
         and not config.dirty and not config.mama_init)
 ```
 
-`no_specific_target()` = no target or `target=all`. **Therefore any `target=X` always takes the
-classic `load_dependency_chain(root)` path.** Scoped discovery only ever concerns that branch.
+`no_specific_target()` = no target or `target=all`. A `deps_only` run also unifies: the
+scheduler still loads every dep, and a `DepsOnlyScope` narrows CONFIGURE and BUILD jobs to the
+named target's dependencies. **Any other `target=X` run takes the classic
+`load_dependency_chain(root)` path.** Scoped discovery only ever concerns that branch.
 
 `execute_unified` - used only for *non*-targeted builds - is **already an incremental loader** **[V]**
 (`mama/dependency_chain.py:983-994`): `_do_load` loads one dep, then `grow()` adds jobs for its
@@ -263,13 +248,10 @@ Combined with section 2's race, non-root `settings()` today are both **concurren
 
 ## 4. Roadmap
 
-### Item 0 - `settings()` under the parallel loader *(external, inbound)*
+### Item 0 - `settings()` under the parallel loader *(landed)*
 
-Owned by another model. Not specified here. **Land first.** Items 2 and 4 touch the same code and
-must rebase onto it.
-
-Ask the author to record: does the fix serialize `settings()`, reorder it, or make specific
-setters safe? Item 2's scope depends on the answer.
+Landed, see section 2. The fix loads the root up front and serializes nothing else. It guards
+no setter, so Item 2 keeps its full scope.
 
 ---
 
@@ -455,7 +437,8 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 
 1. **Re-verify every [R] claim**, especially section 3.5 (shim cost) and section 3.8 (setter list) - the whole
    plan pivots on those two.
-2. Does the Item 0 `settings()` patch make Item 2a redundant, partly or wholly?
+2. Answered: the landed Item 0 fix loads the root first and guards no setter, so Item 2a keeps
+   its full scope.
 3. Item 3 is behavior-changing. Is narrowing `mama test X` to X's subtree *desirable*, or do users
    rely on it building the tree? Needs a product decision, not just a code one.
 4. Is Item 4 worth the loader risk at all? Measure first: time a cold
@@ -472,7 +455,7 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 ## 8. Sequencing summary
 
 ```
-Item 0 (external: settings() parallel fix)     <- land first
+Item 0 (settings() parallel fix)               <- landed
    \_ Item 1 (zombie guards)                   <- standalone, low risk, do next
         \_ Item 2 (setter guards, warn-first)  <- standalone, 2-stage release
              \_ Item 3 (scope executed chain)  <- behavior change, needs decision

--- a/docs/roadmap-load-and-config-hardening.md
+++ b/docs/roadmap-load-and-config-hardening.md
@@ -20,7 +20,7 @@ Evidence is tagged so you know how much to trust it:
   **Re-verify before acting on it.**
 
 `file.py:NN` line numbers were accurate at commit `3b0c654`. `mama/build_dependency.py` is
-under active concurrent development (see §2), so **line numbers drift - always grep for the
+under active concurrent development (see section 2), so **line numbers drift - always grep for the
 quoted code, never trust the number alone.**
 
 ---
@@ -40,7 +40,7 @@ dependency that was supposedly present. Diagnosis chain:
 4. Two mama **processes** writing the same git working trees corrupted them. The in-process
    `threading.Lock` at `BuildDependency._load_lock` does not span processes. **[V]**
 
-That corruption is fixed (§2). What remains is the *waste*: the nested child still loads the
+That corruption is fixed (section 2). What remains is the *waste*: the nested child still loads the
 whole graph to build one leaf. "Scoped discovery" (Item 4) is the proposal to fix the waste -
 and it is now an **optimization, not a correctness fix**. Items 1-3 are hardening that stands
 on its own merit regardless of whether Item 4 ever happens.
@@ -53,9 +53,9 @@ on its own merit regardless of whether Item 4 ever happens.
 
 | Commit | What |
 |---|---|
-| `9b31fac` | `fix:` wipe build dirs whose toolchain moved instead of soft-reconfiguring. Records a toolchain fingerprint per build dir; wipes on mismatch. Fixed Android `-march=x86-64-v3` leaking into arm64 after a nix NDK path change. |
+| `9b31fac` | `fix:` wipe build dirs whose toolchain moved instead of soft-reconfiguring. Records a toolchain fingerprint per build dir, wipes on mismatch. Fixed Android `-march=x86-64-v3` leaking into arm64 after a nix NDK path change. |
 | `0a3f149` | `feature:` `build_host_binary()` - `config.host_platform_name()`, `BuildTarget.host_build_dir()`, `BuildTarget.build_host_binary(relpath, auto_build=True)`, `config.root_source_dir`. Cheap-checks the host build dir, else bootstraps `mama <host> build target=<name>`. |
-| `3b0c654` | `fix:` cross-process dep lock. `mama/utils/dir_lock.py` (`flock`/`msvcrt`, sidecar kept **outside** `dep_dir` so a reclone-wipe cannot unlink a held lock; OS-released so it cannot hang). Wraps shim+checkout in `_load`. |
+| `3b0c654` | `fix:` cross-process dep lock. `mama/utils/dir_lock.py` (`flock`/`msvcrt`, sidecar kept **outside** `dep_dir` so a reclone-wipe cannot unlink a held lock, OS-released so it cannot hang). Wraps shim+checkout in `_load`. |
 
 `2d8f54b` (`guard package() on having artifacts...`) landed from another source between two of
 these. **Expect more concurrent commits in `build_dependency.py`.**
@@ -147,7 +147,7 @@ You **cannot** suppress a single child. So a skipped dep is a *zombie*: present 
 
 Worse, `is_pkg` and `is_src` sources call `create_build_target()` **eagerly in `__init__`** **[V]** -
 so a skipped local-source sibling has a **non-None target with empty
-`exported_libs`/`exported_includes`**. It will not crash; it will silently emit empty
+`exported_libs`/`exported_includes`**. It will not crash. It will silently emit empty
 link/include variables. Silent-wrong beats loud-crash for damage.
 
 Only one place currently handles the zombie state, and it was added after a real crash **[R]**
@@ -182,7 +182,7 @@ So **free** expansion = `add_local` deps and `add_git(..., mamafile="...")` over
 Only the commit-hash step is cheap (`git ls-remote`, 5s timeout). The **dependency list lives
 in `papa.txt` inside the archive**, so obtaining it requires downloading the complete
 `{archive}.zip` over HTTP and unzipping it into `build_dir` **[R]**
-(`artifactory.py:283-290` → `:311-314` → `:252-280`). There is no range fetch, no `papa.txt`
+(`artifactory.py:283-290` -> `:311-314` -> `:252-280`). There is no range fetch, no `papa.txt`
 endpoint, no manifest sidecar.
 
 **Consequence:** "expand the frontier with shims until the target is found" - an intuitive and
@@ -206,13 +206,13 @@ second, independent guard on the same hazard. Both must survive every future cha
 
 ### 3.7 Name-only dedup, first declaration wins, silently
 
-`loaded_dependencies` is keyed on **name alone**; a second parent declaring the same name with a
+`loaded_dependencies` is keyed on **name alone**. A second parent declaring the same name with a
 different url/branch/tag has those fields **discarded with no warning** - only `args` merge **[R]**
 (`build_dependency.py`, `update_existing_dependency`). The first `add_child` also fixes `parent`,
 hence `mamafile` and `src_dir` resolution.
 
 Under full load, "who is first" is a stable-ish whole-graph traversal. Under **scoped** load a
-different parent can win → different clone → different commit hash → **different archive name and
+different parent can win -> different clone -> different commit hash -> **different archive name and
 different `papa.txt` `D` records**. This is the strongest argument for never letting a scoped
 build *upload*.
 
@@ -224,21 +224,21 @@ unguarded, root-relevant setters **[R]**:
 | Setter | Global effect | Guarded? |
 |---|---|---|
 | `BuildConfig.set_artifactory_ftp()` | artifactory URL/auth | **No** - bypasses the root guard that exists on the `BuildTarget` wrapper |
-| `config.use_gcc_stdlib_for_clang()` | `clang_stdlib` | **No**, and **not part of the build-dir suffix** → silent libc++/libstdc++ flip into the *same* dir |
+| `config.use_gcc_stdlib_for_clang()` | `clang_stdlib` | **No**, and **not part of the build-dir suffix** -> silent libc++/libstdc++ flip into the *same* dir |
 | `config.enable_fortran()` | `config.fortran` | **No** |
-| `set_arch` / `set_platform` / sanitizer / coverage | `platform_build_dir_name()` → every dep's `build_dir` | **No** |
-| `macos_version` / `ios_version` / `android_api` / `cc_path` | feed `get_distro_info()`/`compiler_version()` → **archive name** | **No** |
+| `set_arch` / `set_platform` / sanitizer / coverage | `platform_build_dir_name()` -> every dep's `build_dir` | **No** |
+| `macos_version` / `ios_version` / `android_api` / `cc_path` | feed `get_distro_info()`/`compiler_version()` -> **archive name** | **No** |
 | `prefer_gcc` / `prefer_clang` | compiler | **effectively yes** - `lock_compiler()` runs right after *root's* settings, before any child exists, so sibling calls are already inert **[R]** |
 
 The existing good pattern to copy **[R]** (`build_target.py:232-234`): `if not self.dep.is_root: return`.
 
-Combined with §2's race, non-root `settings()` today are both **concurrent** and **unguarded**.
+Combined with section 2's race, non-root `settings()` today are both **concurrent** and **unguarded**.
 
 ### 3.9 What must never be scoped
 
 - **`dirty X`** - `get_deps_that_depend_on_target` **[R]** (`dependency_chain.py:138-166`) is a
   *reverse*-dependency walk over the whole graph, i.e. exactly the sibling information scoping
-  discards. Scoped, it under-marks silently → stale siblings link against a rebuilt X.
+  discards. Scoped, it under-marks silently -> stale siblings link against a rebuilt X.
 - **`clean all`**, bare `list`, bare `deps_only`, `sched_debug`, `target=all` - whole-graph by
   definition.
 - **`serial`** - `execute_task_chain` **[R]** (`dependency_chain.py:552-556`) hard-raises
@@ -247,16 +247,16 @@ Combined with §2's race, non-root `settings()` today are both **concurrent** an
 
 ### 3.10 Things that are already fine (do not "fix")
 
-- `config.loaded_dependencies` is **never iterated** - only a name→instance map inside
+- `config.loaded_dependencies` is **never iterated** - only a name->instance map inside
   `add_child` **[R]**. Not a whole-graph registry.
 - `sweep_orphaned_build_dirs` **[R]** enumerates the workspace **from disk**, not from the graph.
   Scoped loading does not make it delete more. **But** it is gated on `clean_only() &&
-  targets_all()` - treat that as an invariant; if a refactor changes how `target=all` is
+  targets_all()` - treat that as an invariant. If a refactor changes how `target=all` is
   represented, this either stops firing (orphans accumulate) or fires on `clean X` and rmtree's
   every package build dir for the platform.
 - `mark_unbuilt_target_deps` is already subtree-scoped and already `target is None`-safe.
 - **No whole-graph validator exists** (no version-conflict, duplicate-name or url reconciliation
-  pass) **[R]** - so scoping loses no validation. It also means §3.7's silent overwrite is
+  pass) **[R]** - so scoping loses no validation. It also means section 3.7's silent overwrite is
   undetected today.
 
 ---
@@ -287,34 +287,34 @@ guard at `build_dependency.py:212` was added. Every *other* walk lacks it.
 `papa_deploy.py:41,60` (`_gather`), `main.py:210-215` (`print_package_exports`).
 
 **Change sketch:** one predicate (e.g. `dep.is_loaded()` or reuse the existing `target is None`
-test) applied consistently; decide per-site whether to **skip** the dep or **fail loudly**. Prefer
+test) applied consistently. Decide per-site whether to **skip** the dep or **fail loudly**. Prefer
 skip in reporting paths, loud in paths that generate build inputs - a silently truncated
 `mama-dependencies.cmake` is worse than a crash.
 
 **Risk:** low. Adding guards cannot break a graph where every target is loaded.
-**Watch for:** masking a real bug. If a target is None during a *full* load, that is a defect;
-consider a `verbose` warning so it stays visible.
+**Watch for:** masking a real bug. If a target is None during a *full* load, that is a defect.
+Consider a `verbose` warning so it stays visible.
 
-**Tests:** a dep with `target=None` in the tree survives each walk; `_reserve_weight`/
-`_build_detail` do not raise; a truncated-but-valid graph still produces correct cmake for the
+**Tests:** a dep with `target=None` in the tree survives each walk. `_reserve_weight`/
+`_build_detail` do not raise. A truncated-but-valid graph still produces correct cmake for the
 loaded set. Existing `tests/test_target_scoped_build/...:185` is the precedent to mirror.
 
-**Done:** full suite green; a synthetic zombie in the tree cannot crash any listed walk.
-**Rollback:** revert; guards are additive.
+**Done:** full suite green. A synthetic zombie in the tree cannot crash any listed walk.
+**Rollback:** revert. Guards are additive.
 
 ---
 
 ### Item 2 - Root-only guards on global setters + `add_child` collision diagnostic
 
-**Standalone value:** yes. Catches real config bugs today, and §2's race makes non-root
+**Standalone value:** yes. Catches real config bugs today, and section 2's race makes non-root
 `settings()` mutation actively dangerous *now*.
 
 **Change sketch (two independent halves - consider two commits):**
 
 - **2a.** Apply the existing `if not self.dep.is_root: return` pattern (plus a `warning()`) to the
-  setters in §3.8 that are documented as root-only but unenforced - priority order:
+  setters in section 3.8 that are documented as root-only but unenforced - priority order:
   `use_gcc_stdlib_for_clang`, `BuildConfig.set_artifactory_ftp`, `enable_fortran`,
-  `set_arch`/`set_platform`. **Rebase onto Item 0 first**; it may already cover some of these.
+  `set_arch`/`set_platform`. **Rebase onto Item 0 first**. It may already cover some of these.
 - **2b.** In `add_child`, when a name is re-declared with a **different** url/branch/tag/mamefile,
   emit a `warning()` naming both declarations. Do **not** raise - that would break existing
   projects that rely on first-wins.
@@ -326,11 +326,11 @@ silently changes their build.
 **Mitigation:** land 2a as **warn-only first** (log "ignored, root-only" *without* changing
 behavior), ship a release, then enforce in a later release. Two-stage. Do not skip this.
 
-**Tests:** non-root setter is ignored + warns; root setter still applies; collision warning fires
-on differing url and stays silent on identical redeclaration; existing suites green.
+**Tests:** non-root setter is ignored + warns. Root setter still applies. Collision warning fires
+on differing url and stays silent on identical redeclaration. Existing suites green.
 
 **Done:** warn-only release out, no user reports of intentional non-root use.
-**Rollback:** revert; guards are additive and warn-only in stage 1.
+**Rollback:** revert. Guards are additive and warn-only in stage 1.
 
 ---
 
@@ -348,8 +348,8 @@ targeted = ((config.build or config.upload or config.deploy)
 
 So `update X`, `test X`, `start=`, `open`, `wipe`, `unshallow`, bare `coverage-report X` execute
 the chain over the **whole graph**. Under a full load that is merely wasteful. Under a *scoped*
-load it becomes **catastrophic and silent**: `_configure_body` → `_save_mama_cmake_and_dependencies_cmake(root)`
-→ `_save_dependencies_cmake` **[R]** (`dependency_chain.py:309-336`) rewrites root's
+load it becomes **catastrophic and silent**: `_configure_body` -> `_save_mama_cmake_and_dependencies_cmake(root)`
+-> `_save_dependencies_cmake` **[R]** (`dependency_chain.py:309-336`) rewrites root's
 `mama-dependencies.cmake` from a truncated `_get_flattened_deps(root)` and saves it. The next full
 root build then silently loses includes and link libs.
 
@@ -357,36 +357,36 @@ root build then silently loses includes and link libs.
 inherently single-target, keeping `dirty`/`list`/`clean all`/bare `deps_only` on the full chain.
 
 **Risk:** **medium-high - user-visible behavior change.** `mama test X` currently walks (and
-packages) the whole tree; narrowing changes what gets built as a side effect. Some users may
+packages) the whole tree. Narrowing changes what gets built as a side effect. Some users may
 depend on that accidentally.
 
-**Tests:** for each command × `target=X`, assert the executed chain equals `get_flat_deps(X)`;
-assert root's `mama-dependencies.cmake` is **not** rewritten by a targeted run; `dirty`/`list`/
+**Tests:** for each command x `target=X`, assert the executed chain equals `get_flat_deps(X)`.
+Assert root's `mama-dependencies.cmake` is **not** rewritten by a targeted run. `dirty`/`list`/
 `clean all` still see the full chain.
 
-**Done:** full suite green; `test_target_scoped_build`, `test_deps_only`, `test_clean_only`,
+**Done:** full suite green. `test_target_scoped_build`, `test_deps_only`, `test_clean_only`,
 `test_main_dispatch` unchanged or consciously updated.
 **Rollback:** revert the predicate.
 
 ---
 
-### Item 4 - Free-tier scoped discovery *(the actual optimization; do last, or never)*
+### Item 4 - Free-tier scoped discovery *(the actual optimization - do last, or never)*
 
 **Only start this if cold-build timings prove the nested bootstrap is expensive enough to
 justify loader risk.** The correctness problem it was originally meant to solve is already fixed
 by `3b0c654`.
 
-**Design, corrected by §3.5:** two tiers only.
+**Design, corrected by section 3.5:** two tiers only.
 
 - **Free** - mamefile already on disk: `add_local`, `add_git(mamafile=...)` overrides, already-cloned
   trees.
-- **Expensive** - clone *or* shim. **Do not build a shim tier** (§3.5).
+- **Expensive** - clone *or* shim. **Do not build a shim tier** (section 3.5).
 
-Algorithm: BFS from root expanding **only** free children, stopping the moment X is located; then
-fully load X's subtree. **If free expansion is exhausted without finding X, fall back to today's
+Algorithm: BFS from root expanding **only** free children, stopping the moment X is located, then
+fully loading X's subtree. **If free expansion is exhausted without finding X, fall back to today's
 full `load_dependency_chain`.**
 
-That fallback is what dissolves the chicken-and-egg problem (§3.9 / `find_dependency` needs
+That fallback is what dissolves the chicken-and-egg problem (section 3.9 / `find_dependency` needs
 `get_children()`, which is empty for an unloaded dep): on fallback, target resolution and the
 `"Available targets: ..."` typo message are byte-identical to today.
 
@@ -395,7 +395,7 @@ That fallback is what dissolves the chicken-and-egg problem (§3.9 / `find_depen
 hop free, zero clones needed for discovery.
 
 **Gating - deliberately narrow:**
-- `build target=X` **only**. **Not `upload`/`deploy`** - §3.7 means a scoped build can pick a
+- `build target=X` **only**. **Not `upload`/`deploy`** - section 3.7 means a scoped build can pick a
   different declaration winner and therefore publish a package with a different identity and
   different `D` records. Never let that reach a shared artifactory.
 - Excluded: `dirty`, `list`, `clean all`, bare `deps_only`, `sched_debug`, `serial`, `target=all`.
@@ -403,13 +403,13 @@ hop free, zero clones needed for discovery.
 
 **Depends on:** Items 1, 2, 3 all landed.
 
-**Tests:** free-tier BFS finds a local/override target without cloning; unreachable target falls
-back to full load and produces the identical error message; a scoped build of X loads exactly the
-full-build subtree of X; ancestors are never revived (fork-bomb invariant); `serial` refuses or is
+**Tests:** free-tier BFS finds a local/override target without cloning. Unreachable target falls
+back to full load and produces the identical error message. A scoped build of X loads exactly the
+full-build subtree of X. Ancestors are never revived (fork-bomb invariant). `serial` refuses or is
 excluded.
 
-**Done:** opt-in flag green in CI on a real project; measured saving recorded.
-**Rollback:** flag defaults off; revert is a one-line gate.
+**Done:** opt-in flag green in CI on a real project. Measured saving recorded.
+**Rollback:** flag defaults off. Revert is a one-line gate.
 
 ---
 
@@ -417,7 +417,7 @@ excluded.
 
 Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 `BuildTarget.build_host_binary`. Keep the `host == host_platform_name()` early-return untouched
-(§3.6).
+(section 3.6).
 
 ---
 
@@ -425,23 +425,23 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 
 | Rejected | Why |
 |---|---|
-| **Shim-expansion tier in discovery** | A shim probe downloads and unzips the entire package to read `papa.txt` (§3.5). Most expensive option, not cheapest. |
-| **`O_CREAT\|O_EXCL` lockfile** | Leaves a stale lock on crash → hangs a build forever. The landed `flock`/`msvcrt` design is released by the OS on fd close or process death. |
-| **Lock file *inside* `dep_dir`** | `reclone_wipe` rmtree's the whole `dep_dir`; deleting a held lock unlinks its inode and exclusion silently breaks. Sidecar lives in the parent dir. |
+| **Shim-expansion tier in discovery** | A shim probe downloads and unzips the entire package to read `papa.txt` (section 3.5). Most expensive option, not cheapest. |
+| **`O_CREAT\|O_EXCL` lockfile** | Leaves a stale lock on crash -> hangs a build forever. The landed `flock`/`msvcrt` design is released by the OS on fd close or process death. |
+| **Lock file *inside* `dep_dir`** | `reclone_wipe` rmtree's the whole `dep_dir`. Deleting a held lock unlinks its inode and exclusion silently breaks. Sidecar lives in the parent dir. |
 | **Bundling a host binary into the Android artifactory package** | The archive name has no host-OS component, so a Linux-published and a Windows-published package collide, and a cross-host consumer gets an unrunnable binary. |
 | **In-process cross-platform artifactory fetch (`host_platform=True` flag)** | `artifactory_archive_name` derives every token from the single global config, including an **exact** `compiler` token. Reconstructing a foreign platform's identity in-process means hand-building a second config, and the exact-match key would mostly miss anyway. The subprocess child computes its own correct name. |
-| **Suppressing `add_child` for out-of-scope deps** | Would fabricate `'<sibling> was removed'` rebuild triggers via `find_missing_dependency` **[R]**. Zombies must exist; they must be *guarded* (Item 1). |
+| **Suppressing `add_child` for out-of-scope deps** | Would fabricate `'<sibling> was removed'` rebuild triggers via `find_missing_dependency` **[R]**. Zombies must exist. They must be *guarded* (Item 1). |
 
 ---
 
 ## 6. Invariants - assert these in tests, forever
 
-1. **Never revive ancestors of the target** (§3.6, fork bomb). Guarded twice: in
+1. **Never revive ancestors of the target** (section 3.6, fork bomb). Guarded twice: in
    `mark_unbuilt_target_deps` and by `build_host_binary`'s host early-return.
-2. `clean_only() && targets_all()` still triggers `sweep_orphaned_build_dirs` (§3.10).
+2. `clean_only() && targets_all()` still triggers `sweep_orphaned_build_dirs` (section 3.10).
 3. A targeted run never rewrites **root's** `mama-dependencies.cmake` (Item 3).
 4. A scoped build of X loads exactly the same dep *set* as a full build restricted to X's subtree.
-5. Scoped loading never feeds `upload`/`deploy` (§3.7).
+5. Scoped loading never feeds `upload`/`deploy` (section 3.7).
 6. The cross-process dep lock's sidecar stays **outside** the dir it guards.
 
 **Regression suites that must stay green:** `test_target_scoped_build` (15),
@@ -453,7 +453,7 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 
 ## 7. Open questions for the auditing model
 
-1. **Re-verify every [R] claim**, especially §3.5 (shim cost) and §3.8 (setter list) - the whole
+1. **Re-verify every [R] claim**, especially section 3.5 (shim cost) and section 3.8 (setter list) - the whole
    plan pivots on those two.
 2. Does the Item 0 `settings()` patch make Item 2a redundant, partly or wholly?
 3. Item 3 is behavior-changing. Is narrowing `mama test X` to X's subtree *desirable*, or do users
@@ -461,9 +461,9 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 4. Is Item 4 worth the loader risk at all? Measure first: time a cold
    `mama linux build target=protobuf` and count the downloads/clones it performs. If the saving is
    small, stop after Item 3.
-5. Should `add_child`'s silent first-wins overwrite (§3.7) become an **error** in a future major
+5. Should `add_child`'s silent first-wins overwrite (section 3.7) become an **error** in a future major
    version? It is a genuine latent bug independent of everything here.
-6. `execute_unified` already grows lazily (§3.1). Is extending it with a stop condition a better
+6. `execute_unified` already grows lazily (section 3.1). Is extending it with a stop condition a better
    Item 4 than a separate scoped loader, given `_can_unify` currently excludes targeted builds
    precisely because the classic path "resolves the whole tree up front for target lookup"?
 
@@ -473,11 +473,11 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 
 ```
 Item 0 (external: settings() parallel fix)     <- land first
-   └─ Item 1 (zombie guards)                   <- standalone, low risk, do next
-        └─ Item 2 (setter guards, warn-first)  <- standalone, 2-stage release
-             └─ Item 3 (scope executed chain)  <- behavior change, needs decision
-                  └─ Item 4 (free-tier discovery, opt-in, build-only)   <- optional
-                       └─ Item 5 (enable for bootstrap child)
+   \_ Item 1 (zombie guards)                   <- standalone, low risk, do next
+        \_ Item 2 (setter guards, warn-first)  <- standalone, 2-stage release
+             \_ Item 3 (scope executed chain)  <- behavior change, needs decision
+                  \_ Item 4 (free-tier discovery, opt-in, build-only)   <- optional
+                       \_ Item 5 (enable for bootstrap child)
 ```
 
 Stop at any point. Every prefix of this list leaves the tree stable and better than it started.

--- a/docs/roadmap-load-and-config-hardening.md
+++ b/docs/roadmap-load-and-config-hardening.md
@@ -9,9 +9,8 @@
 
 ## 0. How to use this document
 
-Each roadmap item below is designed to be **landed alone** and leave the tree stable. Do not
-batch them. Every item states its own goal, evidence, risks, test plan, done-criteria and
-rollback.
+Each roadmap item below **lands alone** and leaves the tree stable. Do not batch them. Every
+item states its own goal, evidence, risks, test plan, done-criteria and rollback.
 
 Evidence is tagged so you know how much to trust it:
 
@@ -21,7 +20,7 @@ Evidence is tagged so you know how much to trust it:
 
 The commit hashes quoted below predate a squash of the branch history, so they no longer
 resolve on `master`. Verify a claim by the quoted code and the named test suite, never by the
-hash. **Line numbers drift too - always grep for the quoted code, never trust the number alone.**
+hash. **Line numbers drift too - grep for the quoted code, never trust the number alone.**
 
 ---
 
@@ -35,15 +34,15 @@ dependency that was supposedly present. Diagnosis chain:
    at **configure** time, so the path must exist before configure completes.
 2. The bootstrap for that is a nested `mama <host> build target=protobuf` child process.
 3. A **targeted** build takes the classic path and calls `load_dependency_chain(root)`, which
-   loads/clones the **entire** graph - so the nested Linux child was re-cloning shared deps into
-   the *same* source trees the outer Android build was compiling from.
+   loads/clones the **entire** graph. The nested Linux child therefore re-cloned shared deps
+   into the *same* source trees the outer Android build was compiling from.
 4. Two mama **processes** writing the same git working trees corrupted them. The in-process
    `threading.Lock` at `BuildDependency._load_lock` does not span processes. **[V]**
 
-That corruption is fixed (section 2). What remains is the *waste*: the nested child still loads the
-whole graph to build one leaf. "Scoped discovery" (Item 4) is the proposal to fix the waste -
-and it is now an **optimization, not a correctness fix**. Items 1-3 are hardening that stands
-on its own merit regardless of whether Item 4 ever happens.
+That corruption is fixed (section 2). What remains is the *waste*: the nested child still loads
+the whole graph to build one leaf. "Scoped discovery" (Item 4) fixes the waste, and it is now an
+**optimization, not a correctness fix**. Items 1-3 are hardening that stands on its own, with or
+without Item 4.
 
 ---
 
@@ -72,13 +71,12 @@ consumer-side commit must wait for the pin bump or its CI breaks.
 
 ### Landed - **Item 0**: `settings()` under the parallel loader
 
-The fix landed. `execute_unified` loads the ROOT up front, before the display and before any
-parallel job starts **[V]** (`mama/dependency_chain.py`, `root.load()` before
-`_make_scheduler`). Root `settings()` therefore picks the compiler and the toolchain first.
-Right after root
-`settings()`, `_load` runs `lock_compiler()` and `init_platform_toolchain()`, so a root
-`set_*_toolchain()` beats the default SDK probe **[V]**. `tests/test_root_settings_order/`
-pins the order on both execution paths.
+`execute_unified` loads the ROOT up front, before the display and before any parallel job
+starts **[V]** (`mama/dependency_chain.py`, `root.load()` before `_make_scheduler`). Root
+`settings()` therefore picks the compiler and the toolchain first. Right after root `settings()`,
+`_load` runs `lock_compiler()` and `init_platform_toolchain()`, so a root `set_*_toolchain()`
+beats the default SDK probe **[V]**. `tests/test_root_settings_order/` pins the order on both
+execution paths.
 
 Sibling non-root `settings()` still run **concurrently on different threads**, so any global
 `config` mutation from a non-root `settings()` is still a data race **[V]**. The landed fix
@@ -105,7 +103,7 @@ scheduler still loads every dep, and a `DepsOnlyScope` narrows CONFIGURE and BUI
 named target's dependencies. **Any other `target=X` run takes the classic
 `load_dependency_chain(root)` path.** Scoped discovery only ever concerns that branch.
 
-`execute_unified` - used only for *non*-targeted builds - is **already an incremental loader** **[V]**
+`execute_unified` is **already an incremental loader** **[V]**
 (`mama/dependency_chain.py:983-994`): `_do_load` loads one dep, then `grow()` adds jobs for its
 newly discovered children under the scheduler lock. It never stops early. This is the machinery
 Item 4 should extend rather than replace.
@@ -146,10 +144,10 @@ if self.target is None: return self.has_build_files()  # load failed/never ran: 
 
 A child inherits the parent's workspace **[V]** (`BuildDependency(self, self.config, self.workspace, ...)`),
 and `_update_dep_name_and_dirs` derives `dep_dir = workspaces_root/workspace/name`. So a dep's
-location is known **before** its mamefile is parsed. This is what makes a pre-clone probe
-structurally possible.
+location is known **before** its mamafile is parsed. This makes a pre-clone probe structurally
+possible.
 
-### 3.4 A mamefile is readable without cloning *only sometimes*
+### 3.4 A mamafile is readable without cloning *only sometimes*
 
 `mamafile_path()` **[V]**:
 
@@ -165,8 +163,8 @@ So **free** expansion = `add_local` deps and `add_git(..., mamafile="...")` over
 ### 3.5 An artifactory shim probe is NOT cheap - kills the obvious design
 
 Only the commit-hash step is cheap (`git ls-remote`, 5s timeout). The **dependency list lives
-in `papa.txt` inside the archive**, so obtaining it requires downloading the complete
-`{archive}.zip` over HTTP and unzipping it into `build_dir` **[R]**
+in `papa.txt` inside the archive**, so to read it mama must download the complete
+`{archive}.zip` over HTTP and unzip it into `build_dir` **[R]**
 (`artifactory.py:283-290` -> `:311-314` -> `:252-280`). There is no range fetch, no `papa.txt`
 endpoint, no manifest sidecar.
 
@@ -201,9 +199,9 @@ different parent can win -> different clone -> different commit hash -> **differ
 different `papa.txt` `D` records**. This is the strongest argument for never letting a scoped
 build *upload*.
 
-### 3.8 Global config is writable from any mamefile's `settings()`
+### 3.8 Global config is writable from any mamafile's `settings()`
 
-`self.config` is public on `BuildTarget` and the README documents mamefiles writing it. Reported
+`self.config` is public on `BuildTarget` and the README documents mamafiles writing it. Reported
 unguarded, root-relevant setters **[R]**:
 
 | Setter | Global effect | Guarded? |
@@ -250,16 +248,15 @@ Combined with section 2's race, non-root `settings()` today are both **concurren
 
 ### Item 0 - `settings()` under the parallel loader *(landed)*
 
-Landed, see section 2. The fix loads the root up front and serializes nothing else. It guards
-no setter, so Item 2 keeps its full scope.
+Landed, see section 2. It guards no setter, so Item 2 keeps its full scope.
 
 ---
 
 ### Item 1 - Zombie hardening: guard `dep.target is None` in graph walks
 
-**Standalone value:** yes, independent of scoped discovery. A dep can already have `target is
-None` today from an interrupted clone or a mamefile that failed to parse - that is exactly why the
-guard at `build_dependency.py:212` was added. Every *other* walk lacks it.
+**Standalone value:** yes, independent of scoped discovery. An interrupted clone or a failed
+mamafile parse already leaves `target is None` today - that is why the guard at
+`build_dependency.py:212` exists. Every *other* walk lacks it.
 
 **Reported unguarded dereferences [R]** - re-verify each:
 `dependency_chain.py:53-55` (`_get_exported_libs`), `:286-291`
@@ -297,12 +294,12 @@ loaded set. Existing `tests/test_target_scoped_build/...:185` is the precedent t
   setters in section 3.8 that are documented as root-only but unenforced - priority order:
   `use_gcc_stdlib_for_clang`, `BuildConfig.set_artifactory_ftp`, `enable_fortran`,
   `set_arch`/`set_platform`. **Rebase onto Item 0 first**. It may already cover some of these.
-- **2b.** In `add_child`, when a name is re-declared with a **different** url/branch/tag/mamefile,
+- **2b.** In `add_child`, when a name is re-declared with a **different** url/branch/tag/mamafile,
   emit a `warning()` naming both declarations. Do **not** raise - that would break existing
   projects that rely on first-wins.
 
 **Risk:** **medium - this is behavior-changing.** A project today may *depend* on a non-root
-mamefile setting one of these (e.g. a dep setting the artifactory URL). Turning that into a no-op
+mamafile setting one of these (e.g. a dep setting the artifactory URL). Turning that into a no-op
 silently changes their build.
 
 **Mitigation:** land 2a as **warn-only first** (log "ignored, root-only" *without* changing
@@ -360,7 +357,7 @@ by `3b0c654`.
 
 **Design, corrected by section 3.5:** two tiers only.
 
-- **Free** - mamefile already on disk: `add_local`, `add_git(mamafile=...)` overrides, already-cloned
+- **Free** - mamafile already on disk: `add_local`, `add_git(mamafile=...)` overrides, already-cloned
   trees.
 - **Expensive** - clone *or* shim. **Do not build a shim tier** (section 3.5).
 
@@ -368,7 +365,7 @@ Algorithm: BFS from root expanding **only** free children, stopping the moment X
 fully loading X's subtree. **If free expansion is exhausted without finding X, fall back to today's
 full `load_dependency_chain`.**
 
-That fallback is what dissolves the chicken-and-egg problem (section 3.9 / `find_dependency` needs
+That fallback dissolves the chicken-and-egg problem (section 3.9 / `find_dependency` needs
 `get_children()`, which is empty for an unloaded dep): on fallback, target resolution and the
 `"Available targets: ..."` typo message are byte-identical to today.
 
@@ -437,8 +434,7 @@ Trivial once Item 4 is proven: pass the flag in the child argv constructed in
 
 1. **Re-verify every [R] claim**, especially section 3.5 (shim cost) and section 3.8 (setter list) - the whole
    plan pivots on those two.
-2. Answered: the landed Item 0 fix loads the root first and guards no setter, so Item 2a keeps
-   its full scope.
+2. Answered: the landed Item 0 fix guards no setter, so Item 2a keeps its full scope.
 3. Item 3 is behavior-changing. Is narrowing `mama test X` to X's subtree *desirable*, or do users
    rely on it building the tree? Needs a product decision, not just a code one.
 4. Is Item 4 worth the loader risk at all? Measure first: time a cold

--- a/docs/roadmap-target-version.md
+++ b/docs/roadmap-target-version.md
@@ -6,7 +6,7 @@ only unbuilt item. Section 5.3 parks it as potentially unnecessary.
 **Origin:** a mamafile moved `self.version` into `settings()` and asked whether the artifactory fetch
 still sees it. It does. The investigation found a worse problem, in section 2, and P1 and P2 fixed it.
 
-**This document records its own corrections.** Three claims in earlier drafts turned out to be wrong.
+**This document records its own corrections.** Three claims in earlier drafts were wrong.
 Each one is kept next to the thing it was wrong about: the papa.txt blocker (section 4), the network saving
 (section 3.2) and the shared-archive gain (section 3.2). Leaving them in is the point. A reader who wonders whether
 anyone checked gets an answer instead of repeating the work.
@@ -106,9 +106,8 @@ consumer **downloaded** `...-8.0.1`. The result was a permanent cache miss. Ever
 rebuilt, with no warning, and nobody ever used the uploaded artifact. A computed version failed the same
 way, because the reader returned nothing and the download fell back to the commit hash.
 
-Keep this in mind when you extend the model. **Any version input that one side can see and the other
-cannot recreates this defect.** That single test rejects most tempting designs, including every one in
-section 7.
+**Any version input that one side can see and the other cannot recreates this defect.** That single
+test rejects most tempting designs, including every one in section 7.
 
 ---
 
@@ -152,7 +151,7 @@ branch runs depends on runtime state that no reader has before the clone.
 #### Why `mamafile_version.py` and not `types/git.py`  [V]
 
 The scan landed in `Git` because the old one-line regex lived there. Almost none of it is git work:
-parsing Python, judging a declaration and warning about it hold no git concept at all. Only
+parsing Python, judging a declaration and warning about it hold no git concept. Only
 `Git.fetch_self_version_from_remote` is genuinely git. It fetches the text for a dep that has no clone
 yet, and then asks `mamafile_version` what the text means.
 
@@ -180,7 +179,7 @@ Tests: `tests/test_version_from_pin/`.
 side always read the same declared value. The rename cannot drift into the section 2 defect.
 
 **Migration:** every tag-pinned and every branch-pinned dep gets a new archive name once, and the first
-build after it rebuilds and republishes them. How wide that wave is depends entirely on how a project
+build after it rebuilds and republishes them. How wide that wave is depends on how a project
 declares its deps. A tree of unpinned deps renames nothing.
 
 #### Two claims an earlier draft got wrong  [V]
@@ -230,9 +229,9 @@ qcoro,https://x/qcoro.git,,v0.13.0,mamadeps/qcoro.py,version_from=commit,LGPL
 
 So the mechanism exists, and no cached package would need a rewrite.
 
-**Mama is not going to use it.** section 5 shows that every case a mode would serve already has an answer. An
-unused mode is one more naming input a future reader must understand. Keep this section as the record of
-how a keyed field would work, in case a real case appears.
+**Mama will not use it.** Section 5 shows that every case a mode would serve already has an answer.
+An unused mode is one more naming input a future reader must understand. Keep this section as the
+record of how a keyed field would work, in case a real case appears.
 
 ## 5. Why no consumer-side version argument is needed  [V]
 
@@ -275,8 +274,7 @@ section 6. P1, P2 and 5.1 shrank its value. The literal covers a fixed version, 
 and an override mamafile covers a transformed one. What remains is a dep whose version lives in a file
 that only that dep knows about, and whose mamafile the consumer does not own.
 
-**Recommendation:** leave section 6 unbuilt until such a dep actually appears. Every case seen so far is
-already covered.
+**Recommendation:** leave section 6 unbuilt until such a dep appears.
 
 ## 6. `def version(self)`, executed in a probe context  [?]
 
@@ -372,4 +370,3 @@ Open work outside this document:
 
 - None. `feature/improved-version-parsing` is merged to `master` (PR #33). The first build after
   the merge rebuilds the deps section 3.2 renamed.
-- Every case that has come up so far is covered.

--- a/docs/roadmap-target-version.md
+++ b/docs/roadmap-target-version.md
@@ -1,7 +1,7 @@
 # The version field: how it works now, and what is left to build
 
-**Status:** P1 and P2 have landed (section 3), on branch `feature/improved-version-parsing`. Section 6 is the only
-unbuilt item, and section 5.3 parks it deliberately.
+**Status:** P1 and P2 are merged to `master` (PR #33, section 3). Section 6, `def version(self)`, is the
+only unbuilt item. Section 5.3 parks it as potentially unnecessary.
 **Audience:** an engineer or model picking this up cold. This document is self-contained.
 **Origin:** a mamafile moved `self.version` into `settings()` and asked whether the artifactory fetch
 still sees it. It does. The investigation found a worse problem, in section 2, and P1 and P2 fixed it.
@@ -370,5 +370,6 @@ those stay unchanged.
 
 Open work outside this document:
 
-- Merge `feature/improved-version-parsing`, then expect one rebuild wave for the deps section 3.2 renamed.
-- Nothing else. Every case that has come up so far is covered.
+- None. `feature/improved-version-parsing` is merged to `master` (PR #33). The first build after
+  the merge rebuilds the deps section 3.2 renamed.
+- Every case that has come up so far is covered.

--- a/docs/roadmap-target-version.md
+++ b/docs/roadmap-target-version.md
@@ -1,14 +1,14 @@
 # The version field: how it works now, and what is left to build
 
-**Status:** P1 and P2 have landed (§3), on branch `feature/improved-version-parsing`. §6 is the only
-unbuilt item, and §5.3 parks it deliberately.
+**Status:** P1 and P2 have landed (section 3), on branch `feature/improved-version-parsing`. Section 6 is the only
+unbuilt item, and section 5.3 parks it deliberately.
 **Audience:** an engineer or model picking this up cold. This document is self-contained.
 **Origin:** a mamafile moved `self.version` into `settings()` and asked whether the artifactory fetch
-still sees it. It does. The investigation found a worse problem, in §2, and P1 and P2 fixed it.
+still sees it. It does. The investigation found a worse problem, in section 2, and P1 and P2 fixed it.
 
 **This document records its own corrections.** Three claims in earlier drafts turned out to be wrong.
-Each one is kept next to the thing it was wrong about: the papa.txt blocker (§4), the network saving
-(§3.2) and the shared-archive gain (§3.2). Leaving them in is the point. A reader who wonders whether
+Each one is kept next to the thing it was wrong about: the papa.txt blocker (section 4), the network saving
+(section 3.2) and the shared-archive gain (section 3.2). Leaving them in is the point. A reader who wonders whether
 anyone checked gets an answer instead of repeating the work.
 
 Line numbers drift. Grep for the quoted code, never trust the number.
@@ -17,10 +17,10 @@ Line numbers drift. Grep for the quoted code, never trust the number.
 
 ## 0. How to use this document
 
-§1 and §2 are reference: what the version field is, and why it has the shape it has. Read them before
+Sections 1 and 2 are reference: what the version field is, and why it has the shape it has. Read them before
 you change anything, because most of the rules exist to stop one specific failure.
 
-§4 onward is planning. **Each item lands alone and leaves the tree stable.** Do not batch them.
+Section 4 onward is planning. **Each item lands alone and leaves the tree stable.** Do not batch them.
 
 Evidence tags:
 
@@ -60,7 +60,7 @@ The download side cannot run anything, because naming a package before the clone
 the artifactory shim. Every rule below follows from that one constraint.
 
 `self.version` covers a third-party dep too, because `add_git(mamafile='mamadeps/x.py')` points at a
-file in the CONSUMER's repo, which the reader can open before any clone. See §5.1.
+file in the CONSUMER's repo, which the reader can open before any clone. See section 5.1.
 
 ### 1.1 The rules, and the constraint each one serves
 
@@ -108,7 +108,7 @@ way, because the reader returned nothing and the download fell back to the commi
 
 Keep this in mind when you extend the model. **Any version input that one side can see and the other
 cannot recreates this defect.** That single test rejects most tempting designs, including every one in
-§7.
+section 7.
 
 ---
 
@@ -127,7 +127,7 @@ cannot recreates this defect.** That single test rejects most tempting designs, 
 
 The first cut of P1 scanned line by line, and that was wrong twice over.
 
-An anchored regex misses `if lgpl: self.version = '8.0.1-lgpl'`, which is the exact shape §2 is about.
+An anchored regex misses `if lgpl: self.version = '8.0.1-lgpl'`, which is the exact shape section 2 is about.
 Dropping the anchor fixed that, and introduced a worse bug: a line scan counts anything that MENTIONS
 the field. A mamafile documenting its own version lost its pin.
 
@@ -161,7 +161,7 @@ guard) and `tests/test_self_version_probe/` (the git-side fetch and the shim fal
 
 ### 3.2 P2 - a git pin names the package  [IMPLEMENTED]
 
-The precedence table in §1. A tag names the package alone, a branch labels the commit, and a commit pin
+The precedence table in section 1. A tag names the package alone, a branch labels the commit, and a commit pin
 shortens to the hash. `build_names.sanitize_version` makes any of them a legal file name.
 
 Tests: `tests/test_version_from_pin/`.
@@ -177,7 +177,7 @@ Tests: `tests/test_version_from_pin/`.
 | nothing pinned | `a1b2c3d` | `a1b2c3d` | no |
 
 `branch` and `tag` are never reassigned after `Git.__init__` [V], so the download side and the upload
-side always read the same declared value. The rename cannot drift into the §2 defect.
+side always read the same declared value. The rename cannot drift into the section 2 defect.
 
 **Migration:** every tag-pinned and every branch-pinned dep gets a new archive name once, and the first
 build after it rebuilds and republishes them. How wide that wave is depends entirely on how a project
@@ -199,7 +199,7 @@ declares its deps. A tree of unpinned deps renames nothing.
 - A readable, shareable name. `qcoro-...-release-v0.13.0` says what it is, and a human scanning the
   server can tell a branch build from a release without resolving anything.
 - It removes the reason to write `self.version = '0.13.0'` next to `git_tag='v0.13.0'`. That
-  duplication is exactly where the §2 bug class lives.
+  duplication is exactly where the section 2 bug class lives.
 
 **Decision on the branch label:** keep it. `main-a1b2c3d` is not needed for correctness, because the
 hash alone identifies the source. It is worth its one-time rename for the operational readability of an
@@ -230,7 +230,7 @@ qcoro,https://x/qcoro.git,,v0.13.0,mamadeps/qcoro.py,version_from=commit,LGPL
 
 So the mechanism exists, and no cached package would need a rewrite.
 
-**Mama is not going to use it.** §5 shows that every case a mode would serve already has an answer. An
+**Mama is not going to use it.** section 5 shows that every case a mode would serve already has an answer. An
 unused mode is one more naming input a future reader must understand. Keep this section as the record of
 how a keyed field would work, in case a real case appears.
 
@@ -257,7 +257,7 @@ class ffmpeg(mama.BuildTarget):
 `fetch_self_version_from_remote` returns None when `dep.mamafile` is set. The local override was already
 read, and the remote repo's own mamafile is not the one mama runs.
 
-`self.version` beats the tag in the §1 table, so the package is named `8.1.0`. No new argument, no
+`self.version` beats the tag in the section 1 table, so the package is named `8.1.0`. No new argument, no
 papa.txt field, and the rule a reader has to learn is one they already know.
 
 Pinned by `test_a_consumer_owned_override_mamafile_names_the_package`.
@@ -271,16 +271,16 @@ naming by identity asks for one thing and means another.
 ### 5.3 What genuinely remains: a dep that computes its own version  [?]
 
 Reading a `VERSION` file, or deriving a version inside the dep's own mamafile, still needs code. That is
-§6. P1, P2 and 5.1 shrank its value. The literal covers a fixed version, the pin covers a released one,
+section 6. P1, P2 and 5.1 shrank its value. The literal covers a fixed version, the pin covers a released one,
 and an override mamafile covers a transformed one. What remains is a dep whose version lives in a file
 that only that dep knows about, and whose mamafile the consumer does not own.
 
-**Recommendation:** leave §6 unbuilt until such a dep actually appears. Every case seen so far is
+**Recommendation:** leave section 6 unbuilt until such a dep actually appears. Every case seen so far is
 already covered.
 
 ## 6. `def version(self)`, executed in a probe context  [?]
 
-Kept for the case §5.3 describes. Read §5 first: this is the last resort, not the next step.
+Kept for the case section 5.3 describes. Read section 5 first: this is the last resort, not the next step.
 
 ### 6.1 The Python mechanic that decides the shape  [V]
 
@@ -346,8 +346,8 @@ those stay unchanged.
 - **Do not make the version depend on the platform, the arch, the compiler, coverage or sanitizers.**
   Those are separate fields in the archive name already.
 - **Do not add a naming input that only a mamafile attribute can set.** No reader can see a mamafile
-  attribute before the clone, which is §2 again. A consumer-side `add_git` argument is always safe.
-- **Do not add a `version_from` mode.** Every case it would serve has an answer in §5. An unused naming
+  attribute before the clone, which is section 2 again. A consumer-side `add_git` argument is always safe.
+- **Do not add a `version_from` mode.** Every case it would serve has an answer in section 5. An unused naming
   input is one more rule a reader must learn before they can predict an archive name.
 - **Do not require a papa.txt rewrite.** Many packages are already cached with today's records. A change
   that invalidates them is not worth any naming improvement.
@@ -362,13 +362,13 @@ those stay unchanged.
 |---|---|
 | P1, the scan reports and the upload refuses | **done**. Two mamafiles that would once diverge now agree or warn, and no upload can publish a name the download cannot construct |
 | P1a, the scan parses instead of grepping | **done**. A documented mamafile keeps its pin, and a module constant resolves |
-| P2, a git pin names the package | **done**. Tag, branch and commit each name their archive, and the rename table in §3.2 says what moved |
+| P2, a git pin names the package | **done**. Tag, branch and commit each name their archive, and the rename table in section 3.2 says what moved |
 | 5.1, "the upstream tag is not the name I want" | **no code needed**. The override mamafile already answers it |
 | 5.2, "this tag moves, name it by commit" | **no code needed**. Pin the commit |
-| §4, a consumer-side `version_from` | **rejected**. The mechanism works, and §5 shows nothing needs it |
-| §6, `def version(self)` | **parked**. Build it when a dep appears that §5 cannot serve |
+| section 4, a consumer-side `version_from` | **rejected**. The mechanism works, and section 5 shows nothing needs it |
+| section 6, `def version(self)` | **parked**. Build it when a dep appears that section 5 cannot serve |
 
 Open work outside this document:
 
-- Merge `feature/improved-version-parsing`, then expect one rebuild wave for the deps §3.2 renamed.
+- Merge `feature/improved-version-parsing`, then expect one rebuild wave for the deps section 3.2 renamed.
 - Nothing else. Every case that has come up so far is covered.

--- a/mama/__init__.py
+++ b/mama/__init__.py
@@ -1,4 +1,4 @@
-# these imports are executed when mamafile.py does `import mama`
+# a mamafile.py `import mama` runs these imports
 from .build_config import BuildConfig
 from .build_target import BuildTarget
 from .main import mamabuild

--- a/mama/_version.py
+++ b/mama/_version.py
@@ -1,2 +1,2 @@
-# this is parsed by pyproject.toml and defines current mamabuild version
+# pyproject.toml reads the mamabuild version from this file
 __version__ = "0.13.10"

--- a/mama/artifactory.py
+++ b/mama/artifactory.py
@@ -26,25 +26,23 @@ class ArtifactoryCredentialsError(RuntimeError):
 
 def artifactory_archive_name(target:BuildTarget):
     """
-    Constructs archive name for papa deploy packages in the form of:
+    Builds the archive name for a papa deploy package:
     {name}-{platform}-{os_major}-{compiler}-{arch}-{build_type}[-variant]-{version}
     Example: opencv-linux-24-gcc14-x64-release-df76b66
 
-    The version field is the first of these the dep has: a `self.version` literal in its mamafile, the
-    `git_tag` the consumer pinned, or the commit hash. A `git_branch` pin labels the hash rather than
-    replacing it. See docs/roadmap-target-version.md.
+    The version field is the first of these the dep has: a `self.version` literal in the mamafile,
+    the pinned `git_tag`, or the commit hash. A `git_branch` pin labels the hash and does not
+    replace it. See docs/roadmap-target-version.md.
     """
     p:ArtifactoryPkg = target.dep.dep_source
 
-    # if this is an ArtifactoryPkg with full name of the archive
     if p.is_pkg and p.fullname:
         return p.fullname
 
     version = ''
 
-    # if mamafile defines a specific version tag, then we will respect that
-    # regardless of dependency source type or any commit hashes
-    # explicit versioning will remove the version hash tag from the archive name
+    # A mamafile version wins over every dep source type and any commit hash.
+    # It replaces the commit hash in the archive name.
     if target.version:
         version = target.version
     else:
@@ -56,11 +54,10 @@ def artifactory_archive_name(target:BuildTarget):
             version = p.version
         elif p.is_git:
             git:Git = p
-            # A git_tag pin names the package after the tag. The consumer wrote that tag, so the download
-            # and the upload read the same value, and neither one resolves a commit hash to name
-            # anything. A tag is immutable by convention, so the tag alone identifies the source.
-            # add_git stores a git_commit pin in the tag field, and Git.is_hex_string is how the clone
-            # path tells the two apart. A commit pin takes the hash path below, which shortens it.
+            # A git_tag pin names the package after the tag. The consumer wrote the tag, so the download
+            # and the upload read the same value, with no commit hash resolution. A tag is immutable by
+            # convention, so the tag alone identifies the source. add_git stores a git_commit pin in the
+            # tag field, and Git.is_hex_string tells the two apart. A commit pin takes the hash path below.
             version = '' if Git.is_hex_string(git.tag) else build_names.sanitize_version(git.tag)
             if not version:
                 # No tag. The commit hash identifies the source, and a branch pin puts its name in front
@@ -76,13 +73,13 @@ def artifactory_archive_name(target:BuildTarget):
                 raise RuntimeError(f'Local package {target.name} has no target.version set in mamafile')
 
     name = target.name
-    # triplets information to make this package platform unique
+    # the triplet that makes the package name unique per platform
     platform, os_major, _ = target.config.get_distro_info()
     compiler = target.config.compiler_version()
     arch = target.config.arch # eg 'x86', 'arm64'
     # The SAME suffix the dep's build dir carries, computed once at dep init: e.g. '-cov-asan-lgpl'.
-    # It reads from the dep, not from target.args, because the dep holds what the consumer passed before
-    # any mamafile parse, so the pre-clone shim probe and the upload compose the same name.
+    # It reads from the dep, not from target.args, because the dep holds the pre-parse consumer args.
+    # The pre-clone shim probe and the upload then compose the same name.
     build_type = ('release' if target.config.release else 'debug') + target.dep.variant_suffix
 
     return f'{name}-{platform}-{os_major}-{compiler}-{arch}-{build_type}-{version}'
@@ -91,7 +88,7 @@ def artifactory_archive_name(target:BuildTarget):
 keyr = None
 def _get_keyring():
     global keyr
-    if not keyr: # lazy init keyring, because it loads certs and other slow stuff
+    if not keyr: # lazy init, because the keyring import loads certs and is slow
         import keyring
         if System.linux:
             import importlib
@@ -104,7 +101,6 @@ def _get_keyring():
 
 
 def _get_artifactory_ftp_credentials(config:BuildConfig, url:str):
-    # get the values from ENV
     username = os.getenv('MAMA_ARTIFACTORY_USER', None)
     password = os.getenv('MAMA_ARTIFACTORY_PASS', None)
     if username is not None:
@@ -199,11 +195,10 @@ def artifactory_upload(ftp:ftplib.FTP_TLS, target_name:str, file_path:str):
                 right = ' ' * int(50 - n)
                 progress(f'{indent}|{left}>{right}| {percent:>3} %')
         progress(f'{indent}|>{" ":50}| {0:>3} %')  # via progress(), so a headless run throttles it
-        # chdir into FTP_ROOT/target_name/
         try:
             ftp.cwd(target_name)
         except:
-            ftp.mkd(target_name) # create subdirectory if needed
+            ftp.mkd(target_name)
             ftp.cwd(target_name)
         ftp.storbinary(f'STOR {os.path.basename(file_path)}', f, callback=print_progress)
         progress(f'{indent}|{"="*50}>| 100 %', final=True)
@@ -216,7 +211,7 @@ def artifact_already_exists(ftp:ftplib.FTP_TLS, target:BuildTarget, file_path:st
     if target.config.verbose:
         file_list = "\n    ".join(items)
         console(f'    Checking if artifact "{target_path}" already exists on server:\n    {file_list}')
-    return len(items) > 0 # the file already exists
+    return len(items) > 0
 
 
 def artifactory_upload_ftp(target:BuildTarget, file_path:str) -> bool:
@@ -227,7 +222,6 @@ def artifactory_upload_ftp(target:BuildTarget, file_path:str) -> bool:
 
     with ftplib.FTP_TLS() as ftp:
         try:
-            # sanitize url for ftplib
             url = artifactory_sanitize_url(url)
             artifactory_ftp_login(ftp, config, url)
             if config.if_needed and artifact_already_exists(ftp, target, file_path):
@@ -252,8 +246,8 @@ def artifactory_upload_ftp(target:BuildTarget, file_path:str) -> bool:
 
 
 def _warn_on_compiler_mismatch(target:BuildTarget, papa:PapaFileInfo):
-    """Foreign-compiler package = libc++ archives in a libstdc++ build, dies on undefined std::__1:: symbols.
-    Compiler-scoped build dirs make this unreachable, so warn (don't fail) - a pre-C-record package has no stamp."""
+    """A foreign-compiler package mixes libc++ archives into a libstdc++ build and fails the link.
+    Compiler-scoped build dirs make this unreachable, so warn and do not fail. A pre-C-record package has no stamp."""
     if not papa.compiler: return  # pre-C-record package: unknown, allow
     try: current = target.config.compiler_version()
     except Exception: return
@@ -263,7 +257,7 @@ def _warn_on_compiler_mismatch(target:BuildTarget, papa:PapaFileInfo):
 
 def artifactory_load_target(target:BuildTarget, deploy_path, num_files_copied) -> Tuple[bool, list]:
     """
-    Reconfigures `target` from {deployment_path}/papa.txt.
+    Reconfigures `target` from {deploy_path}/papa.txt.
     Returns (fetched:bool, dep_sources:list)
     """
     papa_list = normalized_join(deploy_path, 'papa.txt')
@@ -284,12 +278,12 @@ def artifactory_load_target(target:BuildTarget, deploy_path, num_files_copied) -
     _warn_on_compiler_mismatch(target, papa)
 
     target.dep.from_artifactory = True
-    target.exported_includes = papa.includes # include folders to export from this target
-    target.exported_assets = papa.assets # exported asset files
+    target.exported_includes = papa.includes
+    target.exported_assets = papa.assets
     package.set_export_libs_and_products(target, papa.libs)
-    package.reload_syslibs(target, papa.syslibs) # set exported system libraries
+    package.reload_syslibs(target, papa.syslibs)
 
-    # for git repos, save the used commit hash status, so that next time the fetch is faster
+    # save the commit hash status for a git dep, so the next fetch is faster
     if target.dep.dep_source.is_git:
         git: Git = target.dep.dep_source
         git.save_status(target.dep)
@@ -316,11 +310,10 @@ def _fetch_package(target:BuildTarget, url, archive, cache_dir):
         if d.is_pkg:
             raise RuntimeError(f'Artifactory package {d} did not exist at {url}')
 
-        # NB: a 404 here for a git dep is normal (no prebuilt archive uploaded
-        # for the current commit). DO NOT wipe git_status - check_status already
-        # detects url/tag/branch/commit changes from the mamafile; wiping the
-        # status causes the *next* `mama update` to falsely report 'SCM change
-        # detected' and trigger a full rebuild of an already-up-to-date dep.
+        # NB: a 404 here for a git dep is NORMAL. No prebuilt archive exists for the current
+        # commit. DO NOT wipe git_status. check_status already detects a url, tag, branch or
+        # commit change by direct comparison. A wiped status makes the next `mama update`
+        # falsely report 'SCM change detected' and forces a full rebuild of an up-to-date dep.
 
         return None
 
@@ -331,21 +324,21 @@ def unzip_and_load_target(target:BuildTarget, local_file:str) -> Tuple[bool, lis
         return artifactory_load_target(target, target.dep.build_dir, num_files_copied = num_extracted)
     else:
         error(f'    Artifactory unzip failed, possibly corrupt package {local_file}')
-        os.remove(local_file) # it's probably corrupted
+        os.remove(local_file)
         return (False, None)
 
 
 def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
     """
-    Try to fetch prebuilt package from artifactory
+    Tries to fetch a prebuilt package from artifactory.
     Returns (fetched:bool, dep_sources:list)
     """
     url = target.config.artifactory_ftp
     if not url:
         return (False, None)
 
-    # A pinned version names the UPLOADED archive (artifactory_archive_name drops the commit
-    # hash), so a probe without it looks for a name uploads no longer produce - and a
+    # A pinned version names the UPLOADED archive, because artifactory_archive_name drops the
+    # commit hash. A probe without the pin asks for a name uploads no longer produce. A
     # hash-named archive it finds instead can only be a stale pre-pin leftover.
     if not target.version:
         target.version = pinned_version(target.dep)
@@ -354,10 +347,10 @@ def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
     if not archive:
         return (False, None)
 
-    cache_dir = target.dep.dep_dir #target.dep.workspace
+    cache_dir = target.dep.dep_dir
     local_file = normalized_join(cache_dir, f'{archive}.zip')
 
-    # cache is normally used, however `mama update` will ignore the cache and re-downloads the latest
+    # use the cache, except when `mama update` runs on this target: then download the latest
     if os.path.exists(local_file) and not (target.config.update and target.is_current_target()):
         if (target.is_current_target() or target.config.no_specific_target()) \
             and not target.config.test:
@@ -365,7 +358,6 @@ def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
         success, deps = unzip_and_load_target(target, local_file)
         if success: return (success, deps)
 
-    # use mama verbose to show the failure msgs
     url = artifactory_sanitize_url(url)
     local_file = _fetch_package(target, url, archive, cache_dir)
     if not local_file:
@@ -376,13 +368,13 @@ def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
 
 def try_load_artifactory_shim(dep) -> Tuple:
     """
-    Probe artifactory for a prebuilt package using the commit hash resolved via
-    `git ls-remote` (no clone). On hit, construct a default BuildTarget, load
-    papa.txt exports/deps into it, write the shim marker, and return the target
-    plus its child dep_sources.
+    Probes artifactory for a prebuilt package, named by the commit hash that
+    `git ls-remote` resolves without a clone. On a hit, constructs a default
+    BuildTarget and loads the papa.txt exports and deps into it. It then writes
+    the shim marker and returns the target plus its child dep_sources.
 
-    On miss (or when artifactory is not configured), returns (None, None) and
-    leaves dep state untouched so the caller can fall back to the clone path.
+    On a miss, or when artifactory is not configured, returns (None, None) and
+    leaves the dep state untouched, so the caller can use the clone path.
 
     Returns (target_or_None, dep_sources_or_None).
     """
@@ -396,7 +388,7 @@ def try_load_artifactory_shim(dep) -> Tuple:
 
     git: Git = dep.dep_source
 
-    # Resolve commit hash without cloning. `init_commit_hash` already supports
+    # Resolve the commit hash without a clone. `init_commit_hash` supports
     # ls-remote and respects the stored git_status cache when `update` is not set.
     commit_hash = git.init_commit_hash(dep, use_cache=True, fetch_remote=True)
     if not commit_hash:
@@ -410,10 +402,10 @@ def try_load_artifactory_shim(dep) -> Tuple:
     probe_target = BuildTarget(name=dep.name, config=config, dep=dep, args=dep.target_args)
     fetched, dependencies = artifactory_fetch_and_reconfigure(probe_target)
 
-    # Fallback: dep may pin target.version (e.g. boost 1.60) in its own not-yet-cloned
-    # mamafile, so its archive name doesn't include the commit hash. Sparse-fetch only the
-    # mamafile, grep self.version, and re-probe with that version. A version-pinned first
-    # probe gets no fallback: re-probing by hash would resurrect a stale pre-pin archive.
+    # Fallback: the dep may pin target.version (e.g. boost 1.60) in its own not-yet-cloned
+    # mamafile, so its archive name holds no commit hash. Sparse-fetch only the mamafile,
+    # grep self.version, and re-probe with that version. A version-pinned first probe gets
+    # no fallback: a re-probe by hash would resurrect a stale pre-pin archive.
     if not fetched and not probe_target.version:
         version = git.fetch_self_version_from_remote(dep)
         if version:
@@ -428,7 +420,7 @@ def try_load_artifactory_shim(dep) -> Tuple:
         dep.from_artifactory = False
         return (None, None)
 
-    # Hit: persist marker and return the configured target.
+    # Hit: write the marker and return the configured target.
     archive = artifactory_archive_name(probe_target)
     dep.write_shim_marker(archive_name=archive or '', commit_hash=commit_hash)
     config.update_stats.record_shim()

--- a/mama/artifactory.py
+++ b/mama/artifactory.py
@@ -28,11 +28,9 @@ def artifactory_archive_name(target:BuildTarget):
     """
     Builds the archive name for a papa deploy package:
     {name}-{platform}-{os_major}-{compiler}-{arch}-{build_type}[-variant]-{version}
-    Example: opencv-linux-24-gcc14-x64-release-df76b66
-
-    The version field is the first of these the dep has: a `self.version` literal in the mamafile,
-    the pinned `git_tag`, or the commit hash. A `git_branch` pin labels the hash and does not
-    replace it. See docs/roadmap-target-version.md.
+    The version is the first of: mamafile `self.version`, the pinned `git_tag`, or the commit hash.
+    A `git_branch` pin labels the hash and does not replace it.
+    target: the BuildTarget whose dep and config name the archive
     """
     p:ArtifactoryPkg = target.dep.dep_source
 
@@ -41,8 +39,7 @@ def artifactory_archive_name(target:BuildTarget):
 
     version = ''
 
-    # A mamafile version wins over every dep source type and any commit hash.
-    # It replaces the commit hash in the archive name.
+    # a mamafile version wins over every dep source type and replaces the commit hash in the archive name
     if target.version:
         version = target.version
     else:
@@ -54,15 +51,12 @@ def artifactory_archive_name(target:BuildTarget):
             version = p.version
         elif p.is_git:
             git:Git = p
-            # A git_tag pin names the package after the tag. The consumer wrote the tag, so the download
-            # and the upload read the same value, with no commit hash resolution. A tag is immutable by
-            # convention, so the tag alone identifies the source. add_git stores a git_commit pin in the
-            # tag field, and Git.is_hex_string tells the two apart. A commit pin takes the hash path below.
+            # A tag is immutable by convention, so the tag alone names the package with no hash resolution.
+            # add_git stores a git_commit pin in the tag field, and Git.is_hex_string routes it to the hash path below.
             version = '' if Git.is_hex_string(git.tag) else build_names.sanitize_version(git.tag)
             if not version:
-                # No tag. The commit hash identifies the source, and a branch pin puts its name in front
-                # for a reader: 'feat-experimental-radio-a1b2c3d'. The branch CANNOT replace the hash,
-                # because a branch moves: one name would then serve every commit ever pushed to it.
+                # No tag: the commit hash identifies the source, and a branch pin only prefixes it for a reader.
+                # A branch moves, so its name alone would serve every commit ever pushed to it.
                 commit = git.get_commit_hash(target.dep)
                 if not commit:
                     return None # nothing to do at this point
@@ -77,8 +71,7 @@ def artifactory_archive_name(target:BuildTarget):
     platform, os_major, _ = target.config.get_distro_info()
     compiler = target.config.compiler_version()
     arch = target.config.arch # eg 'x86', 'arm64'
-    # The SAME suffix the dep's build dir carries, computed once at dep init: e.g. '-cov-asan-lgpl'.
-    # It reads from the dep, not from target.args, because the dep holds the pre-parse consumer args.
+    # The SAME suffix the dep's build dir carries, read from the dep: it holds the pre-parse consumer args.
     # The pre-clone shim probe and the upload then compose the same name.
     build_type = ('release' if target.config.release else 'debug') + target.dep.variant_suffix
 
@@ -257,8 +250,10 @@ def _warn_on_compiler_mismatch(target:BuildTarget, papa:PapaFileInfo):
 
 def artifactory_load_target(target:BuildTarget, deploy_path, num_files_copied) -> Tuple[bool, list]:
     """
-    Reconfigures `target` from {deploy_path}/papa.txt.
-    Returns (fetched:bool, dep_sources:list)
+    Reconfigures `target` from {deploy_path}/papa.txt. Returns (fetched:bool, dep_sources:list).
+    target: the BuildTarget to fill with the papa.txt exports
+    deploy_path: the directory that holds papa.txt
+    num_files_copied: the extracted file count, shown by the verbose report
     """
     papa_list = normalized_join(deploy_path, 'papa.txt')
     if not os.path.exists(papa_list):
@@ -310,10 +305,8 @@ def _fetch_package(target:BuildTarget, url, archive, cache_dir):
         if d.is_pkg:
             raise RuntimeError(f'Artifactory package {d} did not exist at {url}')
 
-        # NB: a 404 here for a git dep is NORMAL. No prebuilt archive exists for the current
-        # commit. DO NOT wipe git_status. check_status already detects a url, tag, branch or
-        # commit change by direct comparison. A wiped status makes the next `mama update`
-        # falsely report 'SCM change detected' and forces a full rebuild of an up-to-date dep.
+        # A 404 for a git dep is NORMAL: no prebuilt archive exists for this commit. Do NOT wipe git_status.
+        # check_status detects real SCM changes by direct comparison, and a wiped status forces a false full rebuild.
 
         return None
 
@@ -330,16 +323,15 @@ def unzip_and_load_target(target:BuildTarget, local_file:str) -> Tuple[bool, lis
 
 def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
     """
-    Tries to fetch a prebuilt package from artifactory.
-    Returns (fetched:bool, dep_sources:list)
+    Tries to fetch a prebuilt package from artifactory. Returns (fetched:bool, dep_sources:list).
+    target: the BuildTarget to load the package into
     """
     url = target.config.artifactory_ftp
     if not url:
         return (False, None)
 
-    # A pinned version names the UPLOADED archive, because artifactory_archive_name drops the
-    # commit hash. A probe without the pin asks for a name uploads no longer produce. A
-    # hash-named archive it finds instead can only be a stale pre-pin leftover.
+    # A pinned version replaces the commit hash in the uploaded archive name, so the probe must use the pin.
+    # A hash-named archive it finds instead can only be a stale pre-pin leftover.
     if not target.version:
         target.version = pinned_version(target.dep)
 
@@ -368,15 +360,11 @@ def artifactory_fetch_and_reconfigure(target:BuildTarget) -> Tuple[bool, list]:
 
 def try_load_artifactory_shim(dep) -> Tuple:
     """
-    Probes artifactory for a prebuilt package, named by the commit hash that
-    `git ls-remote` resolves without a clone. On a hit, constructs a default
-    BuildTarget and loads the papa.txt exports and deps into it. It then writes
-    the shim marker and returns the target plus its child dep_sources.
-
-    On a miss, or when artifactory is not configured, returns (None, None) and
-    leaves the dep state untouched, so the caller can use the clone path.
-
-    Returns (target_or_None, dep_sources_or_None).
+    Probes artifactory for a prebuilt package named by the commit hash that ls-remote resolves without a clone.
+    On a hit, loads the papa.txt exports into a default BuildTarget, writes the shim marker, and
+    returns (target, dep_sources). On a miss it leaves the dep untouched and returns (None, None),
+    so the caller can use the clone path.
+    dep: the git BuildDependency to probe
     """
     from .build_target import BuildTarget  # local import to avoid cycle
 
@@ -388,8 +376,7 @@ def try_load_artifactory_shim(dep) -> Tuple:
 
     git: Git = dep.dep_source
 
-    # Resolve the commit hash without a clone. `init_commit_hash` supports
-    # ls-remote and respects the stored git_status cache when `update` is not set.
+    # resolve the commit hash without a clone, honoring the git_status cache when `update` is not set
     commit_hash = git.init_commit_hash(dep, use_cache=True, fetch_remote=True)
     if not commit_hash:
         if config.verbose:
@@ -397,15 +384,12 @@ def try_load_artifactory_shim(dep) -> Tuple:
         return (None, None)
     git.commit_hash = commit_hash  # cache for downstream consumers
 
-    # First probe: version-named if a local mamafile pins self.version (fetch_and_reconfigure
-    # resolves it), else commit-hash-named. Works for the common case.
+    # first probe: version-named when a local mamafile pins self.version, else commit-hash-named
     probe_target = BuildTarget(name=dep.name, config=config, dep=dep, args=dep.target_args)
     fetched, dependencies = artifactory_fetch_and_reconfigure(probe_target)
 
-    # Fallback: the dep may pin target.version (e.g. boost 1.60) in its own not-yet-cloned
-    # mamafile, so its archive name holds no commit hash. Sparse-fetch only the mamafile,
-    # grep self.version, and re-probe with that version. A version-pinned first probe gets
-    # no fallback: a re-probe by hash would resurrect a stale pre-pin archive.
+    # Fallback: the dep may pin self.version in its own not-yet-cloned mamafile, so sparse-fetch only the
+    # mamafile and re-probe with that version. A re-probe by hash after a version pin would resurrect a stale archive.
     if not fetched and not probe_target.version:
         version = git.fetch_self_version_from_remote(dep)
         if version:
@@ -420,7 +404,6 @@ def try_load_artifactory_shim(dep) -> Tuple:
         dep.from_artifactory = False
         return (None, None)
 
-    # Hit: write the marker and return the configured target.
     archive = artifactory_archive_name(probe_target)
     dep.write_shim_marker(archive_name=archive or '', commit_hash=commit_hash)
     config.update_stats.record_shim()

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -77,9 +77,8 @@ class BuildConfig:
     Every dependency shares it."""
     @staticmethod
     def _default_build_jobs() -> int:
-        """Default parallel build jobs. Linux keeps ONE core free, so a fully parallel build cannot
-        freeze the desktop or trip the OOM killer. Windows and macOS use all cores. An explicit
-        `jobs=N` on the command line overrides this."""
+        """Default parallel build jobs: Linux keeps ONE core free, so a full build cannot freeze the
+        desktop or trip the OOM killer. Windows and macOS use all cores. `jobs=N` overrides this."""
         cpu = psutil.cpu_count() or 4
         return max(1, cpu - 1) if System.linux else cpu
 
@@ -120,8 +119,7 @@ class BuildConfig:
         self.update_stats = UpdateStats() # clone/pull/shim counters for the load phase summary
         self.enable_clang_tidy = False # enables clang-tidy static analysis during build
         self.clang_tidy_path = None # resolved path to clang-tidy executable
-        # The ONE active platform. set_platform() installs it and derives the mamafile-facing
-        # flags below from it, so nothing else stores platform state.
+        # the ONE active platform: set_platform() derives the mamafile flags below from it, and nothing else stores platform state
         self.platform : Platform = None
         self.msvc    = False # whether this is a MSVC build on Windows
         self.linux   = False
@@ -288,30 +286,19 @@ class BuildConfig:
             elif arg == 'release': self.set_build_config(release=True)
             elif arg == 'debug':   self.set_build_config(debug=True)
             elif arg == 'open':    self.open = 'root'
-            # Open a specific target source dir for editing with VSCode or Visual Studio
-            # Ex old: mama open=ReCpp
-            # Ex new: mama open ReCpp
+            # open a target source dir in the editor: `mama open ReCpp`, or the old form `open=ReCpp`
             elif arg.startswith('open='):   self.open = arg[5:]
             elif arg.startswith('jobs='):   self.jobs = int(arg[5:])
-            # Set the target to build/update/clean
-            # Automatic target lookup supersedes this form
-            # Ex old: mama build target=opencv
-            # Ex new: mama build opencv
+            # old target form `target=opencv`: the automatic lookup (`mama build opencv`) supersedes it
             elif arg.startswith('target='): self.target = arg[7:]
-            # Add arguments for the test runner
-            # Ex: mama build test="nogdb threadpool"
-            # Ex: mama build test=nogdb test=threadpool
-            # Ex: mama build test=nogdb,threadpool
+            # test runner args: test="a b", repeated test=a test=b, or the comma form test=a,b
             elif arg.startswith('test='):   self.test = self.join_args(self.test, arg[5:])
-            # Run the tests in a loop until failure, to catch a flaky test
-            # Ex: mama build test="my_flaky_test" test_until_failure=100
+            # run the tests in a loop until failure, to catch a flaky test
             elif arg == 'test_until_failure': self.test_until_failure = 100 # arbitrary default
             elif arg.startswith('test_until_failure='): self.test_until_failure = int(arg[19:]) # max loop iterations
-            # Call target.start with the specified arguments
-            # Ex: mama build start=verify
+            # call target.start with the given arguments, eg start=verify
             elif arg.startswith('start='):  self.start = self.join_args(self.start, arg[6:])
             elif arg.startswith('arch='):   self.set_arch(arg[5:])
-            # Add compiler flags
             elif arg.startswith('flags='):  self.flags = self.join_args(self.flags, arg[6:])
             # Ex: mama build android-24
             elif arg.startswith('android-'):
@@ -342,9 +329,8 @@ class BuildConfig:
         return args + ' ' + arg
 
 
-    ## set_platform() flag to platform class name, in resolution order. Only the FIRST enabled flag
-    ## wins. The lookup goes through this module's globals, so a test can swap a platform with
-    ## monkeypatch.setattr('mama.build_config.Imx8mp', Fake).
+    ## set_platform() flag to platform class name, in resolution order: the FIRST enabled flag wins.
+    ## The lookup goes through this module's globals, so a test can monkeypatch a platform class.
     _PLATFORM_FLAGS = (('msvc','Windows'), ('linux','Linux'), ('macos','Macos'), ('ios','Ios'),
                        ('android','Android'), ('raspi','Raspi'), ('oclea','Oclea'), ('mips','Mips'),
                        ('xilinx','Xilinx'), ('imx8mp','Imx8mp'))
@@ -376,9 +362,8 @@ class BuildConfig:
 
 
     def _update_platform_flags(self):
-        """Refresh the per-platform mamafile properties from `self.platform`. `msvc`, `linux` and
-        `macos` stay bools. The rest return the platform object, because a mamafile reads
-        `config.android.android_api` from them. Both forms are documented API - see README."""
+        """Refresh the mamafile-facing platform properties. `msvc`, `linux` and `macos` stay bools. The
+        rest return the platform object, because a mamafile reads fields like `config.android.android_api`."""
         p = self.platform
         def obj(cls): return p if isinstance(p, cls) else None
         self.msvc  = isinstance(p, Windows)
@@ -438,10 +423,9 @@ class BuildConfig:
 
 
     def host_platform_name(self):
-        """Build-dir / CLI platform name of the HOST mama runs on ('windows'|'linux'|'macos'), independent
-        of the cross-compile target platform. The single source of truth for host build dirs and for a
-        `mama <host> build` bootstrap. It mirrors name() for the host. The host arch stays out, because
-        the `windows` and `linux` build-dir names mean x64."""
+        """Build-dir / CLI name of the HOST mama runs on ('windows'|'linux'|'macos'), independent of the
+        cross-compile target. The single source of truth for host build dirs and a `mama <host> build`
+        bootstrap. The host arch stays out, because the `windows` and `linux` build-dir names mean x64."""
         if System.windows: return 'windows'
         if System.macos:   return 'macos'
         return 'linux'
@@ -520,7 +504,7 @@ class BuildConfig:
 
     def enable_fortran(self, path=''):
         """Enable the Fortran compiler.
-        `path` - optional custom path or command for the Fortran compiler. Default '': search the system."""
+        path: custom path or command for the Fortran compiler, default '' searches the system"""
         if self.fortran: return
         self.fortran = path if path else self.find_default_fortran_compiler()
 
@@ -535,8 +519,7 @@ class BuildConfig:
             version = self.get_gcc_clang_fullversion(cxx_path, dumpfullversion)
             return os.path.dirname(cxx_path) + '/', suffix, version
 
-        # check the priority paths first: /etc/alternatives/<compiler> is the configured default of the
-        # user on linux, and ~/.local/bin/<compiler> is a manual install
+        # priority paths first: /etc/alternatives is the user's configured default, ~/.local/bin a manual install
         priority_choices = [ suggested_path, os.getenv('CXX'),
                             f'{os.getenv("HOME")}/.local/bin/{compiler}',
                             '/etc/alternatives/' + compiler ]
@@ -602,8 +585,7 @@ class BuildConfig:
         if self.msvc:
             return (self.cc_path, self.cxx_path, self.cxx_version)
 
-        # a cross platform always names its own compilers: a fallback to the host compiler
-        # search would silently build x86 binaries for an arm64 board
+        # a cross platform names its own compilers: a host-compiler fallback would silently build for the wrong arch
         cc, cxx, ver = self.platform.compiler_paths()
         if cc:
             self.cc_path, self.cxx_path, self.cxx_version = cc, cxx, ver
@@ -714,14 +696,10 @@ class BuildConfig:
 
 
     def set_toolchain(self, toolchain_dir=None, toolchain_file=None):
-        """Point the active platform at an explicit toolchain, from the ROOT mamafile settings().
-
-        `toolchain_dir` is the SDK root holding the cross compilers and the sysroot. `toolchain_file`
-        is the CMake toolchain file the SDK ships. A platform uses whichever of the two it needs.
-        ```
-            def settings(self):
-                self.config.set_toolchain('/opt/my-imx8mp-sdk')
-        ```
+        """Point the active platform at an explicit toolchain, from the ROOT mamafile settings(), eg
+        self.config.set_toolchain('/opt/my-imx8mp-sdk'). A platform uses whichever argument it needs.
+        toolchain_dir: the SDK root that holds the cross compilers and the sysroot
+        toolchain_file: the CMake toolchain file the SDK ships
         """
         self.platform.init_toolchain(toolchain_dir, toolchain_file)
 
@@ -753,9 +731,8 @@ class BuildConfig:
 
 
     def init_platform_toolchain(self):
-        """Resolve the cross-compile toolchain (NDK/sysroot paths) from the default search paths.
-        MUST run after the ROOT mamafile's settings(), so an explicit set_toolchain() there wins.
-        This is a no-op once settings() already picked a toolchain dir."""
+        """Resolve the cross-compile toolchain from the default search paths. MUST run after the ROOT
+        mamafile's settings(), so an explicit set_toolchain() there wins. A no-op once a toolchain is set."""
         self.platform.init_default()
 
 
@@ -796,8 +773,7 @@ class BuildConfig:
         execute('sudo apt-get update')
         execute(f'sudo apt-get install clang-{clang_major} clang-tidy-{clang_major} '+\
                 f'libc++-{clang_major}-dev libc++abi-{clang_major}-dev -y')
-        # make this clang version the default via update-alternatives,
-        # so mama and the cmake tools find it with no extra configuration
+        # make this clang the default via update-alternatives, so mama and the cmake tools find it
         console(f'Configuring clang-{clang_major} as default clang via update-alternatives', color=Color.MAGENTA)
         execute(f'sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-{clang_major}   100')
         execute(f'sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-{clang_major} 100')
@@ -818,8 +794,7 @@ class BuildConfig:
         console(f'Installing gcc-{gcc_major} and g++-{gcc_major} from apt repositories', color=Color.MAGENTA)
         execute('sudo apt-get update')
         execute(f'sudo apt-get install gcc-{gcc_major} g++-{gcc_major} -y')
-        # make this gcc version the default via update-alternatives,
-        # so mama and the cmake tools find it with no extra configuration
+        # make this gcc the default via update-alternatives, so mama and the cmake tools find it
         console(f'Configuring gcc-{gcc_major} as default gcc via update-alternatives', color=Color.MAGENTA)
         execute(f'sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-{gcc_major} 100')
         execute(f'sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-{gcc_major} 100')

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -73,15 +73,13 @@ class UpdateStats:
 
 
 class BuildConfig:
-    """
-    Mama Build Configuration is created only once in the root project working directory.
-    This configuration is then passed down to dependencies.
-    """
+    """The one build configuration, created in the root project working directory.
+    Every dependency shares it."""
     @staticmethod
     def _default_build_jobs() -> int:
-        """Default parallel build jobs. Linux leaves ONE core free so a perfectly-parallel build can't
-        saturate the desktop into an OOM/freeze; Windows/macOS use all cores. An explicit `jobs=N`
-        on the command line overrides this."""
+        """Default parallel build jobs. Linux keeps ONE core free, so a fully parallel build cannot
+        freeze the desktop or trip the OOM killer. Windows and macOS use all cores. An explicit
+        `jobs=N` on the command line overrides this."""
         cpu = psutil.cpu_count() or 4
         return max(1, cpu - 1) if System.linux else cpu
 
@@ -93,30 +91,29 @@ class BuildConfig:
         self.rebuild = False
         self.update  = False
         self.deploy  = False
-        # if root mamafile has defined an artifacts URL
-        # this will upload deploy archive through SFTP
+        # upload the deploy archive over SFTP, if the root mamafile defines an artifactory URL
         self.upload  = False
-        # currently for uploads only, uploads only if package already not uploaded
+        # for uploads only: upload only when the package is not on the server yet
         self.if_needed = False
-        # if `art` is specified, then artifactory download is mandatory, no source builds are done
+        # `art`: artifactory download is mandatory, no source builds
         self.force_artifactory = False
-        # if `noart` is specified, then artifactory is temporarily ignored
+        # `noart`: ignore artifactory for this run
         self.disable_artifactory = False
         self.reclone   = False
-        self.dirty     = False # marks a target for rebuild on next build even if it's up to date
+        self.dirty     = False # mark a target for rebuild on the next build even if it is up to date
         self.deps_only = False # only execute build/rebuild/clean on dependencies, not the main target
         self.sched_debug = False # TEMP: print each target's build-weight calc, then exit without building
         self.buildstats = False # after the build, print a per-package load/configure/build time breakdown
-        self.unshallow = False  # by default, git clones are shallow, this allows unshallowing
+        self.unshallow = False  # git clones are shallow by default, this flag unshallows them
         self.git_url_override = None  # 'https' or 'ssh': rewrite add_git() urls at build time
-        self.run_cmake_configure = False # if True, forces running CMake configure step even if target doesn't need rebuild
+        self.run_cmake_configure = False # force the CMake configure step even when the target needs no rebuild
         self.mama_init = False
         self.print     = True
         self.verbose   = False
         self.test      = ''
         self.start     = ''
         self.with_tests = False # forces -DENABLE_TESTS=ON
-        self.test_until_failure = 0 # if > 0, runs test executable in a loop until it fails, useful for catching flaky tests
+        self.test_until_failure = 0 # if > 0, run the test executable in a loop until it fails, to catch a flaky test
         self.sanitize  = None # gcc/clang: -fsanitize=[thread|leak|address|undefined]
         self.coverage  = None # gcc/clang: gcov | msvc: /fsanitize-coverage=edge
         self.coverage_report = None # runs gcovr to generate coverage report
@@ -144,20 +141,19 @@ class BuildConfig:
         self.gcc   = False
         self.clang_path = ''
         self.gcc_path = ''
-        # can be used to overide C and C++ compiler paths
+        # override the C and C++ compiler paths
         self.cc_path = ''
         self.cxx_path = ''
         self.cxx_version = '' # c++ compiler version, eg '8.3.0' for gcc 8.3.0
-        # If compiler specificed from command line
-        # using `mama build gcc` or `mama build clang`
+        # True when the command line named a compiler, eg `mama build gcc` or `mama build clang`
         self.compiler_cmd = False
         self.compiler_conflict_warned = False  # the "target prefers X but compiler locked to Y" note fires once, not per dep
-        self.clang_stdlib = 'libc++'  # linux clang C++ stdlib; see use_gcc_stdlib_for_clang()
+        self.clang_stdlib = 'libc++'  # linux clang C++ stdlib, see use_gcc_stdlib_for_clang()
         self.fortran = ''
         # build optimization
         self.release = True
         self.debug   = False
-        # valid architectures: x86, x64, arm, arm64
+        # target architecture, see set_arch() for the valid names
         self.arch    = None
         self.distro  = None  # distro information (name, major, minor)
         self.jobs    = BuildConfig._default_build_jobs()
@@ -177,17 +173,17 @@ class BuildConfig:
         ## Convenient installation utils:
         self.convenient_install = []
         ## Workspace and parsing
-        self.parallel_load = False  ## Whether to load dependencies in parallel?
-        self.serial_load   = False  ## If True, override the auto-parallel-on-update behaviour
-        self.parallel_max  = 20     ## Cap concurrent git fetches (avoids hammering the SSH master)
+        self.parallel_load = False  ## Load dependencies in parallel
+        self.serial_load   = False  ## If True, override the auto-parallel-on-update behavior
+        self.parallel_max  = 20     ## Cap concurrent git fetches, so the SSH master does not overload
         # The toolchain file a platform picked, '' for a native build. cmake_configure records it and
         # reads it back: a toolchain file owns compiler selection, so mama must not name a compiler too.
         self.cmake_toolchain_file = ''
         self.git_timeout   = 30     ## Kill a git clone/fetch with no progress for this many seconds
         self.no_compiler_cache = False  ## Disable cross-build-dir reuse of cmake compiler detection
         self.global_workspace = False
-        # The root project dir (mamabuild sets it from source_dir); cwd for a `mama <host> build` bootstrap
-        # child so it resolves the same dependency graph. None until mamabuild runs (direct-construct tests).
+        # The root project dir, set by mamabuild from source_dir. A `mama <host> build` bootstrap child
+        # uses it as cwd, so it resolves the same dependency graph. None until mamabuild runs (direct-construct tests).
         self.root_source_dir = None
         if System.windows:
             self.workspaces_root = util.normalized_path(os.getenv('HOMEPATH'))
@@ -198,8 +194,8 @@ class BuildConfig:
         self._announce_lock = threading.Lock()
         self._cmake_ver_num = None   # cached `cmake --version`, also the CMakeFiles/<ver> dir name
         self._seed_coord = None      # compiler-seed Coordinator, built on first configure
-        self._buildstats_start = None  # buildstats wall start; set only on a non-MSVC insights run
-        self._timetrace_json = None    # vcperf trace path; set only on an MSVC insights run
+        self._buildstats_start = None  # buildstats wall start, set only on a non-MSVC insights run
+        self._timetrace_json = None    # vcperf trace path, set only on an MSVC insights run
         self.unused_args = []
         self.loaded_dependencies : dict[str, BuildDependency] = {}
         self.dep_registry_lock = threading.Lock()  # guards loaded_dependencies under parallel_load
@@ -221,7 +217,7 @@ class BuildConfig:
             elif arg == 'if_needed': self.if_needed = True
             elif arg == 'art':       self.force_artifactory = True
             elif arg == 'noart':     self.disable_artifactory = True
-            # Updates, Builds and Deploys the project as a package
+            # update, rebuild, deploy and upload the project as a package
             elif arg == 'serve':
                 self.rebuild = True
                 self.update = True
@@ -297,25 +293,25 @@ class BuildConfig:
             # Ex new: mama open ReCpp
             elif arg.startswith('open='):   self.open = arg[5:]
             elif arg.startswith('jobs='):   self.jobs = int(arg[5:])
-            # Sets the target to build/update/clean
-            # This is superceded by automatic target lookup
+            # Set the target to build/update/clean
+            # Automatic target lookup supersedes this form
             # Ex old: mama build target=opencv
             # Ex new: mama build opencv
             elif arg.startswith('target='): self.target = arg[7:]
-            # Adding arguments for tests runner
+            # Add arguments for the test runner
             # Ex: mama build test="nogdb threadpool"
             # Ex: mama build test=nogdb test=threadpool
             # Ex: mama build test=nogdb,threadpool
             elif arg.startswith('test='):   self.test = self.join_args(self.test, arg[5:])
-            # Adding arguments for test runner to run tests in a loop until failure, useful for catching flaky tests
+            # Run the tests in a loop until failure, to catch a flaky test
             # Ex: mama build test="my_flaky_test" test_until_failure=100
             elif arg == 'test_until_failure': self.test_until_failure = 100 # arbitrary default
-            elif arg.startswith('test_until_failure='): self.test_until_failure = int(arg[19:]) # set number of iterations to run tests until failure
-            # Calls target.start with the specified arguments
+            elif arg.startswith('test_until_failure='): self.test_until_failure = int(arg[19:]) # max loop iterations
+            # Call target.start with the specified arguments
             # Ex: mama build start=verify
             elif arg.startswith('start='):  self.start = self.join_args(self.start, arg[6:])
             elif arg.startswith('arch='):   self.set_arch(arg[5:])
-            # Add additional compiler flags
+            # Add compiler flags
             elif arg.startswith('flags='):  self.flags = self.join_args(self.flags, arg[6:])
             # Ex: mama build android-24
             elif arg.startswith('android-'):
@@ -335,7 +331,7 @@ class BuildConfig:
             continue
 
 
-    # modifies existing `args` by parsing and appending `arg` contents
+    # parse `arg` and append its contents to `args`
     def join_args(self, args, arg):
         if arg[0] == '"' and arg[-1] == '"':
             arg = arg[1:-1]
@@ -347,8 +343,8 @@ class BuildConfig:
 
 
     ## set_platform() flag to platform class name, in resolution order. Only the FIRST enabled flag
-    ## wins, exactly as the old if/elif chain did. Looked up through this module's globals, so a test
-    ## can swap a platform out with monkeypatch.setattr('mama.build_config.Imx8mp', Fake).
+    ## wins. The lookup goes through this module's globals, so a test can swap a platform with
+    ## monkeypatch.setattr('mama.build_config.Imx8mp', Fake).
     _PLATFORM_FLAGS = (('msvc','Windows'), ('linux','Linux'), ('macos','Macos'), ('ios','Ios'),
                        ('android','Android'), ('raspi','Raspi'), ('oclea','Oclea'), ('mips','Mips'),
                        ('xilinx','Xilinx'), ('imx8mp','Imx8mp'))
@@ -372,8 +368,8 @@ class BuildConfig:
 
 
     def set_platform_class(self, cls):
-        """Install `cls` as the one active platform. Selecting the SAME platform twice keeps the
-        existing instance, so `mama build android-31 ndk-28` does not throw away the api level."""
+        """Install `cls` as the one active platform. The SAME class twice keeps the existing
+        instance, so `mama build android-31 ndk-28` does not discard the api level."""
         if cls is None:                     self.platform = None
         elif type(self.platform) is not cls: self.platform = cls(self)
         self._update_platform_flags()
@@ -381,8 +377,8 @@ class BuildConfig:
 
     def _update_platform_flags(self):
         """Refresh the per-platform mamafile properties from `self.platform`. `msvc`, `linux` and
-        `macos` stay bools. The rest hand back the platform object, because a mamafile reads
-        `config.android.android_api` off them. Both forms are documented API - see README."""
+        `macos` stay bools. The rest return the platform object, because a mamafile reads
+        `config.android.android_api` from them. Both forms are documented API - see README."""
         p = self.platform
         def obj(cls): return p if isinstance(p, cls) else None
         self.msvc  = isinstance(p, Windows)
@@ -395,7 +391,7 @@ class BuildConfig:
         self.mips    = obj(Mips)
         self.xilinx  = obj(Xilinx)
         self.imx8mp  = obj(Imx8mp)
-        # convenience alias for detecting embedded Yocto Linux platforms (e.g. Oclea, Xilinx, IMX8MP)
+        # convenience alias that matches any embedded Yocto Linux platform (Oclea, Xilinx, IMX8MP)
         self.yocto_linux = obj(GenericYocto)
 
 
@@ -405,7 +401,7 @@ class BuildConfig:
 
     def check_platform(self):
         if not self.is_platform_set():
-            # choose MSVC if user did not specify `mama build gcc` on windows system
+            # choose MSVC on Windows, unless the user named gcc or clang on the command line
             msvc = System.windows and not (self.gcc or self.clang)
             self.set_platform(msvc=msvc, linux=System.linux, macos=System.macos)
             if not self.is_platform_set():
@@ -417,7 +413,6 @@ class BuildConfig:
         self.platform.validate_arch(self.arch) # set_arch() only checks the arch name itself
 
         if self.enable_clang_tidy:
-            # resolve clang-tidy path based on platform
             self.set_clang_tidy_path(self.clang_tidy_path)
 
 
@@ -443,10 +438,10 @@ class BuildConfig:
 
 
     def host_platform_name(self):
-        """Build-dir / CLI platform name of the HOST mama runs on ('windows'|'linux'|'macos'), independent of
-        the (possibly cross-compiled) target platform. The single source of truth for locating host build dirs
-        and forming a `mama <host> build` bootstrap; mirrors name() for the host. Host arch is left out (as the
-        `windows`/`linux` build-dir names are for x64), which matches every non-arm64-host build."""
+        """Build-dir / CLI platform name of the HOST mama runs on ('windows'|'linux'|'macos'), independent
+        of the cross-compile target platform. The single source of truth for host build dirs and for a
+        `mama <host> build` bootstrap. It mirrors name() for the host. The host arch stays out, because
+        the `windows` and `linux` build-dir names mean x64."""
         if System.windows: return 'windows'
         if System.macos:   return 'macos'
         return 'linux'
@@ -465,8 +460,8 @@ class BuildConfig:
 
 
     def announce_once(self, key: str, text: str):
-        """Print `text` only the first time `key` comes up. Option builders run per fingerprint
-        computation, not per configure, so a plain console() repeats the same line with no new news."""
+        """Print `text` only on the first call with `key`. Option builders run per fingerprint
+        computation, not per configure, so a plain console() repeats the same line."""
         if not self.print: return
         with self._announce_lock:
             if key in self._announced: return
@@ -480,14 +475,14 @@ class BuildConfig:
 
 
     def lock_compiler(self):
-        """Freeze the compiler after the ROOT mamafile's settings(). build_dir depends on it, so a dep
-        flipping it mid-load would scatter the tree across linux/ and linux-clang/. Later prefer_*() just notes."""
+        """Freeze the compiler after the ROOT mamafile's settings(). build_dir depends on it, so a dep that
+        flips it mid-load would scatter the tree across linux/ and linux-clang/. A later prefer_*() only prints a note."""
         self.compiler_cmd = True
 
 
     def _warn_compiler_conflict(self, target_name, requested, locked):
-        """The 'target prefers X but the compiler is already locked to Y' note - emitted ONCE per run
-        (every dep re-requests its preference, so this used to flood the output one line per target)."""
+        """Print the 'target requested X but compiler already set to Y' note ONCE per run. Every dep
+        re-requests its preference, so a per-call print repeats the same line for each target."""
         if self.print and not self.compiler_conflict_warned:
             self.compiler_conflict_warned = True
             console(f'Target {target_name} requested {requested} but compiler already set to {locked}.')
@@ -523,20 +518,16 @@ class BuildConfig:
         self.clang_stdlib = 'libstdc++'
 
 
-    ##
-    # Enables fortran compiler
-    # @path Optional custom path or command for the Fortran compiler
-    #
     def enable_fortran(self, path=''):
+        """Enable the Fortran compiler.
+        `path` - optional custom path or command for the Fortran compiler. Default '': search the system."""
         if self.fortran: return
         self.fortran = path if path else self.find_default_fortran_compiler()
 
 
     def find_compiler_root(self, suggested_path, compiler, suffixes, dumpfullversion) -> tuple[str, str, str]:
-        """
-        root path where the compilers exist and the discovered suffix
-            returns (root_path, suffix, version)
-        """
+        """Find the root path that holds the compiler and the discovered name suffix.
+        Returns (root_path, suffix, version)."""
         def resolve_compiler(cxx_path, suffix) -> tuple[str, str, str]:
             cxx_path = os.path.realpath(cxx_path) # resolve symlinks
             if not os.path.exists(cxx_path):
@@ -544,9 +535,8 @@ class BuildConfig:
             version = self.get_gcc_clang_fullversion(cxx_path, dumpfullversion)
             return os.path.dirname(cxx_path) + '/', suffix, version
 
-        # stop search early if we meet an already pre-configure /etc/alternatives/clang++ path on linux
-        # since this is likely what the user has configured as their default compiler
-        # if user has ~/.local/bin/clang or ~/.local/bin/gcc try to resolve that
+        # check the priority paths first: /etc/alternatives/<compiler> is the configured default of the
+        # user on linux, and ~/.local/bin/<compiler> is a manual install
         priority_choices = [ suggested_path, os.getenv('CXX'),
                             f'{os.getenv("HOME")}/.local/bin/{compiler}',
                             '/etc/alternatives/' + compiler ]
@@ -558,12 +548,12 @@ class BuildConfig:
                         console(f'Compiler {compiler} ({ver}) at {os.path.realpath(priority_cxx)} via {priority_cxx}')
                     return path, '', ver
 
-        # perform exhaustive search through all candidate directories for any suitable compilers
+        # search every candidate directory for a suitable compiler
         roots = []
         if suggested_path: roots.append(suggested_path)
         roots += ['/etc/alternatives/', '/usr/bin/', '/usr/local/bin/', '/bin/']
 
-        # Look in PATH in addition to hardcoded paths
+        # also search PATH, not only the hardcoded paths
         pathDirs = os.getenv('PATH').split(":")
         pathDirs = list(map(lambda p: p if p.endswith("/") else p + "/", pathDirs)) # Add slash at end if missing
         roots += pathDirs
@@ -575,7 +565,7 @@ class BuildConfig:
                 cxx_path = root + compiler + suffix # compiler=clang++
                 if os.path.exists(cxx_path):
                     path, _, ver = resolve_compiler(cxx_path, suffix)
-                    if ver and not path in already_added: # if version is valid and path not already added
+                    if ver and not path in already_added:
                         already_added.add(path)
                         candidates.append((path, suffix, ver))
         if not candidates:
@@ -593,7 +583,7 @@ class BuildConfig:
         # sort by version, descending eg 10.3, 9.4, 8.3
         candidates.sort(key=lambda x: version_to_int(x[2]), reverse=True)
 
-        # print this out for debugging on CI machines if they select verbose
+        # with verbose, print every candidate to debug a CI machine
         if self.verbose:
             for root, suffix, version in candidates:
                 console(f'Compiler {compiler+suffix} ({version}) at {root+compiler+suffix}')
@@ -612,7 +602,7 @@ class BuildConfig:
         if self.msvc:
             return (self.cc_path, self.cxx_path, self.cxx_version)
 
-        # a cross platform always names its own compilers: falling back to the host compiler
+        # a cross platform always names its own compilers: a fallback to the host compiler
         # search would silently build x86 binaries for an arm64 board
         cc, cxx, ver = self.platform.compiler_paths()
         if cc:
@@ -641,7 +631,7 @@ class BuildConfig:
             version = execute_piped([cc_path, '-dumpfullversion']).strip() # eg 9.4.0
             if version.count('.') >= 1:
                 return version
-        # clang++ doesn't support -dumpfullversion in latest releases -_-
+        # recent clang++ releases do not support -dumpfullversion
         return execute_piped([cc_path, '-dumpversion']).strip()
 
 
@@ -686,7 +676,7 @@ class BuildConfig:
             else:
                 warning(f'{CLANG_TIDY_ENV} environment variable is set to \'{clang_tidy_env}\' but it is not a valid file!')
 
-        # if android root has been configured, check if clang-tidy exists in the android toolchain bin dir
+        # when the android platform is set, check the NDK toolchain bin dir for clang-tidy
         if self.android:
             ndk_bin = self.android.bin()
             clang_tidy_exe = f'{ndk_bin}/clang-tidy.exe' if System.windows else f'{ndk_bin}/clang-tidy'
@@ -695,7 +685,7 @@ class BuildConfig:
                 if self.print: console(f'Found clang-tidy in Android NDK bin dir: {clang_tidy_exe}', color=Color.GREEN)
                 return
 
-        # display the full path of clang-tidy by resolving symlinks (/etc/alternatives/clang-tidy -> /usr/bin/clang-tidy-18)
+        # resolve symlinks to show the full clang-tidy path (/etc/alternatives/clang-tidy -> /usr/bin/clang-tidy-18)
         clang_tidy_exe = util.find_executable_from_system('clang-tidy', follow_symlinks=True)
         if clang_tidy_exe:
             self.clang_tidy_path = clang_tidy_exe
@@ -764,8 +754,8 @@ class BuildConfig:
 
     def init_platform_toolchain(self):
         """Resolve the cross-compile toolchain (NDK/sysroot paths) from the default search paths.
-        MUST run after the ROOT mamafile's settings(), so an explicit set_toolchain() there wins:
-        this is a no-op once settings() already picked a toolchain dir."""
+        MUST run after the ROOT mamafile's settings(), so an explicit set_toolchain() there wins.
+        This is a no-op once settings() already picked a toolchain dir."""
         self.platform.init_default()
 
 
@@ -797,7 +787,7 @@ class BuildConfig:
 
 
     def install_clang(self, clang_major):
-        if type(clang_major) != int: clang_major = int(clang_major) # convert to int
+        if type(clang_major) != int: clang_major = int(clang_major)
         if System.windows: raise OSError('Install Visual Studio 2026 with Clang support')
         if System.macos:   raise OSError('Install Xcode to get Clang on macOS')
         id, major, minor = self.get_distro_info()
@@ -806,8 +796,8 @@ class BuildConfig:
         execute('sudo apt-get update')
         execute(f'sudo apt-get install clang-{clang_major} clang-tidy-{clang_major} '+\
                 f'libc++-{clang_major}-dev libc++abi-{clang_major}-dev -y')
-        # configure current clang version as default clang via update-alternatives
-        # this way mama and cmake tools can find it without additional configuration
+        # make this clang version the default via update-alternatives,
+        # so mama and the cmake tools find it with no extra configuration
         console(f'Configuring clang-{clang_major} as default clang via update-alternatives', color=Color.MAGENTA)
         execute(f'sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-{clang_major}   100')
         execute(f'sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-{clang_major} 100')
@@ -820,7 +810,7 @@ class BuildConfig:
 
 
     def install_gcc(self, gcc_major):
-        if type(gcc_major) != int: gcc_major = int(gcc_major) # convert to int
+        if type(gcc_major) != int: gcc_major = int(gcc_major)
         if System.windows: raise OSError('Install MinGW to get GCC on Windows')
         if System.macos:   raise OSError('install-gcc not implemented for macOS')
         id, major, minor = self.get_distro_info()
@@ -828,8 +818,8 @@ class BuildConfig:
         console(f'Installing gcc-{gcc_major} and g++-{gcc_major} from apt repositories', color=Color.MAGENTA)
         execute('sudo apt-get update')
         execute(f'sudo apt-get install gcc-{gcc_major} g++-{gcc_major} -y')
-        # configure current gcc version as default gcc via update-alternatives
-        # this way mama and cmake tools can find it without additional configuration
+        # make this gcc version the default via update-alternatives,
+        # so mama and the cmake tools find it with no extra configuration
         console(f'Configuring gcc-{gcc_major} as default gcc via update-alternatives', color=Color.MAGENTA)
         execute(f'sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-{gcc_major} 100')
         execute(f'sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-{gcc_major} 100')
@@ -913,8 +903,8 @@ class BuildConfig:
 
 
     def install_raspi(self, arch: str):
-        """Install the Raspberry Pi cross toolchain from apt. The packages land in /usr/bin/<triple>-gcc,
-        which Raspi.init_default() already searches, so a build works straight afterwards with no env var."""
+        """Install the Raspberry Pi cross toolchain from apt. The packages install to /usr/bin/<triple>-gcc,
+        which Raspi.init_default() already searches, so a build works immediately with no env var."""
         if System.windows: raise OSError('install-raspi is linux only. On Windows install SysGCC/raspberry')
         if System.macos:   raise OSError('install-raspi not implemented for macOS')
         id, _, _ = self.get_distro_info()
@@ -952,26 +942,26 @@ class BuildConfig:
 
 
     def has_target(self) -> bool:
-        """ A target was specified from cmdline, eg 'all' or 'mypackage' """
+        """ True when the cmdline named a target, eg 'all' or 'mypackage' """
         return self.target is not None and len(self.target) > 0
 
     def no_target(self) -> bool:
-        """ No target specified from cmdline """
+        """ True when the cmdline named no target """
         return self.target is None or len(self.target) == 0
 
     def targets_all(self) -> bool:
-        """ Target specified from cmdline was 'all' """
+        """ True when the cmdline target is 'all' """
         return self.target == 'all'
 
 
     def target_matches(self, target_name: str) -> bool:
-        """ True if target_name matches the target specified from cmdline """
+        """ True when `target_name` matches the cmdline target """
         return self.targets_all() \
             or (self.target and self.target.lower() == target_name.lower())
 
 
     def no_specific_target(self) -> bool:
-        """ True if no target or 'all' was specified from cmdline """
+        """ True when the cmdline named no target, or named 'all' """
         return self.no_target() or self.targets_all()
 
     def is_network_available(self) -> bool:

--- a/mama/build_dependency.py
+++ b/mama/build_dependency.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
     from .build_target import BuildTarget
 
 
-# Backstop for the cross-process dep-dir lock: a single dep's shim/clone is seconds-to-minutes, and mama's
-# git_timeout kills a stalled clone (releasing the lock), so a waiter almost never approaches this. If it
-# does, it proceeds unlocked rather than hang - a genuinely stuck holder can't block a build forever.
+# Backstop for the cross-process dep-dir lock. A shim or clone of one dep takes seconds to minutes, and
+# the git_timeout kills a stalled clone and releases the lock, so a waiter almost never reaches this.
+# If it does, it proceeds without the lock, so a stuck holder cannot block a build forever.
 _LOAD_LOCK_TIMEOUT_SEC = 300
 
 
@@ -46,17 +46,17 @@ class BuildDependency:
         self.currently_loading = False
         self.load_action = 'check'  # what load() did, for the display: check|clone|pulling|local|artifactory
         self.phase_times = {}  # 'load'|'configure'|'build' -> wall seconds, for the `buildstats` breakdown
-        self._load_lock = threading.Lock()  # serialises concurrent load() of THIS dep (parallel_load)
-        self.from_artifactory = False # if true, this Dependency was loaded from Artifactory
-        self.did_check_artifactory = False # if true, artifactory was already checked and can be skipped
+        self._load_lock = threading.Lock()  # serializes concurrent load() of THIS dep (parallel_load)
+        self.from_artifactory = False # True when this dep loaded from artifactory
+        self.did_check_artifactory = False # True when the artifactory check already ran, so skip it
         self._is_shim_cache = None # tri-state cache for is_artifactory_shim()
-        self.is_root = parent is None # Root deps are always built
+        self.is_root = parent is None # a root dep always builds
         self.children: List[BuildDependency] = []
         self.product_sources = []
         self.flattened_deps: List[BuildDependency] = [] # flat dependencies only, nothing else
 
-        self.src_dir = None # source directory where the code is located
-        self.dep_dir = None # dependency dir where platform build dirs are kept
+        self.src_dir = None # source directory that holds the code
+        self.dep_dir = None # dependency dir that holds the platform build dirs
         self.build_dir_name = None # this dep's platform+variant dir name, eg 'linux-asan-lgpl'
         self.build_dir = None # {dep_dir}/{build_dir_name}
         self.dep_source = dep_source
@@ -70,12 +70,11 @@ class BuildDependency:
                 self.mamafile = parent.get_mamafile_path_relative_to_us(self.name, git.mamafile)
             self._add_args(git.args)
             self._update_dep_name_and_dirs(self.name)
-            # put the git repo in workspace
             self.src_dir = normalized_join(self.dep_dir, self.name)
         elif dep_source.is_pkg:
             if not config.artifactory_ftp:
                 raise RuntimeError(f'add_artifactory_pkg({self.name}) failed because config.artifactory_ftp is not set!')
-            self.src_dir = None # there is no src_dir when using artifactory packages
+            self.src_dir = None # an artifactory package has no src_dir
             self.create_build_target()
         elif dep_source.is_src:
             src:LocalSource = dep_source
@@ -104,7 +103,7 @@ class BuildDependency:
 
 
     def _add_args(self, args):
-        if args: # only add non-empty args (bugfix)
+        if args: # skip empty args
             for arg in args:
                 if arg:
                     self.target_args.append(arg)
@@ -120,17 +119,15 @@ class BuildDependency:
 
     def add_child(self, dep_source: DepSource) -> BuildDependency:
         """
-        Adds a new child dependency to this BuildDependency. Thread-safe: under parallel_load two
-        parents can add the same-named child concurrently; the registry lock makes the dedup +
-        creation atomic so a shared (diamond) dep resolves to one instance.
+        Add a child dependency to this BuildDependency. Under parallel_load two parents can add the
+        same child concurrently. The registry lock makes the lookup and creation atomic, so a
+        shared (diamond) dep resolves to one instance.
         """
         with self.config.dep_registry_lock:
             dep = self.config.loaded_dependencies.get(dep_source.name)
             if dep:
-                # reuse & update existing dep
                 dep.update_existing_dependency(dep_source)
             else:
-                # add new
                 dep = BuildDependency(self, self.config, self.workspace, dep_source)
                 self.config.loaded_dependencies[dep_source.name] = dep
                 if self.config.verbose:
@@ -145,16 +142,16 @@ class BuildDependency:
 
 
     def add_children(self, dep_sources):
-        """Adds papa.txt-declared children, skipping any already present. One dep can load its
-        artifactory package twice - shim probe, then the post-clean re-extract - and both report the
-        same list; add_child's duplicate raise must stay for genuine mamafile double-declares."""
+        """Add papa.txt children and skip any child already present. One dep can load its artifactory
+        package twice: the shim probe, then the re-extract after a clean. Both report the same list.
+        The duplicate raise in add_child must stay for a real mamafile double-declare."""
         existing = {c.name for c in self.children}
         for dep_source in dep_sources:
             if dep_source.name not in existing: self.add_child(dep_source)
 
 
     def get_children(self) -> List[BuildDependency]:
-        """ Gets already resolved dependencies """
+        """ Return the resolved child dependencies. """
         if self.children is None:
             raise RuntimeError(f'Target {self.name} child dependencies unresolved')
         return self.children
@@ -163,8 +160,7 @@ class BuildDependency:
     def _update_dep_name_and_dirs(self, name):
         self.name = name
         dep_name = name
-        # TODO: using branch or tag in the dep name complicates the whole package system
-        #       while only adding marginal value.
+        # TODO: a branch or tag in the dep name complicates the package system and adds little value.
         # if self.dep_source.is_git:
         #     git:Git = self.dep_source
         #     if git.branch:
@@ -172,9 +168,9 @@ class BuildDependency:
         #         dep_name = f'{self.name}-{branch_name}'
         #     elif git.tag:
         #         dep_name = f'{self.name}-{git.tag}'
-        # Computed ONCE here, then read by the build dir below and by the artifactory archive name, so a
-        # build and the package it uploads always agree on the variant. Recomputed when a second parent
-        # adds this dep with more args (see update_existing_dependency).
+        # Compute the variant suffix once here. The build dir below and the artifactory archive name read
+        # it, so a build and the package it uploads always agree on the variant. A second parent that
+        # adds this dep with more args recomputes it (see update_existing_dependency).
         self.variant_suffix = build_names.build_variant_suffix(self.config, self.target_args)
         self.dep_dir = normalized_join(self.config.workspaces_root, self.workspace, dep_name)
         self.build_dir_name = build_names.build_dir_name(self.config, self.variant_suffix)
@@ -187,9 +183,6 @@ class BuildDependency:
 
 
     def is_first_time_build(self):
-        # conditions for considering this as a first-time build
-        # - rebuild: always first time build
-        # - no_build_files: definitely a first time build
         def first_time_build():
             return not self.build_file_exists('mamafile_tag') \
                 and not self.build_file_exists('CMakeCache.txt')
@@ -205,7 +198,7 @@ class BuildDependency:
 
 
     def load_build_products(self, target):
-        """ These are the build products that were generated during last build """
+        """ Load the build products that the last build recorded. """
         loaded_deps = read_lines_from(self.exported_libs_file())
         if loaded_deps:
             package.set_export_libs_and_products(target, loaded_deps)
@@ -216,8 +209,8 @@ class BuildDependency:
 
 
     def has_usable_artifacts(self) -> bool:
-        """Is there anything on disk a dependent could link/include against? build_products carries the
-        last build's recorded exports, so a custom build() target with no CMakeCache still reads as built."""
+        """True if a dependent can link or include against something on disk. build_products carries the
+        exports of the last build, so a custom build() target with no CMakeCache still counts as built."""
         if self.from_artifactory or self.nothing_to_build or self.is_artifactory_shim(): return True
         if self.target is None: return self.has_build_files()  # load failed/never ran: judge by the build dir
         if self.find_first_missing_build_product(): return False
@@ -240,13 +233,13 @@ class BuildDependency:
 
 
     def mama_shim_file(self) -> str:
-        """ Marker file path identifying this dep as an artifactory shim. """
+        """ Marker file path that identifies this dep as an artifactory shim. """
         return normalized_join(self.build_dir, MAMA_SHIM_FILENAME)
 
 
     def is_artifactory_shim(self) -> bool:
-        """True if this dep was loaded from artifactory without a git clone.
-        Cached: state only changes via write/remove_shim_marker and dirty()."""
+        """True if this dep loaded from artifactory without a git clone.
+        Cached: only write_shim_marker, remove_shim_marker and dirty() change the state."""
         if self._is_shim_cache is None:
             self._is_shim_cache = (self.dep_source.is_git and os.path.exists(self.mama_shim_file())
                                    and not self.is_real_clone())
@@ -259,10 +252,7 @@ class BuildDependency:
 
 
     def write_shim_marker(self, archive_name: str, commit_hash: str):
-        """
-        Persist shim metadata so subsequent runs (and Phase 7 transitions)
-        can identify the shim and know which archive backed it.
-        """
+        """ Write the shim metadata, so a later run can identify the shim and its backing archive. """
         git: Git = self.dep_source
         lines = [
             'shim 1',
@@ -274,13 +264,13 @@ class BuildDependency:
             f'archive {archive_name}',
         ]
         write_text_to(self.mama_shim_file(), '\n'.join(lines) + '\n')
-        # Invalidate (not set True): a real .git may also be present.
+        # Invalidate, do not set True: a real .git can also be present.
         self._is_shim_cache = None
 
 
     def read_shim_marker(self) -> dict:
         """
-        Returns a dict of shim metadata, or empty dict if no marker.
+        Return a dict of shim metadata, or an empty dict when there is no marker.
         Keys: name, url, branch, tag, hash, archive.
         """
         result = {}
@@ -304,9 +294,9 @@ class BuildDependency:
 
 
     def try_load_cached_shim(self, check_staleness: bool = True):
-        """Honour an existing shim's local cache. With `check_staleness`, ls-remote
-        first and drop the marker on upstream advance. Returns the configured
-        BuildTarget, or None on cache miss/staleness."""
+        """Use the local cache of an existing shim. With `check_staleness`, run ls-remote
+        first and drop the marker when upstream advanced. Return the configured
+        BuildTarget, or None on a cache miss or a stale shim."""
         from .artifactory import artifactory_load_target  # local import: avoid cycle
         from .build_target import BuildTarget
         from .types.git import Git
@@ -317,9 +307,9 @@ class BuildDependency:
         stored_hash = marker.get('hash', '')
         if not stored_hash: return None
 
-        # A locally-pinned self.version renames the archive (it replaces the commit hash), so
-        # a shim cached under a non-matching name predates the pin: a stale package the pin
-        # was bumped precisely to invalidate. Re-probe instead of trusting it.
+        # A pinned self.version replaces the commit hash in the archive name. A shim cached under
+        # another name predates the pin, so it is exactly the stale package the pin invalidates.
+        # Re-probe instead of trusting it.
         pinned = pinned_version(self)
         stored_archive = marker.get('archive', '')
         if pinned and stored_archive and not stored_archive.endswith(f'-{pinned}'):
@@ -353,11 +343,11 @@ class BuildDependency:
             os.makedirs(self.build_dir, exist_ok=True)
 
 
-    ## @return True if dependency has changed
+    ## @return True if the dependency has changed
     def load(self):
-        # Per-dep lock: under parallel_load a shared (diamond) dep can get two concurrent load()
-        # calls; serialise loads of THIS dep so exactly one thread clones it (the old
-        # `currently_loading` busy-wait had a TOCTOU race). Different deps still clone concurrently.
+        # Under parallel_load a shared (diamond) dep can get two concurrent load() calls. The lock
+        # serializes loads of THIS dep, so exactly one thread clones it. Different deps still
+        # clone concurrently.
         with self._load_lock:
             if self.already_loaded:
                 return self.should_rebuild
@@ -371,7 +361,7 @@ class BuildDependency:
         return self.target
 
     def _git_checkout_if_needed(self) -> bool:
-        # Shims have no working tree; upstream check happens via ls-remote in try_load_artifactory_shim.
+        # A shim has no working tree. The ls-remote in try_load_artifactory_shim checks upstream.
         if self.is_artifactory_shim():
             return False
         if not self.is_root and self.dep_source.is_git:
@@ -381,16 +371,16 @@ class BuildDependency:
 
 
     def _force_source_clone(self) -> bool:
-        """A `rebuild` (build from source) or `mama unshallow` of THIS target must materialize a real
-        clone, even from a cached shim: drop the shim so the git path clones source instead of reusing
-        the prebuilt package. A plain `clean` does NOT force a clone - it reloads the package post-clean."""
+        """A `rebuild` or a `mama unshallow` of THIS target must produce a real clone, even from a
+        cached shim. Drop the shim so the git path clones source instead of the prebuilt package.
+        A plain `clean` does NOT force a clone. It reloads the package after the clean."""
         return (self.config.rebuild or self.config.unshallow) and self.is_current_target()
 
 
     def _drop_stale_shim_marker(self):
         """Remove a marker left in the build dir of a dep that now has a real clone. A rebuild, an
         unshallow, or a build for another platform can clone the source without dropping this marker.
-        The two shim tests then disagree: is_artifactory_shim() reads False, so deploy is not skipped,
+        The two shim checks then disagree: is_artifactory_shim() returns False, so deploy runs,
         but papa_deploy refuses any directory with a marker."""
         if self.is_real_clone() and has_shim_marker(self.build_dir):
             if self.config.verbose: console(f'  - Target {self.name: <16} STALE shim marker dropped (real clone on disk)')
@@ -398,9 +388,9 @@ class BuildDependency:
 
 
     def _try_artifactory_shim(self) -> bool:
-        """Pre-clone artifactory load for non-root git deps. Either honours a
-        cached shim or probes artifactory via ls-remote. Returns True when the
-        dep was satisfied without a clone."""
+        """Pre-clone artifactory load for a non-root git dep. It uses a cached
+        shim or probes artifactory via ls-remote. Return True when the dep
+        loads without a clone."""
         self._drop_stale_shim_marker()
         # rebuild/unshallow target: drop the shim marker so the git path clones source.
         if self._force_source_clone():
@@ -408,14 +398,14 @@ class BuildDependency:
                 if self.config.print:
                     console(f'  - Target {self.name: <16} REBUILD shim -> source clone', color=Color.BLUE)
                 self.remove_shim_marker()
-            # Build-from-source means "use this target's source": suppress the post-clone probe so it
-            # doesn't re-load the prebuilt pkg over the clone (true for an already-cloned target too).
+            # Build-from-source means "use the source of this target". Suppress the post-clone probe so it
+            # does not reload the prebuilt package over the clone (also true for an already-cloned target).
             self.did_check_artifactory = True
             return False
         # Existing shim: trust the local cache under plain `mama build`. Under
-        # noart, still ls-remote to catch upstream-advanced shims (a mismatch
-        # drops the marker so the caller's git path takes over). Under `update`
-        # the cached path is skipped entirely so the regular probe re-extracts.
+        # noart, still run ls-remote to catch an upstream-advanced shim. A
+        # mismatch drops the marker, so the git path of the caller clones instead.
+        # Under `update` skip the cached path, so the regular probe re-extracts.
         if self.is_artifactory_shim() and not self.config.update:
             cached = self.try_load_cached_shim(check_staleness=self.config.disable_artifactory)
             if cached is not None:
@@ -435,8 +425,8 @@ class BuildDependency:
 
 
     def _try_artifactory_load(self, target) -> bool:
-        """Post-clone artifactory probe. Catches the target.version case where
-        the archive name isn't predictable until the mamafile has been parsed."""
+        """Post-clone artifactory probe. It covers the target.version case:
+        the archive name is unknown until the mamafile parse."""
         if not self.should_load_artifactory(): return False
         if self.can_fetch_artifactory(print=True, which='LOAD'):
             self.did_check_artifactory = True
@@ -452,9 +442,9 @@ class BuildDependency:
 
 
     def _reload_artifactory_after_clean(self, target) -> bool:
-        """Re-fetch the artifactory package a plain `clean` just wiped from the build dir. The cached
-        zip lives in dep_dir (clean only rmtree's build_dir), so this re-extracts offline. Returns True
-        on success; on failure the caller falls through to the regular post-clone probe."""
+        """Re-fetch the artifactory package that a plain `clean` removed from the build dir. The cached
+        zip lives in dep_dir (clean only removes build_dir), so this re-extracts offline. Return True
+        on success. On failure the caller continues to the regular post-clone probe."""
         self.create_build_dir_if_needed()
         fetched, dependencies = artifactory_fetch_and_reconfigure(target)
         if fetched and dependencies: self.add_children(dependencies)
@@ -471,37 +461,37 @@ class BuildDependency:
         git_changed = False
 
         if self.is_root:
-            # For root targets, always load the BuildTarget immediately - we need the workspace from its mamafile.
+            # A root target loads its BuildTarget at once: the workspace comes from its mamafile.
             target = self._load_target()
         else:
-            # For non-root targets, only create the required dirs; mamafile is loaded after the shim/clone step.
+            # A non-root target only creates the required dirs. The mamafile loads after the shim or clone step.
             self._update_dep_name_and_dirs(self.name)
             self.create_build_dir_if_needed()
             if self.dep_source.is_git:
-                # One cross-process lock over BOTH the shim setup and the checkout: a sibling `mama <host>
-                # build` (build_host_binary's bootstrap) can be materialising this SAME dep_dir, and a
-                # half-written clone must never be read as a broken tree by the other process. Keyed on
-                # dep_dir; different deps never contend, so parallel loads stay fully concurrent. Once the
-                # checkout returns the tree is a real clone, so the mamefile parse below is safe unlocked.
+                # One cross-process lock over BOTH the shim setup and the checkout. A sibling `mama <host>
+                # build` (the build_host_binary bootstrap) can create this SAME dep_dir, and the other
+                # process must never read a half-written clone as a broken tree. The lock is keyed on
+                # dep_dir. Different deps never contend, so parallel loads stay concurrent. After the
+                # checkout returns the tree is a real clone, so the mamafile parse below needs no lock.
                 with interprocess_dir_lock(self.dep_dir, timeout=_LOAD_LOCK_TIMEOUT_SEC):
                     loaded_from_pkg = self._try_artifactory_shim()
-                    # A clean deletes build dirs; it never needs source. Without this a dep whose shim marker a
-                    # PREVIOUS clean removed gets cloned from scratch - minutes of git for a dir we then delete.
+                    # A clean deletes build dirs and never needs source. Without this guard, a dep whose shim
+                    # marker a PREVIOUS clean removed clones from scratch - minutes of git for a dir we then delete.
                     if not loaded_from_pkg and not conf.clean_only():
-                        git_changed = self._git_checkout_if_needed() ## pull Git before loading target Mamafile
+                        git_changed = self._git_checkout_if_needed() ## pull git before the target mamafile load
             elif not conf.clean_only():
                 git_changed = self._git_checkout_if_needed()  # non-git local source: no shared tree to lock
             target = self._load_target() ## load target for Git and Src
 
         if conf.clean and is_target:
             self.clean() ## requires a parsed mamafile target
-            # A plain `clean` rmtree'd the build dir, including a shim-loaded artifactory package's libs;
-            # re-extract it so dependents can still link. (`rebuild` dropped the shim above -> from source.)
+            # A plain `clean` removed the build dir, including the libs of a shim-loaded artifactory
+            # package. Re-extract it so dependents can still link. (`rebuild` dropped the shim above.)
             if loaded_from_pkg:
                 loaded_from_pkg = self._reload_artifactory_after_clean(target)
 
         if not self.is_root and not loaded_from_pkg:
-            # Post-clone probe catches target.version-pinned deps that the pre-clone shim couldn't predict.
+            # The post-clone probe covers target.version-pinned deps that the pre-clone shim could not predict.
             loaded_from_pkg = self._try_artifactory_load(target)
             if not loaded_from_pkg:
                 self.load_build_products(target)
@@ -510,9 +500,9 @@ class BuildDependency:
             console(f'  - Target {self.name: <16} load settings and dependencies')
         target.settings() ## customization point for project settings
         if self.is_root:
-            conf.lock_compiler()  # root settings() is the last prefer_clang/gcc; lock before any dep loads
+            conf.lock_compiler()  # root settings() is the last prefer_clang/gcc call, lock before any dep loads
             conf.init_platform_toolchain()  # after settings(), so its set_*_toolchain() beats the default probe
-            self._update_dep_name_and_dirs(self.name)  # build_dir was computed pre-flip, re-resolve it
+            self._update_dep_name_and_dirs(self.name)  # the build_dir predates the compiler lock, so re-resolve it
         target.dependencies() ## customization point for additional dependencies
 
         if not loaded_from_pkg and self.is_root:
@@ -535,7 +525,7 @@ class BuildDependency:
 
     def _display_load_action(self, loaded_from_pkg: bool) -> str:
         """The load label for the display breakdown letter: artifactory (A) / local (L), else the
-        git action (check/clone/pulling -> G) already recorded during checkout."""
+        git action (check/clone/pulling -> G) that the checkout recorded."""
         if loaded_from_pkg:        return 'artifactory'
         if self.dep_source.is_src: return 'local'
         return self.load_action
@@ -550,8 +540,8 @@ class BuildDependency:
         is_target = self.is_current_target()
 
         def noart(r, expected=False):
-            # `expected`: OUR decision to skip (a clean/rebuild ignores artifactory by design), so it's
-            # verbose-only - a second line per dep next to its CLEAN/BUILD line is pure noise.
+            # `expected`: our own decision to skip, because a clean or rebuild ignores artifactory by
+            # design. Show it only under verbose. A second line next to the CLEAN/BUILD line is noise.
             show = self.config.verbose if expected else (self.config.print or force_art)
             if print and show:
                 warning(f'  - Target {self.name: <16} NO ARTIFACTORY PKG [{which} {r}]')
@@ -561,9 +551,9 @@ class BuildDependency:
         if disable_art:
             return noart('noart override')
         elif is_target and not force_art:
-            # don't load during rebuild -- defer to source based builds in that case
+            # do not load during a rebuild, defer to the source build
             if self.config.rebuild: return noart('target rebuild', expected=True)
-            # don't load anything during cleaning -- because it will get cleaned anyways
+            # do not load during a clean, the clean deletes it anyway
             if self.config.clean: return noart('target clean', expected=True)
         elif print and (self.config.verbose or force_art):
             warning(f'  - Target {self.name: <16} CHECK ARTIFACTORY PKG [{which}]')
@@ -597,16 +587,16 @@ class BuildDependency:
                 warning(f'  - Target {target.name: <16} BUILD [{r}]{args}')
             return True
 
-        # Artifactory shim: no source on disk, nothing to build from. The shim was
-        # already (re-)loaded during _load(); a rebuild requires `mama unshallow`
+        # An artifactory shim has no source on disk, so there is nothing to build.
+        # _load() already loaded the shim. A rebuild requires `mama unshallow`
         # to convert it to a real clone first.
         if self.is_artifactory_shim():
             return False
 
-        if conf.target and not is_target: # if we called: "target=SpecificProject"
-            return False # skip; mark_unbuilt_target_deps() revives the ones X actually needs, post-load
+        if conf.target and not is_target: # the run named another target
+            return False # skip: mark_unbuilt_target_deps() re-marks the deps the target needs after the load
 
-        ## build also entails packaging
+        ## a build also packages
         if conf.clean and is_target: return build('cleaned target')
         if conf.run_cmake_configure and is_target: return build('cmake reconfigure')
         if self.is_root:             return build('root target')
@@ -619,41 +609,36 @@ class BuildDependency:
             if self.dep_source.source_tree_changed(self): return build('source modified')
 
         # in-place edits of a local dep tracked by an enclosing git repo: same fast fingerprint
-        # path, so a large root build doesn't silently skip a modified subfolder.
+        # path, so a large root build does not silently skip a modified subfolder.
         if self.dep_source.is_src and self.dep_source.source_tree_changed(self):
             return build('source modified')
 
-        # if we call `update this_target`
         if conf.update and conf.target == target.name:
             return build('update target='+conf.target)
 
-        # if we call sub-dependency `build this_target`
         if not self.is_root and conf.build and conf.target == target.name:
             return build('build target='+conf.target)
 
-        # if the project has been built at least once or downloaded from artifactory package
-        # then there will be a list of build products
-        # if any of those are missing, then this needs to be rebuilt to re-acquire them
+        # A previous build or an artifactory download recorded the build products.
+        # A missing one forces a rebuild to re-acquire it.
         missing_product = self.find_first_missing_build_product()
         if missing_product:
             return build(f'{missing_product} does not exist')
 
-        # project has not defined `nothing_to_build` which is for header-only projects
-        # thus we need to check if build should execute
+        # `nothing_to_build` marks a header-only project, so check if the build should run
         can_build = not loaded_from_pkg and not self.nothing_to_build
         if can_build:
-            # there are no build products defined at all, it hasn't been built or downloaded
+            # no build products defined: the project never built and never downloaded
             if not target.build_products:
                 if not self.has_build_files():
                     return build('not built yet')
                 return build('no build dependencies')
 
-            # we have build products, and none of them are missing
+            # build products exist and none are missing, so nothing to do
             if target.build_products and not missing_product:
-                pass # added this condition for clarity -- all should be OK
+                pass
 
-        # something changed in the mamafile, or artifactory package
-        # and the list of dependency targets changed, thus we need to rebuild
+        # a removed dependency changes the link list, so rebuild
         missing_dep = self.find_missing_dependency()
         if missing_dep: return build(f'{missing_dep} was removed')
 
@@ -670,7 +655,7 @@ class BuildDependency:
         # A shim has no source, so a changed child cannot change what it produces. _should_build()
         # already refuses to mark one. Without the same guard here the flag reaches _run_packaging,
         # which then drops the exports the fetched papa.txt carries and re-derives them from the
-        # unzipped tree. That manifest came from a real source build, so re-deriving only loses.
+        # unzipped tree. That papa.txt came from a real source build, so a re-derive only loses data.
         if self.config.no_specific_target() and not self.is_artifactory_shim():
             first_changed = next((c for c in self.children if c.should_rebuild), None)
             if first_changed and not self.should_rebuild:
@@ -696,7 +681,6 @@ class BuildDependency:
             self.target._set_args(self.target_args)
             return
 
-        # load the default mama.BuildTarget class
         from .build_target import BuildTarget as mamaBuildTarget  # deferred: circular at import time
         mamaFilePath = self.mamafile_path()
         if mamaFilePath and self.config.verbose:
@@ -704,7 +688,7 @@ class BuildDependency:
             relpath = os.path.relpath(mamaFilePath)
             console(f'  - Target {self.name: <16} Load Mamafile: {relpath} (Exists={exists})', color=Color.BLUE)
 
-        # this will load the specific `<class project(mama.build_target)>` class
+        # parse the project-specific BuildTarget subclass from the mamafile
         project, buildTarget = parse_mamafile(self.config, mamaBuildTarget, mamaFilePath)
         if project and buildTarget:
             buildStatics = buildTarget.__dict__
@@ -763,9 +747,8 @@ class BuildDependency:
 
 
     def update_mamafile_tag(self):
-        # Shims have no source; the mamafile we'd be tagging doesn't exist on disk.
-        # Explicit short-circuit so a future parent-mamafile fetch (Phase 2 target.version
-        # probe) doesn't accidentally flag the shim as "modified" every run.
+        # A shim has no source, so the mamafile to tag does not exist on disk. The explicit
+        # short-circuit keeps a parent-mamafile fetch from flagging the shim as modified every run.
         if self.is_artifactory_shim():
             return False
         return self.src_dir and update_mamafile_tag(self.config, self.mamafile_path(), self.build_dir)
@@ -778,7 +761,7 @@ class BuildDependency:
 
 
     def build_file_exists(self, filename):
-        """ TRUE if a file relative to build_dir exists """
+        """ True if the file exists relative to build_dir. """
         return os.path.exists(normalized_join(self.build_dir, filename))
 
 
@@ -797,7 +780,7 @@ class BuildDependency:
         sanitizers_file = self.sanitizer_list_path()
         if self.target.config.sanitize:
             write_text_to(sanitizers_file, self.target.config.sanitize)
-        elif os.path.exists(sanitizers_file): # otherwise delete the file, which means sanitizer was not used
+        elif os.path.exists(sanitizers_file): # delete the file to record that no sanitizer was in use
             os.remove(sanitizers_file)
 
 
@@ -819,21 +802,22 @@ class BuildDependency:
 
     def path_relative_to_us(self, relpath) -> str:
         """
-        Converts relative path into an absolute path based on self mamafile location
+        Convert a relative path to an absolute path. The base is this mamafile dir, else the source dir.
         """
         if not relpath or os.path.isabs(relpath):
-            return relpath # the path is already None, or Absolute
-        elif self.mamafile: # if we have mamafile, set path relative to it
+            return relpath # the path is already None or absolute
+        elif self.mamafile:
             return normalized_join(os.path.dirname(self.mamafile), relpath)
-        else: # otherwise relative to source dir
-            if not self.src_dir: # however, artifactory pkgs have no source dir!
+        else:
+            if not self.src_dir: # an artifactory pkg has no source dir
                 return relpath
             return normalized_join(self.src_dir, relpath)
 
 
     def get_mamafile_path_relative_to_us(self, name, relative_mamafile) -> str:
         """
-        Converts a relative mamafile path into an absolute path relative to self mamafile location
+        Resolve a relative mamafile path against this dep. Without one, look for
+        mama/<name>.py. Return None when neither exists.
         """
         if relative_mamafile:
             local_mamafile = self.path_relative_to_us(relative_mamafile)
@@ -872,7 +856,6 @@ class BuildDependency:
         return None # Nothing missing
 
 
-    ## Clean
     def clean(self):
         if self.config.print:
             console(f'  - Target {self.name: <16} CLEAN  {self.build_dir_name}')
@@ -885,28 +868,28 @@ class BuildDependency:
 
 
     def dirty(self):
-        """ Marks this dependency as dirty in the mamafile_tag """
+        """ Force the next build: remove a build product, the mamafile_tag, papa.txt and the shim marker. """
         if self.config.print: console(f'  - Target {self.name: <16} Dirty')
 
         if self.target.build_products:
-            # make sure we don't have a valid build product to link to
+            # make sure no valid build product remains to link against
             depfile = self.target.build_products[0]
             if os.path.exists(depfile):
                 os.remove(depfile)
                 if self.config.verbose: console(f'    dirty: removed {depfile}')
 
         if self.build_dir_exists():
-            # mamafile tag is used to check if mamafile.py has changed
+            # the mamafile_tag detects a mamafile.py change
             mamafile_tag = normalized_join(self.build_dir, 'mamafile_tag')
             if os.path.exists(mamafile_tag):
                 os.remove(mamafile_tag)
                 if self.config.verbose: console('    dirty: removed mamafile_tag')
 
-            # this is needed for artifactory packages
+            # artifactory packages need this
             papafile = self.papa_package_file()
             if os.path.exists(papafile):
                 os.remove(papafile)
                 if self.config.verbose: console('    dirty: removed papa.txt')
 
-            # remove shim marker so next build re-evaluates artifactory freshness
+            # remove the shim marker so the next build re-checks artifactory freshness
             self.remove_shim_marker()

--- a/mama/build_dependency.py
+++ b/mama/build_dependency.py
@@ -21,9 +21,8 @@ if TYPE_CHECKING:
     from .build_target import BuildTarget
 
 
-# Backstop for the cross-process dep-dir lock. A shim or clone of one dep takes seconds to minutes, and
-# the git_timeout kills a stalled clone and releases the lock, so a waiter almost never reaches this.
-# If it does, it proceeds without the lock, so a stuck holder cannot block a build forever.
+# Backstop for the cross-process dep-dir lock: the git_timeout kills a stalled clone and releases the
+# lock first. On expiry the waiter proceeds without the lock, so a stuck holder cannot block a build forever.
 _LOAD_LOCK_TIMEOUT_SEC = 300
 
 
@@ -119,9 +118,9 @@ class BuildDependency:
 
     def add_child(self, dep_source: DepSource) -> BuildDependency:
         """
-        Add a child dependency to this BuildDependency. Under parallel_load two parents can add the
-        same child concurrently. The registry lock makes the lookup and creation atomic, so a
-        shared (diamond) dep resolves to one instance.
+        Add a child dependency. Under parallel_load two parents can add the same child concurrently, and
+        the registry lock makes lookup and creation atomic, so a shared (diamond) dep resolves to one instance.
+        dep_source: the DepSource that names the child
         """
         with self.config.dep_registry_lock:
             dep = self.config.loaded_dependencies.get(dep_source.name)
@@ -142,9 +141,8 @@ class BuildDependency:
 
 
     def add_children(self, dep_sources):
-        """Add papa.txt children and skip any child already present. One dep can load its artifactory
-        package twice: the shim probe, then the re-extract after a clean. Both report the same list.
-        The duplicate raise in add_child must stay for a real mamafile double-declare."""
+        """Add papa.txt children, skipping any child already present: a shim probe and a post-clean re-extract
+        report the same list. The duplicate raise in add_child must stay for a real mamafile double-declare."""
         existing = {c.name for c in self.children}
         for dep_source in dep_sources:
             if dep_source.name not in existing: self.add_child(dep_source)
@@ -160,17 +158,9 @@ class BuildDependency:
     def _update_dep_name_and_dirs(self, name):
         self.name = name
         dep_name = name
-        # TODO: a branch or tag in the dep name complicates the package system and adds little value.
-        # if self.dep_source.is_git:
-        #     git:Git = self.dep_source
-        #     if git.branch:
-        #         branch_name = git.branch.replace('/', '-') # BUGFIX: branches with slashes
-        #         dep_name = f'{self.name}-{branch_name}'
-        #     elif git.tag:
-        #         dep_name = f'{self.name}-{git.tag}'
-        # Compute the variant suffix once here. The build dir below and the artifactory archive name read
-        # it, so a build and the package it uploads always agree on the variant. A second parent that
-        # adds this dep with more args recomputes it (see update_existing_dependency).
+        # A branch or tag in the dep name complicates the package system and adds little value, so dep_name stays plain.
+        # The build dir and the artifactory archive name both read this variant suffix, so a build and its
+        # uploaded package always agree. A second parent that adds more args recomputes it (update_existing_dependency).
         self.variant_suffix = build_names.build_variant_suffix(self.config, self.target_args)
         self.dep_dir = normalized_join(self.config.workspaces_root, self.workspace, dep_name)
         self.build_dir_name = build_names.build_dir_name(self.config, self.variant_suffix)
@@ -269,10 +259,8 @@ class BuildDependency:
 
 
     def read_shim_marker(self) -> dict:
-        """
-        Return a dict of shim metadata, or an empty dict when there is no marker.
-        Keys: name, url, branch, tag, hash, archive.
-        """
+        """Return a dict of shim metadata, or an empty dict when there is no marker.
+        Keys: name, url, branch, tag, hash, archive."""
         result = {}
         path = self.mama_shim_file()
         if not os.path.exists(path):
@@ -294,9 +282,8 @@ class BuildDependency:
 
 
     def try_load_cached_shim(self, check_staleness: bool = True):
-        """Use the local cache of an existing shim. With `check_staleness`, run ls-remote
-        first and drop the marker when upstream advanced. Return the configured
-        BuildTarget, or None on a cache miss or a stale shim."""
+        """Use the local cache of an existing shim. Return the configured BuildTarget, or None on a miss or a stale shim.
+        check_staleness: if True, run ls-remote first and drop the marker when upstream advanced"""
         from .artifactory import artifactory_load_target  # local import: avoid cycle
         from .build_target import BuildTarget
         from .types.git import Git
@@ -307,9 +294,8 @@ class BuildDependency:
         stored_hash = marker.get('hash', '')
         if not stored_hash: return None
 
-        # A pinned self.version replaces the commit hash in the archive name. A shim cached under
-        # another name predates the pin, so it is exactly the stale package the pin invalidates.
-        # Re-probe instead of trusting it.
+        # A pinned self.version replaces the commit hash in the archive name, so a shim cached under
+        # another name predates the pin and is exactly the stale package it invalidates. Re-probe instead.
         pinned = pinned_version(self)
         stored_archive = marker.get('archive', '')
         if pinned and stored_archive and not stored_archive.endswith(f'-{pinned}'):
@@ -346,8 +332,7 @@ class BuildDependency:
     ## @return True if the dependency has changed
     def load(self):
         # Under parallel_load a shared (diamond) dep can get two concurrent load() calls. The lock
-        # serializes loads of THIS dep, so exactly one thread clones it. Different deps still
-        # clone concurrently.
+        # serializes loads of THIS dep only, so exactly one thread clones it and other deps stay concurrent.
         with self._load_lock:
             if self.already_loaded:
                 return self.should_rebuild
@@ -371,16 +356,14 @@ class BuildDependency:
 
 
     def _force_source_clone(self) -> bool:
-        """A `rebuild` or a `mama unshallow` of THIS target must produce a real clone, even from a
-        cached shim. Drop the shim so the git path clones source instead of the prebuilt package.
+        """A `rebuild` or `unshallow` of THIS target must produce a real clone, even from a cached shim.
         A plain `clean` does NOT force a clone. It reloads the package after the clean."""
         return (self.config.rebuild or self.config.unshallow) and self.is_current_target()
 
 
     def _drop_stale_shim_marker(self):
-        """Remove a marker left in the build dir of a dep that now has a real clone. A rebuild, an
-        unshallow, or a build for another platform can clone the source without dropping this marker.
-        The two shim checks then disagree: is_artifactory_shim() returns False, so deploy runs,
+        """Remove a marker left where a real clone now exists: a rebuild, unshallow, or another platform's
+        build can clone without dropping it. is_artifactory_shim() then returns False, so deploy runs,
         but papa_deploy refuses any directory with a marker."""
         if self.is_real_clone() and has_shim_marker(self.build_dir):
             if self.config.verbose: console(f'  - Target {self.name: <16} STALE shim marker dropped (real clone on disk)')
@@ -388,9 +371,8 @@ class BuildDependency:
 
 
     def _try_artifactory_shim(self) -> bool:
-        """Pre-clone artifactory load for a non-root git dep. It uses a cached
-        shim or probes artifactory via ls-remote. Return True when the dep
-        loads without a clone."""
+        """Pre-clone artifactory load for a non-root git dep: a cached shim or an ls-remote probe.
+        Return True when the dep loads without a clone."""
         self._drop_stale_shim_marker()
         # rebuild/unshallow target: drop the shim marker so the git path clones source.
         if self._force_source_clone():
@@ -398,22 +380,18 @@ class BuildDependency:
                 if self.config.print:
                     console(f'  - Target {self.name: <16} REBUILD shim -> source clone', color=Color.BLUE)
                 self.remove_shim_marker()
-            # Build-from-source means "use the source of this target". Suppress the post-clone probe so it
-            # does not reload the prebuilt package over the clone (also true for an already-cloned target).
+            # suppress the post-clone probe so it cannot reload the package over the clone (also for an already-cloned target)
             self.did_check_artifactory = True
             return False
-        # Existing shim: trust the local cache under plain `mama build`. Under
-        # noart, still run ls-remote to catch an upstream-advanced shim. A
-        # mismatch drops the marker, so the git path of the caller clones instead.
-        # Under `update` skip the cached path, so the regular probe re-extracts.
+        # Plain `mama build` trusts the cached shim. Under noart the ls-remote check still drops an
+        # upstream-advanced shim, so the caller clones instead. Under `update` the regular probe re-extracts.
         if self.is_artifactory_shim() and not self.config.update:
             cached = self.try_load_cached_shim(check_staleness=self.config.disable_artifactory)
             if cached is not None:
                 self.target = cached
                 self.did_check_artifactory = True
                 return True
-        # Regular shim probe: skip when a real clone already exists - for an
-        # already-cloned dep the regular update path (fetch+reset) is correct.
+        # regular shim probe: for an already-cloned dep the update path (fetch+reset) is correct, so skip it
         if not self.is_real_clone() and self.can_fetch_artifactory(print=False, which='SHIM'):
             shim_target, shim_deps = try_load_artifactory_shim(self)
             if shim_target is not None:
@@ -442,9 +420,8 @@ class BuildDependency:
 
 
     def _reload_artifactory_after_clean(self, target) -> bool:
-        """Re-fetch the artifactory package that a plain `clean` removed from the build dir. The cached
-        zip lives in dep_dir (clean only removes build_dir), so this re-extracts offline. Return True
-        on success. On failure the caller continues to the regular post-clone probe."""
+        """Re-extract the artifactory package that a plain `clean` removed. The cached zip lives in dep_dir,
+        so this works offline. On failure the caller continues to the regular post-clone probe."""
         self.create_build_dir_if_needed()
         fetched, dependencies = artifactory_fetch_and_reconfigure(target)
         if fetched and dependencies: self.add_children(dependencies)
@@ -468,15 +445,12 @@ class BuildDependency:
             self._update_dep_name_and_dirs(self.name)
             self.create_build_dir_if_needed()
             if self.dep_source.is_git:
-                # One cross-process lock over BOTH the shim setup and the checkout. A sibling `mama <host>
-                # build` (the build_host_binary bootstrap) can create this SAME dep_dir, and the other
-                # process must never read a half-written clone as a broken tree. The lock is keyed on
-                # dep_dir. Different deps never contend, so parallel loads stay concurrent. After the
-                # checkout returns the tree is a real clone, so the mamafile parse below needs no lock.
+                # One dep_dir-keyed cross-process lock over BOTH the shim setup and the checkout: a sibling
+                # `mama <host> build` process must never read a half-written clone as a broken tree.
+                # Different deps never contend, and the mamafile parse below needs no lock.
                 with interprocess_dir_lock(self.dep_dir, timeout=_LOAD_LOCK_TIMEOUT_SEC):
                     loaded_from_pkg = self._try_artifactory_shim()
-                    # A clean deletes build dirs and never needs source. Without this guard, a dep whose shim
-                    # marker a PREVIOUS clean removed clones from scratch - minutes of git for a dir we then delete.
+                    # a clean never needs source: without this guard a shim-less dep clones minutes of git, then deletes it
                     if not loaded_from_pkg and not conf.clean_only():
                         git_changed = self._git_checkout_if_needed() ## pull git before the target mamafile load
             elif not conf.clean_only():
@@ -485,8 +459,7 @@ class BuildDependency:
 
         if conf.clean and is_target:
             self.clean() ## requires a parsed mamafile target
-            # A plain `clean` removed the build dir, including the libs of a shim-loaded artifactory
-            # package. Re-extract it so dependents can still link. (`rebuild` dropped the shim above.)
+            # a plain clean removed the shim-loaded package libs: re-extract so dependents can link (rebuild dropped the shim)
             if loaded_from_pkg:
                 loaded_from_pkg = self._reload_artifactory_after_clean(target)
 
@@ -540,8 +513,7 @@ class BuildDependency:
         is_target = self.is_current_target()
 
         def noart(r, expected=False):
-            # `expected`: our own decision to skip, because a clean or rebuild ignores artifactory by
-            # design. Show it only under verbose. A second line next to the CLEAN/BUILD line is noise.
+            # `expected`: a clean or rebuild skips artifactory by design, so show the line only under verbose
             show = self.config.verbose if expected else (self.config.print or force_art)
             if print and show:
                 warning(f'  - Target {self.name: <16} NO ARTIFACTORY PKG [{which} {r}]')
@@ -587,9 +559,8 @@ class BuildDependency:
                 warning(f'  - Target {target.name: <16} BUILD [{r}]{args}')
             return True
 
-        # An artifactory shim has no source on disk, so there is nothing to build.
-        # _load() already loaded the shim. A rebuild requires `mama unshallow`
-        # to convert it to a real clone first.
+        # An artifactory shim has no source on disk, so there is nothing to build. A rebuild requires
+        # `mama unshallow` to convert it to a real clone first.
         if self.is_artifactory_shim():
             return False
 
@@ -608,8 +579,7 @@ class BuildDependency:
         if self.dep_source.is_git and self.is_real_clone():
             if self.dep_source.source_tree_changed(self): return build('source modified')
 
-        # in-place edits of a local dep tracked by an enclosing git repo: same fast fingerprint
-        # path, so a large root build does not silently skip a modified subfolder.
+        # in-place edits of a local dep: the same fast fingerprint path, so a root build does not skip a modified subfolder
         if self.dep_source.is_src and self.dep_source.source_tree_changed(self):
             return build('source modified')
 
@@ -619,8 +589,7 @@ class BuildDependency:
         if not self.is_root and conf.build and conf.target == target.name:
             return build('build target='+conf.target)
 
-        # A previous build or an artifactory download recorded the build products.
-        # A missing one forces a rebuild to re-acquire it.
+        # a build product that a previous build or download recorded but is now missing forces a rebuild
         missing_product = self.find_first_missing_build_product()
         if missing_product:
             return build(f'{missing_product} does not exist')
@@ -652,10 +621,8 @@ class BuildDependency:
 
 
     def after_load(self):
-        # A shim has no source, so a changed child cannot change what it produces. _should_build()
-        # already refuses to mark one. Without the same guard here the flag reaches _run_packaging,
-        # which then drops the exports the fetched papa.txt carries and re-derives them from the
-        # unzipped tree. That papa.txt came from a real source build, so a re-derive only loses data.
+        # A shim has no source, so a changed child cannot change what it produces. Without this guard the
+        # rebuild flag makes _run_packaging re-derive the exports and lose the papa.txt data of the real build.
         if self.config.no_specific_target() and not self.is_artifactory_shim():
             first_changed = next((c for c in self.children if c.should_rebuild), None)
             if first_changed and not self.should_rebuild:
@@ -747,8 +714,7 @@ class BuildDependency:
 
 
     def update_mamafile_tag(self):
-        # A shim has no source, so the mamafile to tag does not exist on disk. The explicit
-        # short-circuit keeps a parent-mamafile fetch from flagging the shim as modified every run.
+        # a shim has no source to tag: the short-circuit keeps a parent-mamafile fetch from flagging it modified every run
         if self.is_artifactory_shim():
             return False
         return self.src_dir and update_mamafile_tag(self.config, self.mamafile_path(), self.build_dir)
@@ -801,9 +767,7 @@ class BuildDependency:
     
 
     def path_relative_to_us(self, relpath) -> str:
-        """
-        Convert a relative path to an absolute path. The base is this mamafile dir, else the source dir.
-        """
+        """Convert a relative path to absolute. The base is this mamafile dir, else the source dir."""
         if not relpath or os.path.isabs(relpath):
             return relpath # the path is already None or absolute
         elif self.mamafile:
@@ -815,10 +779,8 @@ class BuildDependency:
 
 
     def get_mamafile_path_relative_to_us(self, name, relative_mamafile) -> str:
-        """
-        Resolve a relative mamafile path against this dep. Without one, look for
-        mama/<name>.py. Return None when neither exists.
-        """
+        """Resolve a relative mamafile path against this dep, else look for mama/<name>.py.
+        Return None when neither exists."""
         if relative_mamafile:
             local_mamafile = self.path_relative_to_us(relative_mamafile)
             if not os.path.exists(local_mamafile):
@@ -848,8 +810,6 @@ class BuildDependency:
     def find_missing_dependency(self):
         last_build = [dep.rstrip() for dep in read_lines_from(f'{self.build_dir}/mama_dependency_libs')]
         current = [dep.get_dependency_name() for dep in self.get_children()]
-        #console(f'{self.name: <32} last_build: {last_build}')
-        #console(f'{self.name: <32} current:    {current}')
         for last in last_build:
             if not (last in current):
                 return last.strip()

--- a/mama/build_insights.py
+++ b/mama/build_insights.py
@@ -1,7 +1,5 @@
-"""C++ Build Insights (Stage 2 of `buildstats`): wrap an MSVC build in a vcperf /timetrace session, then
-parse the Chrome-trace JSON to show where compile time goes - frontend parse vs backend codegen, slowest
-TUs, costliest headers. vcperf is a pure observer of whatever the build command compiled, so `build
-buildstats` profiles the iterative build and `rebuild buildstats` the full one. Non-MSVC builds skip this."""
+"""C++ Build Insights (Stage 2 of `buildstats`): wraps an MSVC build in a vcperf /timetrace session, then
+parses the Chrome-trace JSON to show where compile time goes. Non-MSVC builds skip this stage."""
 import os, json, tempfile
 import mama.util as util
 from .util import get_time_str, normalized_join
@@ -9,10 +7,10 @@ from .utils.system import System, console, warning, Color, get_colored_text
 from .utils.sub_process import SubProcess
 
 _SESSION = 'mama_buildstats'  # one global ETW session name around the whole parallel build
-_TIMEOUT = 600  # vcperf /stop relogs the whole trace; give it room on large builds
+_TIMEOUT = 600  # vcperf /stop relogs the whole trace, so give it room on large builds
 _VS_VCPERF_SUBPATH = 'Common7/IDE/CommonExtensions/Platform/CppBuildInsights/vcperf.exe'  # bundled standalone
-# /noadmin: capture without elevation (one-time `vcperf /grantusercontrol` from an elevated prompt is the
-# prerequisite); /nocpusampling: skip the admin-only kernel sampling trace - timetrace needs only MSVC events.
+# /noadmin captures without elevation, after a one-time `vcperf /grantusercontrol` from an elevated prompt.
+# /nocpusampling skips the admin-only kernel sampling trace. Timetrace needs only the MSVC events.
 _START = ('/start', '/noadmin', '/nocpusampling')
 # Structural activity names (passes/threads/codegen wrappers) that carry no path/symbol of interest.
 _STRUCTURAL = ('thread', 'pass', 'frontend', 'backend', 'code generation', 'codegeneration',
@@ -41,7 +39,7 @@ def timetrace_path(build_dir: str) -> str:
 
 
 def _start_reason(output: str) -> str:
-    """One concise, actionable line from vcperf's verbose /start failure blurb."""
+    """One concise, actionable line from the verbose vcperf /start failure output."""
     low = output.lower()
     if 'grantusercontrol' in low:
         return 'vcperf needs one-time setup - run `vcperf /grantusercontrol` from an elevated prompt'
@@ -51,10 +49,10 @@ def _start_reason(output: str) -> str:
 
 
 class VcPerfSession:
-    """Context manager: `/start /noadmin /nocpusampling` on enter, `/stop /timetrace <json>` on exit (always,
-    so an ETW session is never left open even if the build raised). Success is judged by whether the JSON was
-    written, not vcperf's exit code (which is unreliable - it errors on an event-less session yet still writes
-    a valid empty trace). A failed start degrades to a no-op with a one-line hint."""
+    """Context manager: `/start /noadmin /nocpusampling` on enter, `/stop /timetrace <json>` on exit. The
+    exit always runs, so a raised build never leaves an ETW session open. The written JSON defines success,
+    not the vcperf exit code. vcperf errors on an event-less session yet still writes a valid empty trace.
+    A failed start degrades to a no-op with a one-line hint."""
     def __init__(self, vcperf: str, json_out: str, level='/level3'):
         self.vcperf = vcperf; self.json_out = json_out; self.level = level; self.ok = False
 
@@ -67,8 +65,8 @@ class VcPerfSession:
         return st, '\n'.join(out)
 
     def _clear_stale(self):
-        """Best-effort discard of a session left open by a crashed run, so /start can succeed. /stopnoanalyze
-        needs an output path; we write a throwaway ETL and delete it."""
+        """Discards a session that a crashed run left open, so /start can succeed. /stopnoanalyze
+        needs an output path, so write a throwaway ETL and delete it."""
         etl = normalized_join(tempfile.gettempdir(), 'mama_stale.etl')
         self._run([self.vcperf, '/stopnoanalyze', _SESSION, etl])
         try: os.remove(etl)
@@ -78,8 +76,8 @@ class VcPerfSession:
         return self._run([self.vcperf, *_START, self.level, _SESSION])
 
     def _grant_user_control(self) -> bool:
-        """One-time elevated `vcperf /grantusercontrol` (one UAC prompt) so /noadmin needs no elevation on
-        any later run. Windows-only; returns True if the elevated command completed."""
+        """One-time elevated `vcperf /grantusercontrol` (one UAC prompt), so /noadmin needs no elevation on
+        any later run. Windows only. Returns True when the elevated command completed."""
         if not System.windows: return False
         console('buildstats: granting vcperf user-mode trace control (one-time; accept the elevation prompt)')
         cmd = ['powershell', '-NoProfile', '-Command',
@@ -100,8 +98,8 @@ class VcPerfSession:
 
     def __exit__(self, *exc):
         if self.ok:
-            os.makedirs(os.path.dirname(self.json_out) or '.', exist_ok=True)  # vcperf won't create the dir
-            try: os.remove(self.json_out)  # so a leftover trace can't masquerade as this run's
+            os.makedirs(os.path.dirname(self.json_out) or '.', exist_ok=True)  # vcperf does not create the dir
+            try: os.remove(self.json_out)  # so a leftover trace cannot pass as this run's trace
             except OSError: pass
             self._run([self.vcperf, '/stop', _SESSION, '/timetrace', self.json_out])
             self.ok = os.path.exists(self.json_out)  # trust the file, not vcperf's exit code
@@ -110,11 +108,11 @@ class VcPerfSession:
 
 
 # --- timetrace JSON parsing ---------------------------------------------------------------------------
-# Format (vcperf TimeTraceGenerator): {"traceEvents":[...]} where ts/dur are microseconds. Childless
-# entries are complete events (ph "X", carry dur); entries with children are begin/end pairs (ph "B"/"E").
-# Names: "CL Invocation N" / "Link Invocation N" (top-level, with File Input/Output args); a FrontEndFile
-# carries its path as the name; a Function/template carries its symbol. So a path-separator in the name
-# distinguishes a parsed file from a codegen symbol - no dependence on internal pass names.
+# Format (vcperf TimeTraceGenerator): {"traceEvents":[...]} where ts/dur are microseconds. A childless
+# entry is a complete event (ph "X", carries dur). An entry with children is a begin/end pair (ph "B"/"E").
+# Names: "CL Invocation N" / "Link Invocation N" at top level, with File Input/Output args. A FrontEndFile
+# carries its path as the name. A Function/template carries its symbol. So a path separator in the name
+# distinguishes a parsed file from a codegen symbol, with no dependence on internal pass names.
 
 class _Node:
     __slots__ = ('name', 'args', 'start', 'dur', 'children')
@@ -153,10 +151,10 @@ def _arg_values(args, key: str) -> list:
 _FRONTEND_PASS, _BACKEND_PASS = 'FrontEndPass', 'BackEndPass'
 
 def _find_passes(node, fe: list, be: list):
-    """Collect the per-TU FrontEndPass/BackEndPass activities under a CL invocation (descending through
-    any wrapper nodes). With /MP one invocation runs MANY of each in parallel; summing their durations
-    gives aggregate CPU - which is what makes frontend/backend comparable (the invocation's own dur is
-    wall time, so aggregate parse could exceed it and clamp backend to zero - the bug this fixes)."""
+    """Collects the per-TU FrontEndPass/BackEndPass activities under a CL invocation, descending through
+    any wrapper nodes. With /MP one invocation runs MANY of each in parallel. The sum of their durations
+    gives aggregate CPU, which makes frontend and backend comparable. The invocation's own dur is wall
+    time, so aggregate parse could exceed it and clamp backend to zero."""
     for ch in node.children:
         if ch.name == _FRONTEND_PASS: fe.append(ch)
         elif ch.name == _BACKEND_PASS: be.append(ch)
@@ -164,9 +162,9 @@ def _find_passes(node, fe: list, be: list):
 
 
 def _collect(node, depth: int, files: dict, symbols: dict, in_backend: bool) -> str:
-    """DFS of one compiler pass: aggregate each INCLUDED header (a FrontEndFile at depth>0) into `files`
+    """DFS of one compiler pass: aggregates each INCLUDED header (a FrontEndFile at depth>0) into `files`
     and, under a backend pass, each codegen leaf into `symbols`. Returns the outermost source path (the
-    TU's own .cpp at depth 0) for labeling - it's not a header, so it never feeds `files`."""
+    TU's own .cpp at depth 0) for labeling. The source is not a header, so it never feeds `files`."""
     src = None
     for ch in node.children:
         if _is_path(ch.name):
@@ -188,7 +186,7 @@ def _norm(p: str) -> str:
 
 
 class TraceStats:
-    """Aggregated build-insights numbers, all durations in seconds. Lists are sorted slowest-first."""
+    """Aggregated build-insights numbers, all durations in seconds. Lists rank slowest-first."""
     def __init__(self, compile_s, link_s, frontend_s, backend_s, wall_s, n_tu, tus, files, symbols):
         self.compile_s = compile_s; self.link_s = link_s
         self.frontend_s = frontend_s; self.backend_s = backend_s
@@ -246,19 +244,19 @@ def _build_stats(frontend_us, backend_us, link_us, wall_us, n_tu, tus, files, sy
 
 # --- Clang -ftime-trace (Linux/Clang deep dive) -------------------------------------------------------
 # One flat-event JSON per TU (events ph:"X", each with args.detail). Frontend/Backend are the phase
-# totals; Source events carry a parsed file path; Instantiate*/OptFunction carry an ALREADY-demangled
-# symbol. Linking isn't traced (link stays 0), and per-TU timelines are independent, so wall comes from
-# the build clock, not the JSONs.
+# totals. A Source event carries a parsed file path. Instantiate*/OptFunction carry an ALREADY-demangled
+# symbol. Clang does not trace linking (link stays 0), and per-TU timelines are independent, so wall
+# comes from the build clock, not the JSONs.
 _CLANG_CODEGEN = ('InstantiateClass', 'InstantiateFunction', 'OptFunction')
 _SRC_EXTS = ('.c', '.cc', '.cpp', '.cxx', '.c++', '.m', '.mm')
 
 def _is_header(path: str) -> bool:
-    return not _base(path).lower().endswith(_SRC_EXTS)  # the TU's own .cpp isn't a header; STL headers have no ext
+    return not _base(path).lower().endswith(_SRC_EXTS)  # the TU's own .cpp is not a header. STL headers have no ext
 
 
 def parse_clang_traces(paths, wall_s=0.0) -> TraceStats:
-    """Aggregate Clang -ftime-trace JSONs (one per TU) into the same TraceStats vcperf produces, so the
-    Linux deep report renders identically. `wall_s` is the measured build wall time (the JSONs can't give it)."""
+    """Aggregates Clang -ftime-trace JSONs (one per TU) into the same TraceStats vcperf produces, so the
+    Linux deep report renders identically. `wall_s` is the measured build wall time (the JSONs cannot give it)."""
     frontend_us = backend_us = 0.0
     n_tu = 0
     tus, files, symbols = [], {}, {}
@@ -286,9 +284,9 @@ def parse_clang_traces(paths, wall_s=0.0) -> TraceStats:
 
 
 def collect_clang_traces(build_dir: str, since: float = 0.0) -> list:
-    """The `*.json` time-traces clang wrote into `build_dir`, modified at/after `since` (wall seconds) so
-    only THIS build's TUs are analyzed. Content-filtering (skip compile_commands.json etc) is left to the
-    parser. Sorted newest-first is irrelevant; the parser aggregates all."""
+    """The `*.json` time-traces clang wrote into `build_dir`, modified at or after `since` (wall seconds),
+    so the report covers only THIS build's TUs. The parser does the content filtering (it skips
+    compile_commands.json etc) and aggregates every file, so the order does not matter."""
     import glob
     out = []
     for p in glob.glob(util.path_join(build_dir, '**', '*.json'), recursive=True):
@@ -303,7 +301,7 @@ def collect_clang_traces(build_dir: str, since: float = 0.0) -> list:
 _TOP = 8           # rows per ranked section
 _SYM_WIDTH = 100   # truncate a demangled symbol so a codegen row stays one line
 _UNDNAME_NAME_ONLY = 0x1000  # dbghelp flag: drop return type / calling convention / params -> scope::name<...>
-_undname = None    # memoized (ctypes, UnDecorateSymbolName) or False; resolved once (the API is process-constant)
+_undname = None    # memoized (ctypes, UnDecorateSymbolName) or False, resolved once. The API is process-constant
 
 
 def _demangle(name: str) -> str:

--- a/mama/build_names.py
+++ b/mama/build_names.py
@@ -1,19 +1,12 @@
 """How a build is named: the variant suffix that a build dir AND an artifactory archive both carry, and
-the build dir name itself.
-
-ONE module with TWO functions, because a build dir name and an archive name that spell the same axis
-differently let a build and the package it uploads disagree about which variant they are. A `memory`
-build dir used to say 'memory' while its archive said 'msan', and a coverage build uploaded under the
-plain name. A dep calls both functions once at init and stores the results: see
-BuildDependency.variant_suffix and BuildDependency.build_dir_name.
-
-`config` is duck-typed on purpose. These are naming rules, not configuration, so BuildConfig does not
-carry them, and each function reads only the config fields it names."""
+the build dir name itself. ONE spelling for both, so a build and its uploaded package never disagree."""
 
 from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+# `config` is duck-typed on purpose. These are naming rules, not configuration, so BuildConfig does not
+# carry them, and each function reads only the config fields it names.
 if TYPE_CHECKING:
     from .build_config import BuildConfig
 
@@ -34,12 +27,12 @@ def build_variant_suffix(config: BuildConfig, dep_args=()) -> str:
     sanitizers, then the dep args. Coarsest axis first, each token with its own '-', and '' for a plain
     build with no args, so an existing name stays byte-identical.
 
-    THE one place a variant is spelled. Both the build dir name and the archive name carry this string,
+    THE one place that spells a variant. Both the build dir name and the archive name carry this string,
     so they cannot disagree. The compiler is NOT in here: the build dir names it as a token, and the
     archive name already has a field for its full version.
 
-    Dep args come from the consumer's `add_git(..., args=[...])`, so they are known before the clone, the
-    same way the platform and the compiler are. Sorted, lowercased, de-duplicated and stripped of
+    Dep args come from the consumer's `add_git(..., args=[...])`, so mama knows them before the clone,
+    the same way it knows the platform and the compiler. Sorted, lowercased, de-duplicated and stripped of
     punctuation, so the call order, the letter case and a repeated arg never change a name. A '+' becomes
     'p' ('C++20' -> 'cpp20'), and a key=value arg keeps both halves ('NEWMATH=1' -> 'newmath1', which
     stays distinct from 'NEWMATH=2'). `isalnum() and isascii()`, not `isalnum()` alone: isalnum() answers
@@ -63,9 +56,9 @@ def sanitize_version(raw: str) -> str:
     dash and underscore, and collapses every other run into one '-', so the tag `release/1.0` names an
     archive `release-1.0`.
 
-    Keeps the case, and keeps a leading 'v'. Both look like noise until you drop them. Lowercasing
-    merges the tags `v1.0` and `V1.0` into one name, and stripping the 'v' merges `v1.0` and `1.0`. A
-    repo may carry all three, and two sources must never share one archive name."""
+    Keeps the case, and keeps a leading 'v'. A lowercase pass merges the tags `v1.0` and `V1.0` into one
+    name, and a stripped 'v' merges `v1.0` and `1.0`. A repo may carry all three, and two sources must
+    never share one archive name."""
     return _UNSAFE_IN_VERSION.sub('-', raw).strip('-') if raw else ''
 
 

--- a/mama/build_scheduler.py
+++ b/mama/build_scheduler.py
@@ -176,8 +176,8 @@ class Scheduler:
                     if self._gen != gen: continue  # state moved while we drew: re-evaluate, do not sleep on it
                 if not progressed:
                     if self._n_running == 0 and self._pending and not self._error:
-                        # nothing running and nothing launchable: the remaining jobs have unmet
-                        # deps that no running job can satisfy -> a dependency cycle. Do not hang.
+                        # nothing runs and nothing can launch: the remaining jobs wait on deps no
+                        # running job can satisfy -> a dependency cycle. Do not hang.
                         self._error = self._pending[0]
                         self._error.error = RuntimeError(f'Cyclical dependency at {self._error}')
                         break
@@ -304,7 +304,6 @@ class Scheduler:
                 self._error = job  # the first failure wins and stops further launches
             self._cond.notify_all()
         if first_failure and self._abort_hook:
-            # Fail fast: stop the running child processes, so the build exits now. Otherwise it drains
-            # every running sibling first. The hook runs outside the lock, because it waits for a grace
-            # period. The notify_all above already woke the barriers.
+            # Fail fast: stop the running child processes now, instead of draining every running sibling.
+            # The hook waits for a grace period, so it runs outside the lock. notify_all already woke the barriers.
             self._abort_hook(f'{job.node.name if job.node else job.key} failed')

--- a/mama/build_scheduler.py
+++ b/mama/build_scheduler.py
@@ -1,9 +1,5 @@
-"""Parallel DAG scheduler for configure/build jobs: runs a graph of `Job`s honoring dep edges.
-Governors: CONFIGURE jobs (cheap probes) are count-bounded; BUILD jobs (each spawns `cmake
---build -jN`) are gated by a core budget + CPU-load sample. Fail-fast: the first error stops new
-launches AND fires the abort hook to stop the in-flight children (so the build exits fast, not after
-draining every sibling), then returns the failed job. Generic over `Job.run` (the cmake wiring
-lives in the caller), so it unit-tests with fake jobs."""
+"""Parallel DAG scheduler for load/configure/build jobs: runs a graph of `Job`s and honors the dep edges.
+A count cap governs CONFIGURE jobs, a core budget plus a CPU sample gates BUILD jobs, and the first error aborts the build."""
 
 from __future__ import annotations
 import time, threading, concurrent.futures, contextlib
@@ -40,7 +36,7 @@ class Job:
 
 
 def _make_abort_job() -> Job:
-    """Synthetic job run() returns on Ctrl+C so the caller reports an interrupted (failed) build."""
+    """Synthetic failed job that run() returns after Ctrl+C, so the caller reports an interrupted build."""
     job = Job(('<interrupted>',), BUILD, run=(lambda: None), node=SimpleNamespace(name='<interrupted>'))
     job.error = KeyboardInterrupt('build interrupted by Ctrl+C')
     job.done = True
@@ -48,7 +44,7 @@ def _make_abort_job() -> Job:
 
 
 def _check_acyclic(jobs: List[Job]):
-    """DFS cycle check; raises RuntimeError naming a node in the cycle."""
+    """DFS cycle check. Raises RuntimeError and names a node in the cycle."""
     WHITE, GREY, BLACK = 0, 1, 2
     color = {j: WHITE for j in jobs}
     def visit(j: Job):
@@ -63,10 +59,10 @@ def _check_acyclic(jobs: List[Job]):
 
 
 def build_dep_jobs(deps, configure_fn, build_fn, weight_fn=None, children_fn=None) -> List[Job]:
-    """Wire a configure + build job per dep: a dep's configure waits on every in-set child's build
-    (its dependencies.cmake embeds child outputs), its build on its own configure. `weight_fn(dep)`
-    gives the build's core weight, resolved lazily at launch. `children_fn` defaults to get_children.
-    Sets critical-path priorities so trunk deps launch first."""
+    """Wires a configure + build job per dep. A dep's configure waits on every in-set child's build,
+    because its dependencies.cmake embeds the child outputs. Its build waits on its own configure.
+    `weight_fn(dep)` gives the build's core weight, resolved lazily at launch. `children_fn` defaults
+    to get_children. Sets critical-path priorities, so trunk deps launch first."""
     children_fn = children_fn or (lambda d: d.get_children())
     weight_fn = weight_fn or (lambda d: 1)
     dep_set = set(deps)
@@ -83,7 +79,7 @@ def build_dep_jobs(deps, configure_fn, build_fn, weight_fn=None, children_fn=Non
 
 
 def assign_priorities(jobs):
-    """Set job.priority to its critical-path DEPTH: the number of BUILD jobs on the longest chain of jobs
+    """Sets job.priority to its critical-path DEPTH: the number of BUILD jobs on the longest chain of jobs
     that depend on it (configure jobs are free). So a dep deep in the trunk - feeding the root through the
     longest dependency chain - launches first. Purely structural: no (unreliable) build-time estimates."""
     jobs = list(jobs)
@@ -130,9 +126,9 @@ class Scheduler:
         self._error: Optional[Job] = None  # first failed job
 
     def grow(self, build_fn: Callable[[], List[Job]]):
-        """Atomically extend the graph at runtime: `build_fn()` runs under the scheduler lock (so it
-        can safely mutate caller registries + add edges) and returns new jobs. Used by a LOAD job
-        that discovered children; the add happens before LOAD is marked done, so a parent's
+        """Atomically extends the graph at runtime: `build_fn()` runs under the scheduler lock, so it
+        can safely mutate caller registries and add edges, and returns the new jobs. A LOAD job that
+        discovered children uses this. The add happens before the LOAD job reports done, so a parent's
         CONFIGURE never launches before its children's edges exist."""
         with self._cond:
             self._pending.extend(build_fn())
@@ -140,8 +136,8 @@ class Scheduler:
             self._cond.notify_all()
 
     def run(self, jobs: List[Job]) -> Optional[Job]:
-        """Execute all jobs honoring deps + governors; returns the failed job or None. The graph may
-        grow via grow(); the loop ends only when nothing is pending AND nothing runs."""
+        """Executes all jobs and honors deps + governors. Returns the failed job or None. The graph may
+        grow via grow(). The loop ends only when nothing is pending AND nothing runs."""
         _check_acyclic(list(jobs))
         with concurrent.futures.ThreadPoolExecutor(max_workers=self._max_workers) as ex:
             try:
@@ -177,11 +173,11 @@ class Scheduler:
                     self._cond.release()
                     try: self._pending_log(hint)
                     finally: self._cond.acquire()
-                    if self._gen != gen: continue  # state moved while we drew: re-evaluate, don't sleep on it
+                    if self._gen != gen: continue  # state moved while we drew: re-evaluate, do not sleep on it
                 if not progressed:
                     if self._n_running == 0 and self._pending and not self._error:
                         # nothing running and nothing launchable: the remaining jobs have unmet
-                        # deps that no running job can satisfy -> a dependency cycle. Don't hang.
+                        # deps that no running job can satisfy -> a dependency cycle. Do not hang.
                         self._error = self._pending[0]
                         self._error.error = RuntimeError(f'Cyclical dependency at {self._error}')
                         break
@@ -219,10 +215,10 @@ class Scheduler:
         return self._build_admits(self._resolve_weight(job))  # BUILD
 
     def _build_admits(self, weight: int) -> bool:
-        """Budget gate shared by BUILD launch + build_slot() barriers: admit freely while reserved
-        cores stay within budget REGARDLESS of momentary CPU (one compile saturates the sampler;
-        gating on that stalled every build). CPU only gates over-provisioning
-        beyond budget. reserved==0 always admits, so one build always proceeds and no barrier deadlocks."""
+        """Budget gate shared by the BUILD launch and the build_slot() barriers. Admit freely while the
+        reserved cores stay within budget, REGARDLESS of momentary CPU, because one compile already
+        saturates the sampler. CPU only gates over-provisioning beyond the budget. reserved==0 always
+        admits, so one build always proceeds and no barrier deadlocks."""
         if self._reserved == 0:
             return True
         need = self._reserved + weight
@@ -234,13 +230,13 @@ class Scheduler:
 
     @contextlib.contextmanager
     def build_slot(self, weight: int):
-        """Acquire `weight` budget cores for a compile running INSIDE a job (a custom build()'s
-        cmake_build(), reached via system.build_barrier()): the worker thread suspends until the
-        budget admits, reserves, runs, then releases on exit. always-admit-when-idle = no deadlock."""
+        """Acquires `weight` budget cores for a compile that runs INSIDE a job, such as a custom
+        build()'s cmake_build() reached via system.build_barrier(). The worker thread suspends until
+        the budget admits, reserves, runs, then releases on exit. Always-admit-when-idle means no deadlock."""
         weight = max(0, int(weight))
         with self._cond:
             while True:
-                if self._error is not None: raise BuildInterrupted()  # build failing/aborting: don't start a new compile
+                if self._error is not None: raise BuildInterrupted()  # build failing/aborting: do not start a new compile
                 if self._build_admits(weight): break
                 self._cond.wait(timeout=self._poll_interval)
             self._reserved += weight
@@ -262,7 +258,7 @@ class Scheduler:
     def _pending_hint(self, blocked: List[Job]):
         """The single next task waiting to launch + why, for the live display: a governor-held job
         (deps ready, gated by CPU/budget/slots) if any, else a job still waiting on its deps (up to
-        3 named + a (+N) overflow). None if nothing's waiting (the scheduler is keeping up)."""
+        3 named + a (+N) overflow). None when nothing waits (the scheduler keeps up)."""
         if blocked:
             return (self._name(blocked[0]), self._block_reason(blocked[0]))
         for job in self._pending:
@@ -305,7 +301,7 @@ class Scheduler:
             self._gen += 1
             first_failure = job.error is not None and self._error is None
             if first_failure:
-                self._error = job  # first failure wins; stops further launches
+                self._error = job  # the first failure wins and stops further launches
             self._cond.notify_all()
         if first_failure and self._abort_hook:
             # Fail fast: stop the running child processes, so the build exits now. Otherwise it drains

--- a/mama/build_target.py
+++ b/mama/build_target.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .build_config import BuildConfig
     from .build_dependency import BuildDependency
 
-# Non-library trees skipped by the source-file TU fallback (e.g. gtest is ~90% test/ + samples/).
+# Non-library trees that the source-file TU fallback skips. For example gtest is ~90% test/ and samples/.
 _NON_LIB_DIRS = ['build', 'packages', 'libs', 'out', '.git', 'test', 'tests', 'samples', 'example',
                  'examples', 'benchmark', 'benchmarks', 'doc', 'docs', 'third_party', 'thirdparty',
                  'extern', 'external', 'vendor']
@@ -37,8 +37,8 @@ _NON_LIB_DIRS = ['build', 'packages', 'libs', 'out', '.git', 'test', 'tests', 's
 
 class BuildTarget:
     """
-    Describes a single configurable build target.
-    This is the main public interface for configuring a specific target.
+    Describes one configurable build target.
+    This is the main mamafile-facing interface for one target.
     For project-wide configuration, @see BuildConfig in self.config.
 
     Customization points:
@@ -47,7 +47,7 @@ class BuildTarget:
 
         workspace = 'packages'
 
-        def configure(self):
+        def dependencies(self):
             self.add_git('ReCpp',
                          'http://github.com/RedFox20/ReCpp.git')
 
@@ -71,10 +71,10 @@ class BuildTarget:
         self.args = [] # user defined args for this target (must be a list)
         self.install_target = 'install'
         # Pins the last field of the artifactory archive name, in place of the commit hash. It MUST be a
-        # SINGLE RAW STRING LITERAL. Mama names a package before it clones anything, so it reads this
-        # value out of the mamafile TEXT and never runs the file (mamafile_version.py). That reader
-        # cannot see a computed value, and it stops at the first assignment. Either shape makes the
-        # download look for one name while the upload publishes another. See the README, "Package naming".
+        # single raw string literal. Mama names a package before it clones anything. The reader,
+        # mamafile_version.py, reads this value from the mamafile TEXT and never runs the file. That
+        # reader cannot see a computed value, and it stops at the first assignment. Either shape makes
+        # the download look for one name while the upload publishes another. See the README, "Package naming".
         self.version = ''
         self.cmake_ndk_toolchain   = '' # Custom Android toolchain file for this target only
         self.cmake_raspi_toolchain = '' # Custom Raspberry toolchain file for this target only
@@ -89,11 +89,11 @@ class BuildTarget:
         self.cmake_command = config.cmake_command # allow override from config, but also from target
         self.enable_exceptions = True
         self.enable_unix_make  = False
-        self.enable_ninja_build = config.prefer_ninja and config.ninja_path # attempt to use Ninja
+        self.enable_ninja_build = config.prefer_ninja and config.ninja_path
         self.enable_fortran_build = False
         self.enable_cxx_build = True
         self.enable_multiprocess_build = True
-        self.clean_intermediate_files = False # force delete .o and .obj files after build success
+        self.clean_intermediate_files = False # delete .o and .obj files after a successful build
         self.gcc_clang_visibility_hidden = True # -fvisibility=hidden
         self.build_products = [] # executables/libs products from last build
         self.no_includes = False # no includes to export
@@ -102,7 +102,7 @@ class BuildTarget:
         self.exported_libs     = [] # libs to export from this target
         self.exported_syslibs  = [] # exported system libraries
         self.exported_assets: List[Asset] = [] # exported asset files
-        self.packaging_result = '' # how we performed the package() step?
+        self.packaging_result = '' # result of the package() step
         self._fetched = None # set by configure_phase: artifactory auto-fetch result, read by build_phase
         self._did_configure = False # guards configure() to run once across configure/build phases
         self._build_jobs = None # scheduler-sized -j for this target's build (None -> config.jobs)
@@ -166,24 +166,27 @@ class BuildTarget:
 
 
     def host_build_dir(self, subpath=''):
-        """This target's build dir for the HOST platform (.../<name>/<host>), a sibling of build_dir(). Where a
-        host tool built by build_host_binary() lands; equals build_dir() on a native host build."""
+        """This target's build dir for the HOST platform (.../<name>/<host>), a sibling of build_dir().
+        A host tool built by build_host_binary() lands here. Equals build_dir() on a native host build."""
         host_dir = util.path_join(os.path.dirname(self.dep.build_dir), self.config.host_platform_name())
         return util.path_join(host_dir, subpath) if subpath else host_dir
 
 
     def build_host_binary(self, relpath, auto_build=True):
-        """Ensure a HOST-built binary of this target exists and return its absolute path (None on miss / opt
-        out). For a tool needed WHILE cross-compiling - e.g. protoc, which can't run as the arm64 android
-        binary the target build would produce.
+        """Makes sure a HOST-built binary of this target exists, then returns its absolute path.
+        Returns None on a miss when auto_build=False. Use this for a tool needed WHILE cross-compiling,
+        for example protoc, which cannot run as the arm64 android binary the target build would produce.
 
-        Cheap-checks the host build dir first, so warm builds and repeated consumers pay nothing. On a miss,
-        when auto_build (default), bootstraps via `mama <host> build target=<name>` in a correctly
-        host-configured child - which fetches the host artifactory package first and only builds on a miss.
-        No foreign config is synthesised in-process (the child owns its own); no-op returning the local path
-        when this build IS the host."""
+        Checks the host build dir first, so warm builds and repeated consumers pay nothing. On a miss,
+        when auto_build=True, bootstraps via `mama <host> build target=<name>` in a host-configured
+        child process. The child fetches the host artifactory package first and only builds on a miss.
+        The child owns its own config, so this process builds no foreign config. When this build IS
+        the host, returns the local build path.
+
+        - relpath -- binary path relative to the build dir, '.exe' is appended on Windows
+        - auto_build -- [True] bootstrap the host build on a miss, else return None"""
         if System.windows and not os.path.splitext(relpath)[1]:
-            relpath += '.exe'  # host tools are executables: spare every caller the host-suffix dance
+            relpath += '.exe'  # host tools are executables, add the suffix once for every caller
         host = self.config.host_platform_name()
         if self.config.name() == host:
             local = self.build_dir(relpath)  # already the host: the normal build produced it here
@@ -195,13 +198,13 @@ class BuildTarget:
             return None
         if self.config.print:
             console(f'  - {self.name: <16} bootstrapping host binary: mama {host} build target={self.name}', color=Color.BLUE)
-        # sys.executable + the mama.main entry (there's no __main__.py for `python -m mama`); cwd = the root
-        # project so the child resolves the same dependency graph. The child computes the correct host archive
-        # name and does fetch-or-build - no cross-platform naming is attempted from this android-flavoured config.
+        # sys.executable + the mama.main entry, because there is no __main__.py for `python -m mama`.
+        # cwd is the root project so the child resolves the same dependency graph. The child computes
+        # the correct host archive name and does fetch-or-build, so this cross config never guesses it.
         argv = [sys.executable, '-c', 'from mama.main import __main__; __main__()', host, 'build', f'target={self.name}']
-        # io_func is MANDATORY here: without it the child inherits our stdout, and on a pty it draws its
-        # OWN live region over ours - the two fight for the same rows and strand our task lines in the
-        # scrollback. Captured, its output feeds this target's display line, log and failure replay.
+        # io_func is MANDATORY here. Without it the child inherits our stdout, and on a pty it draws
+        # its OWN live region over ours. The two fight for the same rows and strand our task lines in
+        # the scrollback. Captured, the output feeds this target's display line, log and failure replay.
         def child_output(p, line: str):
             line = line.rstrip()
             if line: console(f'  {self.name: <16} | {line}')
@@ -214,21 +217,23 @@ class BuildTarget:
 
     def set_artifactory_ftp(self, ftp_url, auth='store'):
         """
-        Configures the remote Artifactory FTP URL where packages
-        will be checked for download. If a package with correct commit hash
-        exists, it will be used instead of building locally.
+        Configures the remote Artifactory FTP URL where mama checks for
+        prebuilt packages. If a package with the correct commit hash exists,
+        mama downloads it instead of building locally.
+        Only a root target may call this. A non-root call is a no-op.
 
-        If auth='store' then system's secure keyring is used to store
-        the credentials. If authentication fails, then credentials are cleared.
+        The ENV variables `MAMA_ARTIFACTORY_USER` and `MAMA_ARTIFACTORY_PASS`
+        override the username and password, for use in build systems.
 
-        The username and password can be overriden by ENV variables
-        `MAMA_ARTIFACTORY_USER` and `MAMA_ARTIFACTORY_PASS` for use in build systems
+        - ftp_url -- address of the Artifactory FTP server
+        - auth -- ['store'] 'store' keeps the credentials in the secure keyring of the system.
+                  If authentication fails, mama clears the stored credentials.
         ```
             def dependencies(self):
-                self.config.set_artifactory_url('myserver.com', auth='store')
-                self.config.set_artifactory_url('myserver.com', auth='prompt')
+                self.set_artifactory_ftp('myserver.com', auth='store')
+                self.set_artifactory_ftp('myserver.com', auth='prompt')
         ```
-        NOTE: Currently only FTP is supported
+        NOTE: Only FTP is supported.
         """
         if not self.dep.is_root:
             return
@@ -237,18 +242,18 @@ class BuildTarget:
 
     def add_local(self, name, source_dir, mamafile=None, always_build=False, args=[]) -> BuildDependency:
         """
-        Add a local dependency. This can be a git submodule or just some local folder.
-        which contains its own CMakeLists.txt.
-        Optionally you can override the default 'mamafile.py' with your own.
+        Add a local dependency. This can be a git submodule or a local folder
+        that contains its own CMakeLists.txt.
 
-        If the local dependency folder does not contain a `mamafile.py`, you will have to
-        provide your own relative or absolute mamafile path.
+        If the dependency folder has no `mamafile.py`, provide your own
+        relative or absolute mamafile path.
 
-        Optionally, you can set your local library to always build using `always_build=True`.
-        This is useful when chaining together sub-projects that do not depend on each other.
-
-        Additional arguments can be passed to the target mamafile. The target mamafile
-        will have to check `self.args` for any arguments of interest.
+        - name -- name of the dependency
+        - source_dir -- path of the local folder
+        - mamafile -- [None] optional custom mamafile path
+        - always_build -- [False] always build this dependency. Useful when chaining
+                          sub-projects that do not depend on each other.
+        - args -- [[]] extra arguments for the target mamafile, read back via `self.args`
         ```
         self.add_local('zlib', '3rdparty/zlib')
         self.add_local('zlib', '3rdparty/zlib', mamafile='mama/zlib.py')
@@ -262,16 +267,21 @@ class BuildTarget:
 
     def add_git(self, name, git_url, git_branch='', git_tag='', git_commit='', mamafile=None, shallow=True, args=[]) -> BuildDependency:
         """
-        Add a remote GIT dependency.
-        The dependency will be cloned and updated according to mamabuild.
+        Add a remote GIT dependency. Mama clones it and updates it during builds.
         Use `mama update` to force update the git repositories.
 
-        If the remote GIT repository does not contain a `mamafile.py`, you will have to
-        provide your own relative or absolute mamafile path.
+        If the remote GIT repository has no `mamafile.py`, provide your own
+        relative or absolute mamafile path.
 
-        For PUBLIC repositories, only use `https://` to prevent clone failures!!!
+        For a PUBLIC repository, use only an `https://` URL to prevent clone failures.
 
-        Any arguments are passed onto child targets as `self.args`.
+        - git_url -- the git URL to clone from
+        - git_branch -- [''] branch to check out
+        - git_tag -- [''] tag to check out
+        - git_commit -- [''] commit to check out, used as the tag when git_tag is empty
+        - mamafile -- [None] optional custom mamafile path
+        - shallow -- [True] use a shallow clone
+        - args -- [[]] extra arguments for the child target, read back via `self.args`
         ```
         self.add_git('ReCpp', 'git@github.com:RedFox20/ReCpp.git')
         self.add_git('ReCpp', 'git@github.com:RedFox20/ReCpp.git', git_branch='master')
@@ -290,19 +300,13 @@ class BuildTarget:
 
     def add_artifactory_pkg(self, name, version='latest', fullname=None) -> BuildDependency:
         """
-        Adds an Artifactory only dependency.
-        The dependency will be downloaded from the artifactory url.
+        Adds an Artifactory-only dependency. Mama downloads it from the artifactory URL.
 
-        If the remote artifactory does not contain this package,
-        an error is thrown during build.
+        If the remote artifactory does not have this package, the build stops with an error.
 
-        If a version value is given, mamabuild will try to automatically
-        figure out the appropriate remote package.
-
-        If a fullname value is given, only the specific artifactory package
-        will be used as an override. This is mostly useful for source-only packages
-        and for platform-specific configuration.
-
+        - version -- ['latest'] mama picks the matching remote package for this version
+        - fullname -- [None] use only this exact artifactory package as an override.
+                      Useful for source-only packages and for platform-specific configuration.
         ```
         self.add_artifactory_pkg('mylib', version='latest')
         self.add_artifactory_pkg('mylib', version='df76b66')
@@ -332,6 +336,7 @@ class BuildTarget:
     def find_target(self, name, recursive=True):
         """
         Finds a child BuildTarget by name.
+        - recursive -- [True] also search the children of children
         ```
             zlib = self.find_target('zlib')
         ```
@@ -361,8 +366,12 @@ class BuildTarget:
     def inject_products(self, dst_dep, src_dep, include_path, libs, libfilters=None):
         """
         Injects products from `src_dep` into `dst_dep` as CMake defines.
-        Name of defines is given via `include_path` and `libs` params.
-        `libfilters` does simple string matching; if nothing matches, the first export lib is chosen.
+        - dst_dep -- name of the dependency that receives the defines
+        - src_dep -- name of the dependency that provides the products
+        - include_path -- name of the include define
+        - libs -- name of the library define
+        - libfilters -- [None] simple substring match over the exported libs.
+                        If nothing matches, mama picks the first exported lib.
         ```
         self.inject_products('libpng', 'zlib',
                              'ZLIB_INCLUDE_DIR', 'ZLIB_LIBRARY',
@@ -415,7 +424,7 @@ class BuildTarget:
             if libfilters:
                 for lib in self.exported_libs:
                     if libfilters in lib: libs.append(lib)
-                # if no matches with libfilters, just append the first
+                # if nothing matches libfilters, pick the first
                 if not libs: libs.append(self.exported_libs[0])
             else:
                 libs = self.exported_libs
@@ -440,14 +449,14 @@ class BuildTarget:
         """
         Manually add a build dependency to prevent unnecessary rebuilds.
 
-        @note Normally the build dependency is detected from the packaged libraries.
+        Normally mama detects the build dependency from the packaged libraries.
+        If the dependency file does not exist, the project rebuilds.
+        A project with no build dependencies always rebuilds, so make sure to
+        call add_build_dependency() or export_lib().
 
-        if the dependency file does not exist, then the project will be rebuilt
-
-        if your project has no build dependencies, it will always be rebuilt, so make sure
-        to add_build_dependency or export_lib. @see select() for the platform names.
+        - all -- [None] path used on every platform, relative to the build directory
+        - platforms -- per-platform paths, @see select() for the platform names
         ```
-            # Note: relative to build directory
             self.add_build_dependency('customProduct.dat')
             self.add_build_dependency(windows='custom.lib', linux='libcustom.a')
         ```
@@ -461,8 +470,8 @@ class BuildTarget:
 
     def no_export_includes(self):
         """
-        Declares that we do not have any includes to export. This is necesssary to prevent
-        automatic includes generation.
+        Declares that this target has no includes to export. This prevents
+        the automatic include export.
         ```
             def package(self):
                 self.no_export_includes()
@@ -474,9 +483,9 @@ class BuildTarget:
 
     def no_export_libs(self):
         """
-        Declares that we do not have any libs to export. This is necesssary to prevent
-        automatic lib search. This is most common for header-only libraries which might
-        build some test binaries that would otherwise exported unnecessarily.
+        Declares that this target has no libs to export. This prevents the
+        automatic lib search. Most common for a header-only library that builds
+        test binaries which mama would otherwise export.
         ```
             def package(self):
                 self.no_export_libs()
@@ -491,25 +500,28 @@ class BuildTarget:
         """
         CUSTOM PACKAGE INCLUDES (if self.default_package() is insufficient).
 
-        Export include path relative to source directory OR if build_dir=True, then relative to build directory.
+        Exports an include path relative to the source directory.
+        If build_dir=True, the path is relative to the build directory.
         ```
             # as_includes_root deploys as 'deploy/include/mylib/*.h' instead of 'deploy/include/installed/MyLib/*.h'
-            # this way your includes are clean: #include <mylib/mylib.h> instead of <src/mylib/mylib.h>
+            # this keeps includes clean: #include <mylib/mylib.h> instead of <src/mylib/mylib.h>
             self.export_include('src/mylib', build_dir=False, as_includes_root='mylib')
 
-            # if you already use a separate include folder, then everything is ready to go
+            # a project with a separate include folder needs no extra options
             self.export_include('include')  # MyRepo/include
 
             # CMake installed includes in build/installed/MyLib/include
             self.export_include('installed/MyLib/include', build_dir=True)
 
         ```
-        - includes_filter -- see self.include_glob_filter for which .h files are automatically deployed during artifactory packaging
-             This setting applies to the entire target!
-        - as_includes_root -- if set, then this include_path is the root of all includes, any directory prefixes
-                              are stripped. For example:
+        - include_path -- the include folder to export
+        - build_dir -- [False] resolve include_path against the build directory
+        - includes_filter -- [None] replaces self.include_glob_filter, the header suffixes deployed
+             during artifactory packaging. This setting applies to the entire target!
+        - as_includes_root -- [False] if set, this include_path is the root of all includes and
+                              mama strips any directory prefix. For example:
                               self.export_include('src/mylib', as_includes_root='mylib')
-                              --> 'deploy/include/mylib/\\*' instead of 'deploy/include/src/mylib/\\*'
+                              -> 'deploy/include/mylib/\\*' instead of 'deploy/include/src/mylib/\\*'
         """
         if includes_filter is not None:
             self.include_glob_filter = includes_filter
@@ -520,17 +532,18 @@ class BuildTarget:
     def export_includes(self, include_paths=[''], build_dir=False,
                         includes_filter=None):
         """
-        CUSTOM PACKAGE INCLUDES (if self.default_package() is insufficient)
+        CUSTOM PACKAGE INCLUDES (if self.default_package() is insufficient).
 
-        Export include paths relative to source directory
-        OR if build_dir=True, then relative to build directory
-        Example:
+        Exports include paths relative to the source directory.
+        If build_dir=True, the paths are relative to the build directory.
         ```
         self.export_includes(['include', 'src/moreincludes'])
         self.export_includes(['installed/include', 'installed/src/moreincludes'], build_dir=True)
         ```
-        - includes_filter -- see self.include_glob_filter for which .h files are automatically deployed during artifactory packaging
-             This setting applies to the entire target!
+        - include_paths -- [['']] the include folders to export
+        - build_dir -- [False] resolve the paths against the build directory
+        - includes_filter -- [None] replaces self.include_glob_filter, the header suffixes deployed
+             during artifactory packaging. This setting applies to the entire target!
         """
         if includes_filter is not None:
             self.include_glob_filter = includes_filter
@@ -540,15 +553,17 @@ class BuildTarget:
 
     def export_lib(self, relative_path, src_dir=False, build_dir=True):
         """
-        CUSTOM PACKAGE LIBS (if self.default_package() is insufficient)
+        CUSTOM PACKAGE LIBS (if self.default_package() is insufficient).
 
-        Export a specific lib relative to build directory
-        OR if src_dir=True, then relative to source directory
-        Example:
+        Exports one lib relative to the build directory.
+        If src_dir=True, the path is relative to the source directory.
         ```
         self.export_lib('mylib.a')                    # from build dir
         self.export_lib('lib/mylib.a', src_dir=True)  # from project source dir
         ```
+        - relative_path -- path of the lib
+        - src_dir -- [False] resolve against the source directory
+        - build_dir -- [True] resolve against the build directory
         """
         if src_dir and build_dir:
             build_dir = False
@@ -557,12 +572,16 @@ class BuildTarget:
 
     def export_libs(self, path = '.', pattern_substrings = ['.lib', '.a'], src_dir=False, build_dir=True, order=None):
         """
-        CUSTOM PACKAGE LIBS (if self.default_package() is insufficient)
+        CUSTOM PACKAGE LIBS (if self.default_package() is insufficient).
 
-        Export several libs relative to build directory using EXTENSION MATCHING
-        OR if src_dir=True, then relative to source directory
+        Exports several libs relative to the build directory using EXTENSION MATCHING.
+        If src_dir=True, the path is relative to the source directory.
 
-        Example:
+        - path -- ['.'] folder to search
+        - pattern_substrings -- [['.lib', '.a']] substrings that select the files
+        - src_dir -- [False] resolve against the source directory
+        - build_dir -- [True] resolve against the build directory
+        - order -- [None] partial lib names that set the link order, for the Linux linker
         ```
         self.export_libs()                     # gather any .lib or .a from build dir
         self.export_libs('.', ['.dll', '.so']) # gather any .dll or .so from build dir
@@ -583,12 +602,12 @@ class BuildTarget:
 
     def export_asset(self, asset, category=None, src_dir=True, build_dir=False):
         """
-        Exports a single asset file from this target
-        This can be later used when creating a deployment
+        Exports a single asset file from this target for later deployment.
 
-        category -- (optional) Can be used for grouping the assets and flattening folder structure
-
-        Example:
+        - asset -- path of the asset file
+        - category -- [None] groups the assets and flattens the folder structure
+        - src_dir -- [True] resolve against the source directory
+        - build_dir -- [False] resolve against the build directory
         ```
         self.export_asset('extras/csharp/NanoMesh.cs')
             --> {deploy}/extras/csharp/NanoMesh.cs
@@ -604,12 +623,13 @@ class BuildTarget:
 
     def export_assets(self, assets_path: str, pattern_substrings = [], category=None, src_dir=True, build_dir=False):
         """
-        Performs a GLOB recurse, using specific pattern substrings.
-        This can be later used when creating a deployment
+        Exports asset files with a recursive glob for later deployment.
 
-        category -- (optional) Can be used for grouping the assets and flattening folder structure
-
-        Example:
+        - assets_path -- folder to search
+        - pattern_substrings -- [[]] substrings that select the files
+        - category -- [None] groups the assets and flattens the folder structure
+        - src_dir -- [True] resolve against the source directory
+        - build_dir -- [False] resolve against the build directory
         ```
         self.export_assets('extras/csharp', ['.cs'])
             --> {deploy}/extras/csharp/NanoMesh.cs
@@ -625,18 +645,22 @@ class BuildTarget:
 
     def export_syslib(self, name: str, apt='', required=True):
         """
-        For UNIX: Find and export system libraries so they are automatically linked with mamabuild.
+        For UNIX: finds and exports a system library so mamabuild links it automatically.
 
-        :returns: TRUE if syslib was exported; FALSE if required=False and syslib not found
+        - name -- name of the system library
+        - apt -- [''] name of the apt package that provides the library, used in the error hint
+        - required -- [True] if False, a missing syslib is not an error
+
+        :returns: TRUE if the syslib export succeeded. FALSE if required=False and the search failed.
         ```
             self.export_syslib('uuid')
-            # will attempt to find system library in this order:
+            # searches the system library in this order:
             #   1. uuid
             #   2. libuuid.so
             #   3. libuuid.a
 
             self.export_syslib('dw', 'libdw-dev')
-            # upon failure, recommend user to install missing package from `apt install libdw-dev`
+            # on failure, tells the user to install the package: `apt install libdw-dev`
         ```
         """
         return package.export_syslib(self, name, apt, required)
@@ -645,11 +669,11 @@ class BuildTarget:
     def inject_env(self):
         """
         Injects default platform and target specific environment variables.
-        This can be used when performing full custom build step:
+        Use this for a full custom build step:
         ```
             def build(self):
                 self.inject_env()       # prepare platform
-                self.my_custom_build()  #
+                self.my_custom_build()
         ```
         """
         cmake.inject_env(self)
@@ -672,8 +696,8 @@ class BuildTarget:
 
     def add_cxx_flags(self, *flags):
         """
-        Adds C++ flags for compilation step.
-        Supports many different usages: strings, list of strings, kwargs, or space separate string.
+        Adds C++ flags for the compilation step.
+        Accepts strings, lists of strings, or space separated strings.
         ```
             self.add_cxx_flags('-Wall')
             self.add_cxx_flags(['-Wall', '-std=c++17'])
@@ -688,13 +712,13 @@ class BuildTarget:
 
     def add_c_flags(self, *flags):
         """
-        Adds C flags for compilation step.
-        Supports many different usages: strings, list of strings, kwargs, or space separate string.
+        Adds C flags for the compilation step.
+        Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_cxx_flags('-Wall')
-            self.add_cxx_flags(['-Wall', '-std=c99'])
-            self.add_cxx_flags('-Wall', '-std=c99')
-            self.add_cxx_flags('-Wall -std=c99')
+            self.add_c_flags('-Wall')
+            self.add_c_flags(['-Wall', '-std=c99'])
+            self.add_c_flags('-Wall', '-std=c99')
+            self.add_c_flags('-Wall -std=c99')
         ```
         """
         for flag in flags:
@@ -704,13 +728,13 @@ class BuildTarget:
 
     def add_cl_flags(self, *flags):
         """
-        Adds C AND C++ flags for compilation step.
-        Supports many different usages: strings, list of strings, kwargs, or space separate string.
+        Adds C AND C++ flags for the compilation step.
+        Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_cxx_flags('-Wall')
-            self.add_cxx_flags(['-Wall', '-march=native'])
-            self.add_cxx_flags('-Wall', '-march=native')
-            self.add_cxx_flags('-Wall -march=native')
+            self.add_cl_flags('-Wall')
+            self.add_cl_flags(['-Wall', '-march=native'])
+            self.add_cl_flags('-Wall', '-march=native')
+            self.add_cl_flags('-Wall -march=native')
         ```
         """
         for flag in flags:
@@ -722,8 +746,8 @@ class BuildTarget:
 
     def add_ld_flags(self, *flags):
         """
-        Adds flags for linker step; No platform checking is done.
-        Supports many different usages: strings, list of strings, kwargs, or space separate string
+        Adds flags for the linker step. Mama does no platform check here.
+        Accepts strings, lists of strings, or space separated strings.
         ```
             self.add_ld_flags('-rdynamic')
             self.add_ld_flags(['-rdynamic', '-s'])
@@ -738,7 +762,7 @@ class BuildTarget:
 
     def add_platform_cxx_flags(self, **platforms):
         """
-        Adds C / C++ flags depending on the configuration platform. @see select() for the platform names.
+        Adds C++ flags for the active platform. @see select() for the platform names.
         ```
             self.add_platform_cxx_flags(linux='-fPIC', windows='/W4')
             self.add_platform_cxx_flags(imx8mp=['-Wall', '-std=c++17'])
@@ -750,7 +774,7 @@ class BuildTarget:
 
     def add_platform_ld_flags(self, **platforms):
         """
-        Adds linker flags depending on the configuration platform. @see select() for the platform names.
+        Adds linker flags for the active platform. @see select() for the platform names.
         ```
             self.add_platform_ld_flags(windows='/LTCG', ios=['-lobjc', '-rdynamic'], linux='-rdynamic -s')
         ```
@@ -784,7 +808,10 @@ class BuildTarget:
 
     def enable_from_env(self, name, enabled='ON', force=False):
         """
-        Adds a CMake option if the environment variable `name` is set.
+        Adds a CMake option if the environment variable `name` is set to 1, ON or TRUE.
+        - name -- the environment variable to check
+        - enabled -- ['ON'] the value the CMake option gets
+        - force -- [False] add the option even when the variable is not set
         ```
             self.enable_from_env('BUILD_TESTS')
         ```
@@ -824,9 +851,10 @@ class BuildTarget:
 
     def requires_version(self, min_version: str):
         """
-        Require a minimum mamabuild version for this mamafile. Aborts the build immediately (during
-        target load, before any configure/build work) with an upgrade hint when the running mama is
-        older, instead of failing later on an API this mama doesn't have.
+        Require a minimum mamabuild version for this mamafile. When the running mama is older,
+        this stops the build during target load, before any configure or build work.
+        The error message includes an upgrade hint, instead of a late failure on a missing API.
+        - min_version -- the minimum mamabuild version, for example '0.13.01'
         ```
             def settings(self):
                 self.requires_version('0.13.01')
@@ -920,14 +948,16 @@ class BuildTarget:
 
     def copy(self, src: str, dst: str, filter: list = None):
         """
-        Utility for copying files and folders
+        Copies files and folders.
         ```
             # copies built .so into an android archive
             self.copy(self.build_dir('libAwesome.so'),
                       self.source_dir('deploy/Awesome.aar/jni/armeabi-v7a'))
         ```
-        - filter: can be a string or list of strings to filter files by suffix
-                  example: filter=['.h'] or filter='.hpp'
+        - src -- source file or folder
+        - dst -- destination path
+        - filter -- [None] a string or list of strings that filter files by suffix,
+                    for example filter=['.h'] or filter='.hpp'
         """
         if util.copy_if_needed(src, dst, filter):
             if self.config.verbose: console(f'copy {src} --> {dst}')
@@ -935,7 +965,9 @@ class BuildTarget:
 
     def copy_built_file(self, builtFile: str, copyToFolder: str):
         """
-        Utility for copying files within the build directory.
+        Copies a file within the build directory.
+        - builtFile -- source path relative to the build directory
+        - copyToFolder -- destination folder relative to the build directory
         ```
             self.copy_built_file('RelWithDebInfo/libawesome.a', 'lib')
         ```
@@ -950,7 +982,10 @@ class BuildTarget:
 
     def copy_deployed_folder(self, src_dir: str, dst_dir: str, filter: list = None):
         """
-        Utility for copying folders from source dir.
+        Copies a folder from the source directory.
+        - src_dir -- source folder relative to the source directory
+        - dst_dir -- destination folder path
+        - filter -- [None] a string or list of strings that filter files by suffix
         ```
             self.copy_deployed_folder('deploy/NanoMesh', 'C:/Projects/Game/Plugins')
             # --> 'C:/Projects/Game/Plugins/NanoMesh
@@ -964,7 +999,10 @@ class BuildTarget:
 
     def download_file(self, remote_url: str, local_dir: str, force=False):
         """
-        Downloads a file if it doesn't already exist.
+        Downloads a file if it does not already exist.
+        - remote_url -- URL to download from
+        - local_dir -- destination folder
+        - force -- [False] download even when the file exists
         ```
             self.download_file('http://example.com/file1', 'bin')
             # --> 'bin/file1'
@@ -975,9 +1013,10 @@ class BuildTarget:
 
     def download_and_unzip(self, remote_zip: str, extract_dir: str, unless_file_exists=None):
         """
-        Downloads and unzips an archive if it doesn't already exist.
-
-        unless_file_exists -- If the specified file exists, then download and unzip steps are skipped.
+        Downloads and unzips an archive if it does not already exist.
+        - remote_zip -- URL of the archive
+        - extract_dir -- destination folder for extraction
+        - unless_file_exists -- [None] if this file exists, skip the download and unzip steps
         ```
             self.download_and_unzip('http://example.com/archive.zip',
                                     'bin', 'bin/unzipped_file.txt')
@@ -1000,9 +1039,9 @@ class BuildTarget:
 
     def disable_ninja_build(self):
         """
-        Use this to completely disable Ninja build for this target
-        By default, if Ninja build is detected, non-MSVC builds use Ninja for faster builds.
-        Use this if you want to, for example, generate Xcode project:
+        Completely disables the Ninja build for this target.
+        By default, when mama detects Ninja, non-MSVC builds use Ninja for faster builds.
+        Use this for example to generate an Xcode project:
         ```
             if self.ios or self.macos:
                 self.disable_ninja_build()
@@ -1013,8 +1052,8 @@ class BuildTarget:
 
     def enable_fortran(self, path=''):
         """
-        Enable fortran for this target only
-        path -- Optional custom path or command for the Fortran compiler
+        Enables Fortran for this target only.
+        - path -- [''] optional custom path or command for the Fortran compiler
         ```
             self.enable_fortran()   # attempt to autodetect fortran
             self.enable_fortran('/SysGCC/bin/gfortran')  # specify fortran explicitly
@@ -1026,7 +1065,7 @@ class BuildTarget:
 
     def disable_cxx_compiler(self):
         """
-        Disable any C++ options and C++ compiler configuration
+        Disables all C++ options and the C++ compiler configuration.
         ```
             def configure(self):
                 self.disable_cxx_compiler()
@@ -1037,7 +1076,7 @@ class BuildTarget:
 
     def nothing_to_build(self):
         """
-        Call this to completely skip the build step every time
+        Call this to skip the build step every time.
         ```
             def dependencies(self):
                 self.nothing_to_build()
@@ -1055,16 +1094,17 @@ class BuildTarget:
                     configure='configure'):
         """
         Creates a new GnuProject instance for building GNU projects from source.
-        - name: name of the project, eg 'gmp'
-        - version: version of the project, eg '6.2.1'
-        - build_products: the final products to build, eg [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
-                          Supported project variables {{installed}}, {{source}}, {{build}}
-        - url: url to download the project, eg 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
-        - git: git to clone the project from
-        - autogen: whether to use ./autogen.sh before running ./configure
-        - configure: the configuration command, by default 'configure' but can be 'make config' etc
+        - name -- name of the project, for example 'gmp'
+        - version -- version of the project, for example '6.2.1'
+        - url -- [''] URL to download the project, for example 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
+        - git -- [''] git URL to clone the project from
+        - build_products -- [[]] the final products to build, for example
+                            [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
+                            Supported project variables: {{installed}}, {{source}}, {{build}}
+        - autogen -- [False] run ./autogen.sh before ./configure
+        - configure -- ['configure'] the configuration command, can also be 'make config' etc
         ```
-            gmp = self.gnu_project('gmp', '6.2.1', 'https://gmplib.org/download/gmp/{{project}}.tar.xz', 'lib/libgmp.a')
+            gmp = self.gnu_project('gmp', '6.2.1', url='https://gmplib.org/download/gmp/{{project}}.tar.xz')
             gmp.configure()
         ```
         """
@@ -1074,24 +1114,27 @@ class BuildTarget:
 
     def get_cc_prefix(self):
         """
-        Useful for crosscompiling builds, returns the prefix of the compiler, eg '/usr/bin/mipsel-linux-gnu-'
+        Returns the compiler prefix for cross-compiling builds, for example '/usr/bin/mipsel-linux-gnu-'.
+        Returns None when the compiler has no prefix.
         """
         cc = self.config.get_preferred_compiler_paths()[0]
         filename = os.path.basename(cc)
         if filename.endswith('gcc'):
             filename = filename[:-3]
         else:
-            return None # there is no prefix it's something like /usr/bin/gcc-11
+            return None # no prefix, the compiler is something like /usr/bin/gcc-11
         return util.path_join(os.path.dirname(cc), filename)
 
 
     def run(self, command: str, src_dir=False, exit_on_fail=True, quiet=False):
         """
-        Run a command in the build or source folder.
-        Can be used for any custom commands or custom build systems.
-        src_dir -- [False] If true, then command is relative to source directory.
-        quiet   -- [False] Suppress the command's output entirely (it still runs and is exit-checked).
-                   Use for noisy sub-steps like a script's own `git clone`.
+        Runs a command in the build or source folder.
+        Use this for custom commands or custom build systems.
+        - command -- the command line to run
+        - src_dir -- [False] if True, the command runs relative to the source directory
+        - exit_on_fail -- [True] exit the build when the command fails
+        - quiet -- [False] suppress all output of the command. Mama still runs it and
+                   checks the exit code. Use for a noisy sub-step like a script's own `git clone`.
         ```
             self.run('./configure', src_dir=True)
             self.run('make release -j7') # run in build dir
@@ -1103,7 +1146,11 @@ class BuildTarget:
 
     def run_program(self, working_dir: str, command: str, exit_on_fail=True, env=None):
         """
-        Run any program in any directory. Can be used for custom tools.
+        Runs any program in any directory. Use this for custom tools.
+        - working_dir -- the directory to run in
+        - command -- the command line to run
+        - exit_on_fail -- [True] exit the build when the program fails
+        - env -- [None] optional environment variables dict
         ```
             self.run_program(self.source_dir('bin'),
                              self.source_dir('bin/DbTool'))
@@ -1114,10 +1161,13 @@ class BuildTarget:
 
     def run_with_gdb(self, command: str, args: str, src_dir=True, gdb_by_default=True):
         """
-        Run a program with gdb if requested, otherwise run normally.
+        Runs a program with gdb if requested, otherwise runs it normally.
         To control this, add 'gdb' or 'nogdb' to args.
-        The parameter `gdb` controls what the default behavior is.
-        If used inside start(), then `mama start=nogdb` or `mama start=gdb` will control GDB enablement
+        Inside start(), `mama start=gdb` or `mama start=nogdb` controls the GDB enablement.
+        - command -- the program to run
+        - args -- argument string, 'gdb' and 'nogdb' are filtered out
+        - src_dir -- [True] run relative to the source directory
+        - gdb_by_default -- [True] the default when args select neither
         """
         args, gdb = filter_gdb_arg(args, gdb_by_default)
         if gdb:
@@ -1128,7 +1178,8 @@ class BuildTarget:
 
     def gdb(self, command: str, src_dir=True):
         """
-        Run a command with gdb in the build folder.
+        Runs a command with gdb in the source folder.
+        If src_dir=False, runs in the build folder.
         ```
             self.gdb('bin/NanoMeshTests')
         ```
@@ -1138,14 +1189,13 @@ class BuildTarget:
 
     def gtest(self, executable: str, args: str, src_dir=True, gdb=False):
         """
-        Runs a gtest executable with gdb by default.
-        The gtest report is written to $src_dir/test/report.xml.
-        Arguments
+        Runs a gtest executable.
+        Writes the gtest report to {source_dir}/test/report.xml.
         - executable -- which executable to run
-        - args -- a string of options separated by spaces,
-          'gdb', 'nogdb' or gtest fixture/test partial name
-        - src_dir -- [True] If true, then executable is relative to source directory.
-        - gdb -- [False] If true, then run with gdb.
+        - args -- a string of options separated by spaces:
+          'gdb', 'nogdb' or a gtest fixture/test partial name
+        - src_dir -- [True] if True, the executable path is relative to the source directory
+        - gdb -- [False] if True, run with gdb
         ```
             self.gtest("bin/MyAppGtests", "nogdb", src_dir=True)
             self.gtest("bin/MyAppGtests", "MyFixtureName.TheTestName", src_dir=True)
@@ -1159,28 +1209,27 @@ class BuildTarget:
 
     def init(self):
         """
-        Perform any initialization steps right after the mamafile is loaded.
+        Perform any initialization steps right after mama loads the mamafile.
         ```
         class MyProject(mama.BuildTarget):
             def init(self):
                 self.version = '1.2.3'
+        ```
         """
         pass
 
 
-
-
     def settings(self):
         """
-        Define any settings at this stage, it is always
-        the first step after git clone or loading from artifactory.
-
+        Define any settings at this stage. This is always the first step
+        after git clone or after loading from artifactory.
         ```
         class MyProject(mama.BuildTarget):
             def settings(self):
                 # only valid for root targets
                 self.set_artifactory_ftp('artifacts.myftp.com', auth='store')
                 self.nothing_to_build()
+        ```
         """
         pass
 
@@ -1188,10 +1237,10 @@ class BuildTarget:
     def dependencies(self):
         """
         Add any additional dependencies in this step,
-        or setup project configuration for root targets.
+        or configure the project for root targets.
 
-        If this target is fetched as a package from the artifactory,
-        then any add_git()/add_local() calls will be ignored.
+        If this target was fetched as an artifactory package,
+        mama ignores any add_git()/add_local() calls.
         ```
         class MyRootProject(mama.BuildTarget):
             def dependencies(self):
@@ -1219,7 +1268,7 @@ class BuildTarget:
 
     def build(self):
         """
-        Build this target. By default it uses CMake build.
+        Builds this target. The default is a CMake build.
         """
         self.cmake_build()
 
@@ -1233,14 +1282,14 @@ class BuildTarget:
 
     def disable_install(self):
         """
-        Sets self.install_target to None, which disables the CMake install step.
+        Clears self.install_target, which disables the CMake install step.
         """
         self.install_target = ''
 
 
     def install(self):
         """
-        Perform custom install steps here. By default it uses CMake install.
+        Perform custom install steps here. The default is a CMake install.
         """
         self.cmake_install()
 
@@ -1248,12 +1297,13 @@ class BuildTarget:
     def package(self):
         """
         Perform any post-build steps to package the products.
-        If no headers or libs are exported, then `default_package()` will be run instead
+        If package() exports no includes, mama runs default_package_includes().
+        If it exports no libs, mama runs default_package_libs().
 
         Every library should at least export some headers.
         ```
         def package(self):
-            # use the built-in default packing
+            # use the built-in default packaging
             self.default_package()
             # custom export AGL as include from source folder
             self.export_includes(['AGL'])
@@ -1294,7 +1344,7 @@ class BuildTarget:
             self.default_package_includes()
         ```
         """
-        # try multiple common/popular C and C++ library include patterns
+        # try common C and C++ library include patterns
         if   self.export_include('include', build_dir=True):  pass
         elif self.export_include('include', build_dir=False): pass
         elif self.export_include('src',     build_dir=False, as_includes_root=self.name): pass
@@ -1311,7 +1361,6 @@ class BuildTarget:
             self.default_package_libs()
         ```
         """
-        # default export from {build_dir}/{cmake_build_type}
         if self.export_libs(self.cmake_build_type, src_dir=False): pass
         elif self.export_libs('lib', src_dir=False): pass
         elif self.export_libs('.', src_dir=False): pass
@@ -1319,7 +1368,7 @@ class BuildTarget:
 
     def deploy(self):
         """
-        Custom deployment stage. Built in support for PAPA packages:
+        Custom deployment stage. Built-in support for PAPA packages:
         ```
         def deploy(self):
             self.papa_deploy('deploy/NanoMesh')
@@ -1341,17 +1390,18 @@ class BuildTarget:
                     r_includes=False, r_dylibs=False,
                     r_syslibs=False, r_assets=False):
         """
-        This will create a PAPA package, which includes
+        Creates a PAPA package, which includes:
             package_path/papa.txt
             package_path/{includes}
             package_path/{libs}
             package_path/{assets}
 
-        src_dir -- Whether package will be deployed to src dir or build dir
-        r_includes -- Whether to recursively export includes from dynamic libaries
-        r_dylibs   -- Whether to recursively export all *.dll *.so *.dylib libraries
-        r_syslibs  -- Whether to include system libraries from child dependencies
-        r_assets   -- Whether to include assets from child dependencies
+        - package_path -- where to deploy the package
+        - src_dir -- [False] deploy to the source dir instead of the build dir
+        - r_includes -- [False] recursively export includes from dynamic libraries
+        - r_dylibs -- [False] recursively export all *.dll *.so *.dylib libraries
+        - r_syslibs -- [False] include system libraries from child dependencies
+        - r_assets -- [False] include assets from child dependencies
 
         Example: `self.papa_deploy('MyPackageName')`
 
@@ -1369,7 +1419,7 @@ class BuildTarget:
             A someassets/extra.txt
         """
         if self.config.list:
-            return # don't deploy during listing
+            return # no deploy during listing
         build_dir = not src_dir
         self.papa_path = package.target_root_path(self, package_path, build_dir=build_dir)
         papa_deploy_to(self, self.papa_path, \
@@ -1379,14 +1429,14 @@ class BuildTarget:
 
     def test(self, args):
         """
-        Perform test steps here with test args.
+        Perform test steps here with the test args.
         `mama test arg1 arg2 arg3`
+        - args -- the argument string from the `mama test` command line
         ```
             def test(self, args):
-                # simply runs an executable with GDB
+                # runs an executable with GDB
                 self.gdb(f'RppTests {args}')
-                # or run gtest executable, with GDB by default
-                # or you can provide `nogdb` argument to disable GDB
+                # or runs a gtest executable, pass 'gdb' in args to enable GDB
                 self.gtest(f'bin/project_gtests', args, src_dir=True)
         ```
         """
@@ -1395,8 +1445,9 @@ class BuildTarget:
 
     def start(self, args):
         """
-        Start a custom process through mama
+        Start a custom process through mama.
         `mama target start=arg`
+        - args -- the argument string from the `mama start=...` command line
         ```
         def start(self, args):
             if 'dbtool' in args:
@@ -1422,20 +1473,21 @@ class BuildTarget:
 
 
     def _cmake_configure_step(self, out=None):
-        """CMake configure half of a build: ensure CMakeLists, inject env, run config."""
+        """CMake configure half of a build: check CMakeLists, inject env, run config."""
         self.dep.ensure_cmakelists_exists()
         cmake.inject_env(self)
         cmake.run_config(self, out=out) # THROWS on CMAKE failure
 
     def _cmake_build_step(self, out=None):
-        """CMake build+install half. -j was sized from the TU probe in configure_phase; size it
-        here too for the serial path (where configure_phase didn't run)."""
+        """CMake build+install half. configure_phase sized -j from the TU probe.
+        Size it here too for the serial path, where configure_phase did not run."""
         self._ensure_build_jobs()
         cmake.run_build(self, install=True, out=out) # THROWS on CMAKE failure
 
     def _probe_build_jobs(self) -> int:
-        """TU count capped at config.jobs. 0 when nothing's countable (header-only / artifactory /
-        probe miss) -> weight 0, reserves no budget, never blocks real builds (it's a no-op anyway)."""
+        """TU count capped at config.jobs. Returns 0 when nothing is countable: header-only,
+        artifactory, or a probe miss. Weight 0 reserves no budget and never blocks real builds,
+        because such a build is a no-op."""
         try:
             n = self._count_tu()[0]
             if n > 0: return min(n, self.config.jobs)
@@ -1443,22 +1495,22 @@ class BuildTarget:
         return 0
 
     def _ensure_build_jobs(self) -> int:
-        """Lazily memoize the TU-probed -j. configure_phase sets it authoritatively post-configure;
-        this fills it in for the serial path / sched_debug where configure_phase never ran."""
+        """Lazily memoizes the TU-probed -j. configure_phase sets it authoritatively after configure.
+        This fills it in for the serial path and sched_debug, where configure_phase never ran."""
         if self._build_jobs is None: self._build_jobs = self._probe_build_jobs()
         return self._build_jobs
 
     def _reserved_cores(self) -> int:
-        """Budget cores this build occupies: the memoized TU probe (== its actual -j), capped at the
-        FULL pool. Reservation must equal -j so a heavy build (-j = all cores) reserves the whole pool
-        and runs ALONE at full threads instead of being oversubscribed against another full-j build;
-        small builds reserve little and pack. The CPU gate still overprovisions non-saturating builds.
-        0 when unsizable (header-only / probe miss)."""
+        """Budget cores this build occupies: the memoized TU probe, equal to its actual -j, capped at
+        the FULL pool. The reservation must equal -j. A heavy build with -j = all cores then reserves
+        the whole pool and runs ALONE at full threads, never oversubscribed against another full-j
+        build. Small builds reserve little and pack. The CPU gate still overprovisions builds that do
+        not saturate. Returns 0 when unsizable: header-only, or a probe miss."""
         if not self._ensure_build_jobs(): return 0
         return min(self._build_jobs, self.config.jobs)
 
     def _count_tu(self) -> tuple:
-        """(TU count, method) - generator-agnostic, most-accurate first:
+        """(TU count, method) - generator-agnostic, most accurate first:
           compile_commands.json          (Ninja, or Make/VS only when export is on) -> "file" entries
           *.vcxproj                       (Visual Studio generator)                  -> <ClCompile Include=>
           CMakeFiles/**/DependInfo.cmake  (Unix Makefiles, export off)               -> one object per TU
@@ -1499,8 +1551,8 @@ class BuildTarget:
         self._cmake_configure_step()
         config_stop = time.time()
         build_start = config_stop
-        # Barrier: a custom build() reaches here on a worker thread; suspend until the parallel
-        # scheduler grants budget for the compile (no-op on the serial path / no active scheduler).
+        # Barrier: a custom build() reaches here on a worker thread. Suspend until the parallel
+        # scheduler grants budget for the compile. No-op on the serial path or without a scheduler.
         with build_barrier(self._reserved_cores()):
             self._cmake_build_step()
         build_stop = time.time()
@@ -1543,7 +1595,6 @@ class BuildTarget:
         return self.dep.is_current_target()
 
 
-    ## Build only this target
     def _execute_tasks(self):
         if self.dep.already_executed:
             return
@@ -1563,10 +1614,8 @@ class BuildTarget:
         if not self.dep.can_fetch_artifactory(print=True, which='AUTO'):
             return None
 
-        # auto-fetch if:
-        # - is not the root project, roots should never be fetched
-        # - not a deploy/upload task
-        # - not the current build target eg `mama build this_target`
+        # Auto-fetch only for a non-root current target, a root never fetches.
+        # Never for a build, deploy or upload command, those must build locally.
         is_target = not self.dep.is_root and self.is_current_target()
         is_deploy = self.config.deploy or self.config.upload
         is_build = self.config.build
@@ -1577,12 +1626,12 @@ class BuildTarget:
 
 
     def _build_work_enabled(self) -> bool:
-        """True when this target has real build work (not header-only, not artifactory, flagged for rebuild)."""
+        """True when this target has real build work: not header-only, not from artifactory, flagged for rebuild."""
         return not self.dep.nothing_to_build and self.dep.should_rebuild and not self.dep.from_artifactory
 
     def _has_custom_build(self) -> bool:
-        """A mamafile overriding build() fuses cmake configure+build, so it can't be split;
-        the scheduler runs it whole in build_phase and skips the separate configure step."""
+        """A mamafile that overrides build() fuses cmake configure+build, so the split is impossible.
+        The scheduler runs it whole in build_phase and skips the separate configure step."""
         return type(self).build is not BuildTarget.build
 
     def _run_configure_once(self):
@@ -1593,25 +1642,25 @@ class BuildTarget:
 
     def configure_phase(self, out=None):
         """Scheduled CONFIGURE job: user configure() hook + cmake configure. No-op for a
-        no-work node or a custom build() (which owns its own configure inside build_phase)."""
-        self._out_sink = out  # so a custom build()'s cmake output is captured too, not just the default path
+        no-work node or a custom build(), which owns its own configure inside build_phase."""
+        self._out_sink = out  # capture cmake output from a custom build() too, not just the default path
         if not self._build_work_enabled() or self._has_custom_build():
             return
         self._run_configure_once()
         self._fetched = self.try_automatic_artifactory_fetch()
         if not self._fetched:
             self._cmake_configure_step(out=out)
-            # Size build weight NOW (compile_commands.json exists) so the scheduler knows the core
-            # count at BUILD launch; left None it falls back to all cores -> serial builds.
+            # Size the build weight NOW, while compile_commands.json exists, so the scheduler knows
+            # the core count at BUILD launch. Left None it falls back to all cores -> serial builds.
             self._build_jobs = self._probe_build_jobs()
 
     def build_phase(self, out=None):
-        """Scheduled BUILD job: compile (if any) then ALWAYS package - so no-work nodes
-        still package their exports in dependency order. Mirrors _execute_build_tasks."""
+        """Scheduled BUILD job: compile if needed, then ALWAYS package, so a no-work node
+        still packages its exports in dependency order. Mirrors _execute_build_tasks."""
         self._out_sink = out  # captures cmake output from a custom build()->cmake_build() too
         if self._build_work_enabled():
             if self._has_custom_build():
-                self._run_configure_once() # custom build's configure_phase was a no-op
+                self._run_configure_once() # configure_phase was a no-op for a custom build()
                 self._fetched = self.try_automatic_artifactory_fetch()
                 if not self._fetched:
                     self.build() # user override owns configure+build
@@ -1635,19 +1684,19 @@ class BuildTarget:
 
     def _run_packaging(self):
         # package() is user mamafile code that asserts on build outputs, so it needs something to
-        # package. Commands that walk the task chain WITHOUT building (wipe, upload, deploy, test)
-        # would otherwise run it against artifacts never produced, or ones a clean/wipe just deleted.
+        # package. Wipe, upload, deploy and test walk the task chain without building. They would
+        # otherwise run package() against artifacts never produced, or ones a wipe just deleted.
         if not self._build_work_enabled() and not self.dep.has_usable_artifacts():
             if self.config.verbose or self.config.deploy or self.config.upload:
                 warning(f'  - Target {self.name: <16} PACKAGE skipped: nothing built, no artifacts on disk')
             return
 
-        # skip package() if we already fetched it as a package from artifactory()
-        # unless user has specified for a local rebuild
+        # Skip package() when mama already fetched the target from artifactory,
+        # unless the user asked for a local rebuild.
         if self.dep.should_rebuild or not self.dep.from_artifactory:
             self.packaging_result = 'target.package()'
-            # clear libs which were loaded during aritfactory_load_target()
-            # since we're repackaging, we want to have a clean slate of unpolluted exports
+            # Clear the libs that artifactory_load_target() loaded, so the
+            # repackaging starts from empty, unpolluted exports.
             old_includes = self.exported_includes
             old_libs = self.exported_libs
             old_syslibs = self.exported_syslibs
@@ -1665,13 +1714,13 @@ class BuildTarget:
             #  - export_asset() / export_assets()
             self.package() # user customization
 
-            # no packaging provided by user; use default packaging instead
+            # the user provided no packaging, use the default packaging instead
             if not self.exported_includes and not self.no_includes:
                 self.default_package_includes()
             if not (self.exported_libs or self.exported_syslibs) and not self.no_libs:
                 self.default_package_libs()
 
-            # if packages changed, then consider local papafile as stale
+            # if the exports changed, the local papa file is stale
             exports_changed = (old_includes != self.exported_includes or
                                old_libs != self.exported_libs or
                                old_syslibs != self.exported_syslibs or
@@ -1687,15 +1736,15 @@ class BuildTarget:
         elif not self.dep.should_rebuild:
             self.packaging_result = 'local-cache'
         else:
-            self.packaging_result = 'unknown' # if this happens, you didn't update the elif cases above
+            self.packaging_result = 'unknown' # if this happens, update the elif cases above
 
         if self.config.verbose:
             console(f'  - {self.name} package info loaded from [{self.packaging_result}]', color=Color.BLUE)
 
-        # only save and print exports if we built anything
+        # save and print exports only when the build dir exists
         if self.dep.build_dir_exists():
             self.dep.save_exports_as_dependencies(self.exported_libs)
-            # print exports only if target match
+            # print exports only for the current target
             if self.is_current_target():
                 self.print_exports()
 
@@ -1710,8 +1759,8 @@ class BuildTarget:
         if not (for_all or no_targets or one_target):
             return # not going to deploy
 
-        # Shim is read-only: its papa.txt and unzipped tree must not be overwritten
-        # by a re-deploy or re-upload. The artifactory already has the package.
+        # The shim is read-only. A re-deploy or re-upload must not overwrite its
+        # papa.txt and unzipped tree. The artifactory already has the package.
         if self.dep.is_artifactory_shim():
             if self.config.print:
                 warning(f'  - Target {self.name: <16} DEPLOY/UPLOAD skipped (artifactory shim, already on artifactory)')
@@ -1727,8 +1776,8 @@ class BuildTarget:
     def _require_source(self, action: str) -> bool:
         """
         For commands that need source on disk (test, start, open),
-        refuse on shims with a clear message pointing at `mama unshallow`.
-        Returns True if the action may proceed, False if it was refused.
+        refuses on a shim with a clear message that points at `mama unshallow`.
+        Returns True when the action may proceed, False when refused.
         """
         if not self.dep.is_artifactory_shim():
             return True
@@ -1760,7 +1809,7 @@ class BuildTarget:
                 self.test(test_args)
 
         if self.config.start:
-            # start only if it's the current target or root target
+            # start only for the current target or the root target
             if self.is_current_target() or (self.dep.is_root and self.config.no_specific_target()):
                 if not self._require_source('start'):
                     return
@@ -1779,7 +1828,7 @@ class BuildTarget:
             elif path.startswith(self.source_dir()):
                 display_path = path[len(self.source_dir()) + 1:].strip()
                 if display_path == '':
-                    display_path = path # if it's exactly the source dir, keep it as is
+                    display_path = path # for the exact source dir, keep the full path
             elif path.startswith(self.config.workspaces_root):
                 display_path = path[len(self.config.workspaces_root) + 1:]
         ex = exists() if check_exists else ''
@@ -1808,8 +1857,9 @@ class BuildTarget:
 
     def ms_build(self, projectfile, properties:dict = dict()):
         """
-        Invokes MSBuild on the specificied projectfile and passes specified
-        properties to MSBuild.
+        Invokes MSBuild on the specified projectfile with the given properties.
+        - projectfile -- the solution or project file, relative to the source directory
+        - properties -- [dict()] MSBuild properties
         ```
         def build(self):
             self.cmake_build()
@@ -1818,7 +1868,7 @@ class BuildTarget:
                 'Platform': 'Any CPU',
             })
         ```
-        Default properties set by Mama if not specified via properties dict:
+        Mama sets these default properties when the properties dict does not:
         /p:PreferredToolArchitecture=x64
         /p:Configuration=Release
         /p:Platform=x64
@@ -1832,9 +1882,8 @@ class BuildTarget:
 ######################################################################################
 
 
-# The platform flags a mamafile reads off `self`, forwarded from config. Properties, not copies: they
-# used to be copied twice per target, once before init() and once after, so an init() that switched
-# platform would be seen. See README "Platform detection properties".
+# The platform flags a mamafile reads off `self`, forwarded from config. Properties, not copies,
+# so a platform switch inside init() stays visible. See README "Platform detection properties".
 for _flag in ('msvc', 'linux', 'macos', 'ios', 'android', 'raspi', 'oclea',
               'xilinx', 'mips', 'imx8mp', 'yocto_linux'):
     setattr(BuildTarget, _flag, property(lambda self, name=_flag: getattr(self.config, name)))

--- a/mama/build_target.py
+++ b/mama/build_target.py
@@ -70,11 +70,8 @@ class BuildTarget:
         self.dep  = dep
         self.args = [] # user defined args for this target (must be a list)
         self.install_target = 'install'
-        # Pins the last field of the artifactory archive name, in place of the commit hash. It MUST be a
-        # single raw string literal. Mama names a package before it clones anything. The reader,
-        # mamafile_version.py, reads this value from the mamafile TEXT and never runs the file. That
-        # reader cannot see a computed value, and it stops at the first assignment. Either shape makes
-        # the download look for one name while the upload publishes another. See the README, "Package naming".
+        # Pins the last field of the artifactory archive name, in place of the commit hash. It MUST be ONE
+        # raw string literal: mamafile_version.py reads it from the mamafile TEXT and never runs the file.
         self.version = ''
         self.cmake_ndk_toolchain   = '' # Custom Android toolchain file for this target only
         self.cmake_raspi_toolchain = '' # Custom Raspberry toolchain file for this target only
@@ -183,8 +180,8 @@ class BuildTarget:
         The child owns its own config, so this process builds no foreign config. When this build IS
         the host, returns the local build path.
 
-        - relpath -- binary path relative to the build dir, '.exe' is appended on Windows
-        - auto_build -- [True] bootstrap the host build on a miss, else return None"""
+        - relpath: binary path relative to the build dir, '.exe' is appended on Windows
+        - auto_build: [True] bootstrap the host build on a miss, else return None"""
         if System.windows and not os.path.splitext(relpath)[1]:
             relpath += '.exe'  # host tools are executables, add the suffix once for every caller
         host = self.config.host_platform_name()
@@ -199,12 +196,10 @@ class BuildTarget:
         if self.config.print:
             console(f'  - {self.name: <16} bootstrapping host binary: mama {host} build target={self.name}', color=Color.BLUE)
         # sys.executable + the mama.main entry, because there is no __main__.py for `python -m mama`.
-        # cwd is the root project so the child resolves the same dependency graph. The child computes
-        # the correct host archive name and does fetch-or-build, so this cross config never guesses it.
+        # cwd is the root project, so the child resolves the same dependency graph.
         argv = [sys.executable, '-c', 'from mama.main import __main__; __main__()', host, 'build', f'target={self.name}']
-        # io_func is MANDATORY here. Without it the child inherits our stdout, and on a pty it draws
-        # its OWN live region over ours. The two fight for the same rows and strand our task lines in
-        # the scrollback. Captured, the output feeds this target's display line, log and failure replay.
+        # io_func is MANDATORY: an inherited pty lets the child draw its own live region over ours.
+        # Captured, the output feeds this target's display line, log and failure replay.
         def child_output(p, line: str):
             line = line.rstrip()
             if line: console(f'  {self.name: <16} | {line}')
@@ -225,9 +220,8 @@ class BuildTarget:
         The ENV variables `MAMA_ARTIFACTORY_USER` and `MAMA_ARTIFACTORY_PASS`
         override the username and password, for use in build systems.
 
-        - ftp_url -- address of the Artifactory FTP server
-        - auth -- ['store'] 'store' keeps the credentials in the secure keyring of the system.
-                  If authentication fails, mama clears the stored credentials.
+        - ftp_url: address of the Artifactory FTP server
+        - auth: ['store'] 'store' keeps the credentials in the system keyring. Failed authentication clears them.
         ```
             def dependencies(self):
                 self.set_artifactory_ftp('myserver.com', auth='store')
@@ -248,12 +242,11 @@ class BuildTarget:
         If the dependency folder has no `mamafile.py`, provide your own
         relative or absolute mamafile path.
 
-        - name -- name of the dependency
-        - source_dir -- path of the local folder
-        - mamafile -- [None] optional custom mamafile path
-        - always_build -- [False] always build this dependency. Useful when chaining
-                          sub-projects that do not depend on each other.
-        - args -- [[]] extra arguments for the target mamafile, read back via `self.args`
+        - name: name of the dependency
+        - source_dir: path of the local folder
+        - mamafile: [None] optional custom mamafile path
+        - always_build: [False] always build this dependency, for chained sub-projects that do not depend on each other
+        - args: [[]] extra arguments for the target mamafile, read back via `self.args`
         ```
         self.add_local('zlib', '3rdparty/zlib')
         self.add_local('zlib', '3rdparty/zlib', mamafile='mama/zlib.py')
@@ -275,13 +268,13 @@ class BuildTarget:
 
         For a PUBLIC repository, use only an `https://` URL to prevent clone failures.
 
-        - git_url -- the git URL to clone from
-        - git_branch -- [''] branch to check out
-        - git_tag -- [''] tag to check out
-        - git_commit -- [''] commit to check out, used as the tag when git_tag is empty
-        - mamafile -- [None] optional custom mamafile path
-        - shallow -- [True] use a shallow clone
-        - args -- [[]] extra arguments for the child target, read back via `self.args`
+        - git_url: the git URL to clone from
+        - git_branch: [''] branch to check out
+        - git_tag: [''] tag to check out
+        - git_commit: [''] commit to check out, used as the tag when git_tag is empty
+        - mamafile: [None] optional custom mamafile path
+        - shallow: [True] use a shallow clone
+        - args: [[]] extra arguments for the child target, read back via `self.args`
         ```
         self.add_git('ReCpp', 'git@github.com:RedFox20/ReCpp.git')
         self.add_git('ReCpp', 'git@github.com:RedFox20/ReCpp.git', git_branch='master')
@@ -304,9 +297,9 @@ class BuildTarget:
 
         If the remote artifactory does not have this package, the build stops with an error.
 
-        - version -- ['latest'] mama picks the matching remote package for this version
-        - fullname -- [None] use only this exact artifactory package as an override.
-                      Useful for source-only packages and for platform-specific configuration.
+        - version: ['latest'] mama picks the matching remote package for this version
+        - fullname: [None] use only this exact artifactory package as an override,
+          for source-only packages and for platform-specific configuration
         ```
         self.add_artifactory_pkg('mylib', version='latest')
         self.add_artifactory_pkg('mylib', version='df76b66')
@@ -336,7 +329,7 @@ class BuildTarget:
     def find_target(self, name, recursive=True):
         """
         Finds a child BuildTarget by name.
-        - recursive -- [True] also search the children of children
+        - recursive: [True] also search the children of children
         ```
             zlib = self.find_target('zlib')
         ```
@@ -366,12 +359,12 @@ class BuildTarget:
     def inject_products(self, dst_dep, src_dep, include_path, libs, libfilters=None):
         """
         Injects products from `src_dep` into `dst_dep` as CMake defines.
-        - dst_dep -- name of the dependency that receives the defines
-        - src_dep -- name of the dependency that provides the products
-        - include_path -- name of the include define
-        - libs -- name of the library define
-        - libfilters -- [None] simple substring match over the exported libs.
-                        If nothing matches, mama picks the first exported lib.
+        - dst_dep: name of the dependency that receives the defines
+        - src_dep: name of the dependency that provides the products
+        - include_path: name of the include define
+        - libs: name of the library define
+        - libfilters: [None] simple substring match over the exported libs.
+          If nothing matches, mama picks the first exported lib.
         ```
         self.inject_products('libpng', 'zlib',
                              'ZLIB_INCLUDE_DIR', 'ZLIB_LIBRARY',
@@ -454,8 +447,8 @@ class BuildTarget:
         A project with no build dependencies always rebuilds, so make sure to
         call add_build_dependency() or export_lib().
 
-        - all -- [None] path used on every platform, relative to the build directory
-        - platforms -- per-platform paths, @see select() for the platform names
+        - all: [None] path used on every platform, relative to the build directory
+        - platforms: per-platform paths, @see select() for the platform names
         ```
             self.add_build_dependency('customProduct.dat')
             self.add_build_dependency(windows='custom.lib', linux='libcustom.a')
@@ -514,14 +507,12 @@ class BuildTarget:
             self.export_include('installed/MyLib/include', build_dir=True)
 
         ```
-        - include_path -- the include folder to export
-        - build_dir -- [False] resolve include_path against the build directory
-        - includes_filter -- [None] replaces self.include_glob_filter, the header suffixes deployed
-             during artifactory packaging. This setting applies to the entire target!
-        - as_includes_root -- [False] if set, this include_path is the root of all includes and
-                              mama strips any directory prefix. For example:
-                              self.export_include('src/mylib', as_includes_root='mylib')
-                              -> 'deploy/include/mylib/\\*' instead of 'deploy/include/src/mylib/\\*'
+        - include_path: the include folder to export
+        - build_dir: [False] resolve include_path against the build directory
+        - includes_filter: [None] replaces self.include_glob_filter, the header suffixes deployed
+          during artifactory packaging. This setting applies to the entire target!
+        - as_includes_root: [False] if set, this include_path is the root of all includes and mama strips
+          the directory prefix: 'deploy/include/mylib/\\*' instead of 'deploy/include/src/mylib/\\*'
         """
         if includes_filter is not None:
             self.include_glob_filter = includes_filter
@@ -540,10 +531,10 @@ class BuildTarget:
         self.export_includes(['include', 'src/moreincludes'])
         self.export_includes(['installed/include', 'installed/src/moreincludes'], build_dir=True)
         ```
-        - include_paths -- [['']] the include folders to export
-        - build_dir -- [False] resolve the paths against the build directory
-        - includes_filter -- [None] replaces self.include_glob_filter, the header suffixes deployed
-             during artifactory packaging. This setting applies to the entire target!
+        - include_paths: [['']] the include folders to export
+        - build_dir: [False] resolve the paths against the build directory
+        - includes_filter: [None] replaces self.include_glob_filter, the header suffixes deployed
+          during artifactory packaging. This setting applies to the entire target!
         """
         if includes_filter is not None:
             self.include_glob_filter = includes_filter
@@ -561,9 +552,9 @@ class BuildTarget:
         self.export_lib('mylib.a')                    # from build dir
         self.export_lib('lib/mylib.a', src_dir=True)  # from project source dir
         ```
-        - relative_path -- path of the lib
-        - src_dir -- [False] resolve against the source directory
-        - build_dir -- [True] resolve against the build directory
+        - relative_path: path of the lib
+        - src_dir: [False] resolve against the source directory
+        - build_dir: [True] resolve against the build directory
         """
         if src_dir and build_dir:
             build_dir = False
@@ -577,11 +568,11 @@ class BuildTarget:
         Exports several libs relative to the build directory using EXTENSION MATCHING.
         If src_dir=True, the path is relative to the source directory.
 
-        - path -- ['.'] folder to search
-        - pattern_substrings -- [['.lib', '.a']] substrings that select the files
-        - src_dir -- [False] resolve against the source directory
-        - build_dir -- [True] resolve against the build directory
-        - order -- [None] partial lib names that set the link order, for the Linux linker
+        - path: ['.'] folder to search
+        - pattern_substrings: [['.lib', '.a']] substrings that select the files
+        - src_dir: [False] resolve against the source directory
+        - build_dir: [True] resolve against the build directory
+        - order: [None] partial lib names that set the link order, for the Linux linker
         ```
         self.export_libs()                     # gather any .lib or .a from build dir
         self.export_libs('.', ['.dll', '.so']) # gather any .dll or .so from build dir
@@ -604,10 +595,10 @@ class BuildTarget:
         """
         Exports a single asset file from this target for later deployment.
 
-        - asset -- path of the asset file
-        - category -- [None] groups the assets and flattens the folder structure
-        - src_dir -- [True] resolve against the source directory
-        - build_dir -- [False] resolve against the build directory
+        - asset: path of the asset file
+        - category: [None] groups the assets and flattens the folder structure
+        - src_dir: [True] resolve against the source directory
+        - build_dir: [False] resolve against the build directory
         ```
         self.export_asset('extras/csharp/NanoMesh.cs')
             --> {deploy}/extras/csharp/NanoMesh.cs
@@ -625,11 +616,11 @@ class BuildTarget:
         """
         Exports asset files with a recursive glob for later deployment.
 
-        - assets_path -- folder to search
-        - pattern_substrings -- [[]] substrings that select the files
-        - category -- [None] groups the assets and flattens the folder structure
-        - src_dir -- [True] resolve against the source directory
-        - build_dir -- [False] resolve against the build directory
+        - assets_path: folder to search
+        - pattern_substrings: [[]] substrings that select the files
+        - category: [None] groups the assets and flattens the folder structure
+        - src_dir: [True] resolve against the source directory
+        - build_dir: [False] resolve against the build directory
         ```
         self.export_assets('extras/csharp', ['.cs'])
             --> {deploy}/extras/csharp/NanoMesh.cs
@@ -647,9 +638,9 @@ class BuildTarget:
         """
         For UNIX: finds and exports a system library so mamabuild links it automatically.
 
-        - name -- name of the system library
-        - apt -- [''] name of the apt package that provides the library, used in the error hint
-        - required -- [True] if False, a missing syslib is not an error
+        - name: name of the system library
+        - apt: [''] name of the apt package that provides the library, used in the error hint
+        - required: [True] if False, a missing syslib is not an error
 
         :returns: TRUE if the syslib export succeeded. FALSE if required=False and the search failed.
         ```
@@ -699,8 +690,6 @@ class BuildTarget:
         Adds C++ flags for the compilation step.
         Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_cxx_flags('-Wall')
-            self.add_cxx_flags(['-Wall', '-std=c++17'])
             self.add_cxx_flags('-Wall', '-std=c++17')
             self.add_cxx_flags('-Wall -std=c++17')
         ```
@@ -715,8 +704,6 @@ class BuildTarget:
         Adds C flags for the compilation step.
         Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_c_flags('-Wall')
-            self.add_c_flags(['-Wall', '-std=c99'])
             self.add_c_flags('-Wall', '-std=c99')
             self.add_c_flags('-Wall -std=c99')
         ```
@@ -731,8 +718,6 @@ class BuildTarget:
         Adds C AND C++ flags for the compilation step.
         Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_cl_flags('-Wall')
-            self.add_cl_flags(['-Wall', '-march=native'])
             self.add_cl_flags('-Wall', '-march=native')
             self.add_cl_flags('-Wall -march=native')
         ```
@@ -749,8 +734,6 @@ class BuildTarget:
         Adds flags for the linker step. Mama does no platform check here.
         Accepts strings, lists of strings, or space separated strings.
         ```
-            self.add_ld_flags('-rdynamic')
-            self.add_ld_flags(['-rdynamic', '-s'])
             self.add_ld_flags('-rdynamic', '-s')
             self.add_ld_flags('-rdynamic -s')
         ```
@@ -809,9 +792,9 @@ class BuildTarget:
     def enable_from_env(self, name, enabled='ON', force=False):
         """
         Adds a CMake option if the environment variable `name` is set to 1, ON or TRUE.
-        - name -- the environment variable to check
-        - enabled -- ['ON'] the value the CMake option gets
-        - force -- [False] add the option even when the variable is not set
+        - name: the environment variable to check
+        - enabled: ['ON'] the value the CMake option gets
+        - force: [False] add the option even when the variable is not set
         ```
             self.enable_from_env('BUILD_TESTS')
         ```
@@ -854,7 +837,7 @@ class BuildTarget:
         Require a minimum mamabuild version for this mamafile. When the running mama is older,
         this stops the build during target load, before any configure or build work.
         The error message includes an upgrade hint, instead of a late failure on a missing API.
-        - min_version -- the minimum mamabuild version, for example '0.13.01'
+        - min_version: the minimum mamabuild version, for example '0.13.01'
         ```
             def settings(self):
                 self.requires_version('0.13.01')
@@ -954,10 +937,9 @@ class BuildTarget:
             self.copy(self.build_dir('libAwesome.so'),
                       self.source_dir('deploy/Awesome.aar/jni/armeabi-v7a'))
         ```
-        - src -- source file or folder
-        - dst -- destination path
-        - filter -- [None] a string or list of strings that filter files by suffix,
-                    for example filter=['.h'] or filter='.hpp'
+        - src: source file or folder
+        - dst: destination path
+        - filter: [None] a string or list of strings that filter files by suffix, e.g. filter=['.h'] or filter='.hpp'
         """
         if util.copy_if_needed(src, dst, filter):
             if self.config.verbose: console(f'copy {src} --> {dst}')
@@ -966,8 +948,8 @@ class BuildTarget:
     def copy_built_file(self, builtFile: str, copyToFolder: str):
         """
         Copies a file within the build directory.
-        - builtFile -- source path relative to the build directory
-        - copyToFolder -- destination folder relative to the build directory
+        - builtFile: source path relative to the build directory
+        - copyToFolder: destination folder relative to the build directory
         ```
             self.copy_built_file('RelWithDebInfo/libawesome.a', 'lib')
         ```
@@ -983,9 +965,9 @@ class BuildTarget:
     def copy_deployed_folder(self, src_dir: str, dst_dir: str, filter: list = None):
         """
         Copies a folder from the source directory.
-        - src_dir -- source folder relative to the source directory
-        - dst_dir -- destination folder path
-        - filter -- [None] a string or list of strings that filter files by suffix
+        - src_dir: source folder relative to the source directory
+        - dst_dir: destination folder path
+        - filter: [None] a string or list of strings that filter files by suffix
         ```
             self.copy_deployed_folder('deploy/NanoMesh', 'C:/Projects/Game/Plugins')
             # --> 'C:/Projects/Game/Plugins/NanoMesh
@@ -1000,9 +982,9 @@ class BuildTarget:
     def download_file(self, remote_url: str, local_dir: str, force=False):
         """
         Downloads a file if it does not already exist.
-        - remote_url -- URL to download from
-        - local_dir -- destination folder
-        - force -- [False] download even when the file exists
+        - remote_url: URL to download from
+        - local_dir: destination folder
+        - force: [False] download even when the file exists
         ```
             self.download_file('http://example.com/file1', 'bin')
             # --> 'bin/file1'
@@ -1014,9 +996,9 @@ class BuildTarget:
     def download_and_unzip(self, remote_zip: str, extract_dir: str, unless_file_exists=None):
         """
         Downloads and unzips an archive if it does not already exist.
-        - remote_zip -- URL of the archive
-        - extract_dir -- destination folder for extraction
-        - unless_file_exists -- [None] if this file exists, skip the download and unzip steps
+        - remote_zip: URL of the archive
+        - extract_dir: destination folder for extraction
+        - unless_file_exists: [None] if this file exists, skip the download and unzip steps
         ```
             self.download_and_unzip('http://example.com/archive.zip',
                                     'bin', 'bin/unzipped_file.txt')
@@ -1053,7 +1035,7 @@ class BuildTarget:
     def enable_fortran(self, path=''):
         """
         Enables Fortran for this target only.
-        - path -- [''] optional custom path or command for the Fortran compiler
+        - path: [''] optional custom path or command for the Fortran compiler
         ```
             self.enable_fortran()   # attempt to autodetect fortran
             self.enable_fortran('/SysGCC/bin/gfortran')  # specify fortran explicitly
@@ -1094,15 +1076,15 @@ class BuildTarget:
                     configure='configure'):
         """
         Creates a new GnuProject instance for building GNU projects from source.
-        - name -- name of the project, for example 'gmp'
-        - version -- version of the project, for example '6.2.1'
-        - url -- [''] URL to download the project, for example 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
-        - git -- [''] git URL to clone the project from
-        - build_products -- [[]] the final products to build, for example
-                            [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
-                            Supported project variables: {{installed}}, {{source}}, {{build}}
-        - autogen -- [False] run ./autogen.sh before ./configure
-        - configure -- ['configure'] the configuration command, can also be 'make config' etc
+        - name: name of the project, for example 'gmp'
+        - version: version of the project, for example '6.2.1'
+        - url: [''] URL to download the project, for example 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
+        - git: [''] git URL to clone the project from
+        - build_products: [[]] the final products to build, for example
+          [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
+          Supported project variables: {{installed}}, {{source}}, {{build}}
+        - autogen: [False] run ./autogen.sh before ./configure
+        - configure: ['configure'] the configuration command, can also be 'make config' etc
         ```
             gmp = self.gnu_project('gmp', '6.2.1', url='https://gmplib.org/download/gmp/{{project}}.tar.xz')
             gmp.configure()
@@ -1130,11 +1112,11 @@ class BuildTarget:
         """
         Runs a command in the build or source folder.
         Use this for custom commands or custom build systems.
-        - command -- the command line to run
-        - src_dir -- [False] if True, the command runs relative to the source directory
-        - exit_on_fail -- [True] exit the build when the command fails
-        - quiet -- [False] suppress all output of the command. Mama still runs it and
-                   checks the exit code. Use for a noisy sub-step like a script's own `git clone`.
+        - command: the command line to run
+        - src_dir: [False] if True, the command runs relative to the source directory
+        - exit_on_fail: [True] exit the build when the command fails
+        - quiet: [False] suppress all output. Mama still runs the command and checks the exit code.
+          Use for a noisy sub-step like a script's own `git clone`.
         ```
             self.run('./configure', src_dir=True)
             self.run('make release -j7') # run in build dir
@@ -1147,10 +1129,10 @@ class BuildTarget:
     def run_program(self, working_dir: str, command: str, exit_on_fail=True, env=None):
         """
         Runs any program in any directory. Use this for custom tools.
-        - working_dir -- the directory to run in
-        - command -- the command line to run
-        - exit_on_fail -- [True] exit the build when the program fails
-        - env -- [None] optional environment variables dict
+        - working_dir: the directory to run in
+        - command: the command line to run
+        - exit_on_fail: [True] exit the build when the program fails
+        - env: [None] optional environment variables dict
         ```
             self.run_program(self.source_dir('bin'),
                              self.source_dir('bin/DbTool'))
@@ -1164,10 +1146,10 @@ class BuildTarget:
         Runs a program with gdb if requested, otherwise runs it normally.
         To control this, add 'gdb' or 'nogdb' to args.
         Inside start(), `mama start=gdb` or `mama start=nogdb` controls the GDB enablement.
-        - command -- the program to run
-        - args -- argument string, 'gdb' and 'nogdb' are filtered out
-        - src_dir -- [True] run relative to the source directory
-        - gdb_by_default -- [True] the default when args select neither
+        - command: the program to run
+        - args: argument string, 'gdb' and 'nogdb' are filtered out
+        - src_dir: [True] run relative to the source directory
+        - gdb_by_default: [True] the default when args select neither
         """
         args, gdb = filter_gdb_arg(args, gdb_by_default)
         if gdb:
@@ -1191,11 +1173,10 @@ class BuildTarget:
         """
         Runs a gtest executable.
         Writes the gtest report to {source_dir}/test/report.xml.
-        - executable -- which executable to run
-        - args -- a string of options separated by spaces:
-          'gdb', 'nogdb' or a gtest fixture/test partial name
-        - src_dir -- [True] if True, the executable path is relative to the source directory
-        - gdb -- [False] if True, run with gdb
+        - executable: which executable to run
+        - args: a string of space separated options: 'gdb', 'nogdb' or a gtest fixture/test partial name
+        - src_dir: [True] if True, the executable path is relative to the source directory
+        - gdb: [False] if True, run with gdb
         ```
             self.gtest("bin/MyAppGtests", "nogdb", src_dir=True)
             self.gtest("bin/MyAppGtests", "MyFixtureName.TheTestName", src_dir=True)
@@ -1321,29 +1302,15 @@ class BuildTarget:
 
 
     def default_package(self):
-        """
-        Performs default packaging steps.
-        This is called if self.package() did not export anything.
-        It can also be called manually to collect includes and libs.
-        ```
-        def package(self):
-            self.default_package()
-        ```
-        """
+        """Performs the default packaging steps. Mama calls this when self.package() exported nothing.
+        A package() override can also call it to collect the default includes and libs."""
         if self.no_includes: self.default_package_includes()
         if self.no_libs: self.default_package_libs()
 
 
     ## TODO: move this into `package.py`
     def default_package_includes(self):
-        """
-        Performs default INCLUDE packaging steps.
-        It can also be called manually to collect includes.
-        ```
-        def package(self):
-            self.default_package_includes()
-        ```
-        """
+        """Performs the default INCLUDE packaging steps. A package() override can call it to collect includes."""
         # try common C and C++ library include patterns
         if   self.export_include('include', build_dir=True):  pass
         elif self.export_include('include', build_dir=False): pass
@@ -1353,14 +1320,7 @@ class BuildTarget:
 
     ## TODO: move this into `package.py`
     def default_package_libs(self):
-        """
-        Performs default LIB packaging steps.
-        It can also be called manually to collect libs.
-        ```
-        def package(self):
-            self.default_package_libs()
-        ```
-        """
+        """Performs the default LIB packaging steps. A package() override can call it to collect libs."""
         if self.export_libs(self.cmake_build_type, src_dir=False): pass
         elif self.export_libs('lib', src_dir=False): pass
         elif self.export_libs('.', src_dir=False): pass
@@ -1372,11 +1332,6 @@ class BuildTarget:
         ```
         def deploy(self):
             self.papa_deploy('deploy/NanoMesh')
-        ```
-        Or:
-        ```
-        def deploy(self):
-            self.default_deploy()
         ```
         """
         self.default_deploy()
@@ -1396,12 +1351,12 @@ class BuildTarget:
             package_path/{libs}
             package_path/{assets}
 
-        - package_path -- where to deploy the package
-        - src_dir -- [False] deploy to the source dir instead of the build dir
-        - r_includes -- [False] recursively export includes from dynamic libraries
-        - r_dylibs -- [False] recursively export all *.dll *.so *.dylib libraries
-        - r_syslibs -- [False] include system libraries from child dependencies
-        - r_assets -- [False] include assets from child dependencies
+        - package_path: where to deploy the package
+        - src_dir: [False] deploy to the source dir instead of the build dir
+        - r_includes: [False] recursively export includes from dynamic libraries
+        - r_dylibs: [False] recursively export all *.dll *.so *.dylib libraries
+        - r_syslibs: [False] include system libraries from child dependencies
+        - r_assets: [False] include assets from child dependencies
 
         Example: `self.papa_deploy('MyPackageName')`
 
@@ -1431,7 +1386,7 @@ class BuildTarget:
         """
         Perform test steps here with the test args.
         `mama test arg1 arg2 arg3`
-        - args -- the argument string from the `mama test` command line
+        - args: the argument string from the `mama test` command line
         ```
             def test(self, args):
                 # runs an executable with GDB
@@ -1447,7 +1402,7 @@ class BuildTarget:
         """
         Start a custom process through mama.
         `mama target start=arg`
-        - args -- the argument string from the `mama start=...` command line
+        - args: the argument string from the `mama start=...` command line
         ```
         def start(self, args):
             if 'dbtool' in args:
@@ -1683,9 +1638,8 @@ class BuildTarget:
         self._run_packaging()
 
     def _run_packaging(self):
-        # package() is user mamafile code that asserts on build outputs, so it needs something to
-        # package. Wipe, upload, deploy and test walk the task chain without building. They would
-        # otherwise run package() against artifacts never produced, or ones a wipe just deleted.
+        # package() is user mamafile code that asserts on build outputs. Wipe, upload, deploy and test walk
+        # the task chain without building, so they would package artifacts never produced or just deleted.
         if not self._build_work_enabled() and not self.dep.has_usable_artifacts():
             if self.config.verbose or self.config.deploy or self.config.upload:
                 warning(f'  - Target {self.name: <16} PACKAGE skipped: nothing built, no artifacts on disk')
@@ -1695,8 +1649,7 @@ class BuildTarget:
         # unless the user asked for a local rebuild.
         if self.dep.should_rebuild or not self.dep.from_artifactory:
             self.packaging_result = 'target.package()'
-            # Clear the libs that artifactory_load_target() loaded, so the
-            # repackaging starts from empty, unpolluted exports.
+            # clear the libs artifactory_load_target() loaded, so repackaging starts from empty exports
             old_includes = self.exported_includes
             old_libs = self.exported_libs
             old_syslibs = self.exported_syslibs
@@ -1707,11 +1660,7 @@ class BuildTarget:
                 self.exported_syslibs = []
                 self.exported_assets = []
 
-            # this must populate exports by calling:
-            #  - export_include() / export_includes()
-            #  - export_lib() / export_libs()
-            #  - export_syslib()
-            #  - export_asset() / export_assets()
+            # must populate exports via export_include()/export_libs()/export_syslib()/export_asset()
             self.package() # user customization
 
             # the user provided no packaging, use the default packaging instead
@@ -1774,11 +1723,8 @@ class BuildTarget:
 
 
     def _require_source(self, action: str) -> bool:
-        """
-        For commands that need source on disk (test, start, open),
-        refuses on a shim with a clear message that points at `mama unshallow`.
-        Returns True when the action may proceed, False when refused.
-        """
+        """For a command that needs source on disk (test, start, open): refuses on a shim and points
+        at `mama unshallow`. Returns True when the action may proceed, False when refused."""
         if not self.dep.is_artifactory_shim():
             return True
         if self.config.print:
@@ -1858,8 +1804,8 @@ class BuildTarget:
     def ms_build(self, projectfile, properties:dict = dict()):
         """
         Invokes MSBuild on the specified projectfile with the given properties.
-        - projectfile -- the solution or project file, relative to the source directory
-        - properties -- [dict()] MSBuild properties
+        - projectfile: the solution or project file, relative to the source directory
+        - properties: [dict()] MSBuild properties
         ```
         def build(self):
             self.cmake_build()

--- a/mama/buildsys/cmake/compiler_cache.py
+++ b/mama/buildsys/cmake/compiler_cache.py
@@ -1,12 +1,5 @@
-"""Cross-build-dir reuse of CMake compiler detection (~5s of a ~6.5s cold configure, cut to ~1.7s).
-
-Mechanism (a warm reconfigure of the same dir reproduced in a fresh dir, validated cross-project):
-capture the toolchain detection files (`CMakeFiles/<ver>/CMake{C,CXX,RC}Compiler.cmake`,
-`CMakeSystem.cmake`, the ABI `.bin`, VS `VCTargetsPath.txt`); inject them into a fresh build dir +
-write a `CMakeCache.txt` with the `CMAKE_PLATFORM_INFO_INITIALIZED` marker (makes cmake trust the
-cached info) + `CMAKE_HOME_DIRECTORY`. ONLY toolchain detection is transplanted, never project
-flags - so a seed can't poison another project. The fingerprint auto-invalidates on toolchain
-change; a failed seeded configure self-heals. Pure file/string ops + injected clock -> no-cmake tests."""
+"""Cross-build-dir reuse of CMake compiler detection, which cuts a cold configure from about 6.5s to 1.7s.
+publish() captures only the toolchain detection files, never project flags, and inject() replays them."""
 
 from __future__ import annotations
 import os, shutil, hashlib, json, time, threading
@@ -23,33 +16,32 @@ _VS_FILES = ['VCTargetsPath.txt']  # VS-generator MSBuild probe result (reusable
 _MANIFEST = 'seed.json'
 # Cache entries the injected CMakeCache.txt must carry, replayed verbatim from the probe's own cache.
 #
-# The ABI pair is what CMakeDetermineCompilerABI writes to the CACHE, not to the compiler module. Seeding
-# skips that probe, so unless replayed every install-RPATH add_executable dies: 'not supported ... unless
-# on an ELF-based platform'.
+# CMakeDetermineCompilerABI writes the ABI pair to the CACHE, not to the compiler module. Seeding skips
+# that probe, so without the replay every install-RPATH add_executable fails with 'not supported ...
+# unless on an ELF-based platform'.
 #
 # The compiler and toolchain entries are here for a sharper reason. mama passes -DCMAKE_C_COMPILER and
-# -DCMAKE_CXX_COMPILER on every configure. An injected cache that omits them makes cmake announce 'you have
-# changed variables that require your cache to be deleted', delete the cache MID-CONFIGURE and re-run. The
-# second pass no longer applies CMAKE_TOOLCHAIN_FILE, so a cross build silently re-detects as the host: an
-# android configure came out as CMAKE_SYSTEM_PROCESSOR=x86_64 and every -march the target set then broke.
+# -DCMAKE_CXX_COMPILER on every configure. When the injected cache omits them, cmake reports changed
+# variables, deletes the cache MID-CONFIGURE and re-runs. The second pass no longer applies
+# CMAKE_TOOLCHAIN_FILE, so a cross build silently re-detects as the host and compiles with host flags.
 _REPLAY_CACHE_KEYS = ('CMAKE_EXECUTABLE_FORMAT', 'CMAKE_LIBRARY_ARCHITECTURE',
                       'CMAKE_C_COMPILER', 'CMAKE_CXX_COMPILER', 'CMAKE_TOOLCHAIN_FILE')
 
-# Bumped when the seed changes shape. An older seed has the SAME fingerprint but replays too few cache
-# lines, so it must be rejected and re-probed rather than silently reused.
+# Bumped when the seed shape changes. An older seed has the SAME fingerprint but replays too few cache
+# lines, so is_valid rejects it and the probe runs again.
 _SEED_FORMAT = 3
-BACKSTOP_TTL = 7 * 24 * 3600  # seconds; fingerprint is the real gate, this is just paranoia
+BACKSTOP_TTL = 7 * 24 * 3600  # seconds. The fingerprint is the real gate. This TTL is only a backstop.
 
 
 def compute_fingerprint(inputs: dict) -> str:
-    """Stable 16-hex hash of every toolchain input that affects detection (cmake version, generator,
-    compiler path+mtime+size, SDK, ...). A toolchain change flips the hash -> auto-invalidate."""
+    """Stable 16-hex hash of every toolchain input that affects detection: cmake version, generator,
+    compiler path + mtime + size, SDK. A toolchain change flips the hash and invalidates the seed."""
     blob = json.dumps(inputs, sort_keys=True, default=str)
     return hashlib.sha1(blob.encode('utf-8')).hexdigest()[:16]
 
 
 def compiler_stat(path: str) -> dict:
-    """Path + size + mtime of a compiler binary, for the fingerprint. {} if missing."""
+    """Path, size and mtime of a compiler binary, for the fingerprint. Only the path when stat fails."""
     try:
         st = os.stat(path)
         return {'path': normalized_path(path), 'size': st.st_size, 'mtime': int(st.st_mtime)}
@@ -58,21 +50,21 @@ def compiler_stat(path: str) -> dict:
 
 
 def detected_langs(build_files_dir: str) -> list:
-    """Which languages a build dir actually detected (by which compiler files it wrote)."""
+    """The languages a build dir detected, judged by the compiler module files it wrote."""
     return [lang for lang, (mod, _) in _LANG_FILES.items()
             if os.path.exists(path_join(build_files_dir, mod))]
 
 
 def detection_is_partial(build_files_dir: str) -> bool:
-    """True if a compiler module exists but its ABI/feature probe never finished (configure killed mid-detection).
-    cmake trusts such a stage-1 module on the next run, so every target_compile_features() dies with
-    'no known features'. RC is skipped - it has no ABI step."""
+    """True when a compiler module exists but its ABI probe never finished (a killed configure).
+    cmake trusts such a stage-1 module on the next run, so every target_compile_features() fails with
+    'no known features'. RC has no ABI step, so the check skips it."""
     for lang, (mod, abi) in _LANG_FILES.items():
         if not abi: continue
         path = path_join(build_files_dir, mod)
         if not os.path.exists(path): continue
         try: text = read_text_from(path)
-        except OSError: return True  # unreadable module: distrust it, a needless redetect is the cheap outcome
+        except OSError: return True  # unreadable module: treat it as partial, a needless redetect is cheap
         if f'set(CMAKE_{lang}_ABI_COMPILED TRUE)' not in text: return True
     return False
 
@@ -81,8 +73,8 @@ _CORE_LANGS = ('C', 'CXX')  # RC is windows-only and has no ABI step, so it neve
 
 
 def covers_core_langs(langs) -> bool:
-    """Backstop: the probe is a C+CXX project so its seed always covers both, but a seed that somehow
-    lacks one would let a project enabling it skip detection and die on 'CMAKE_<lang>_COMPILER not set'."""
+    """Backstop check. The probe is a C+CXX project, so its seed covers both. A seed that lacks one
+    would let a project that enables it skip detection and fail on 'CMAKE_<lang>_COMPILER not set'."""
     return all(lang in (langs or []) for lang in _CORE_LANGS)
 
 
@@ -95,11 +87,11 @@ def _seed_file_names(langs: list) -> list:
     return names
 
 
-_COMPILER_SET = 'set(CMAKE_{}_COMPILER "'  # first line of a generated CMake<lang>Compiler.cmake
+_COMPILER_SET = 'set(CMAKE_{}_COMPILER "'  # the set() line of a generated CMake<lang>Compiler.cmake
 
 
 def compiler_from_module(build_files_dir: str, lang: str) -> str:
-    """The compiler path the captured CMake<lang>Compiler.cmake records, '' when absent."""
+    """The compiler path the captured CMake<lang>Compiler.cmake records. Returns '' when absent."""
     try: text = read_text_from(path_join(build_files_dir, _LANG_FILES[lang][0]))
     except OSError: return ''
     prefix = _COMPILER_SET.format(lang)
@@ -112,7 +104,7 @@ def usable_compilers(build_files_dir: str) -> dict:
     """{lang: compiler path} for the core languages, or {} when any of them is unusable.
 
     Mama writes a seed once and every later build dir reuses it. One bad seed therefore costs the slow
-    probe AND every build after it. cmake records an empty CMAKE_<lang>_COMPILER when detection failed,
+    probe AND every build after it. cmake records an empty CMAKE_<lang>_COMPILER when detection fails,
     and a build dir seeded from that compiles with "". Read the value back and stat it. A seed then
     names a compiler this machine has, or mama writes no seed at all."""
     compilers = {}
@@ -143,7 +135,7 @@ def read_replay_cache_lines(build_dir: str, compilers: dict = None) -> list:
 
 def publish(seed_dir: str, build_files_dir: str, fingerprint='', probe='', build_dir='', clock=time.time) -> bool:
     """Capture detection artifacts from a freshly-configured `build_files_dir`
-    (`<build>/CMakeFiles/<ver>`) into `seed_dir`. Returns False if nothing usable was found. Each
+    (`<build>/CMakeFiles/<ver>`) into `seed_dir`. Returns False when the detection is not usable. Each
     file lands via a temp + os.replace so a concurrent reader never copies a half-written file. The
     manifest records three things. `fingerprint` lets a load re-verify the toolchain. `probe` names the
     compiler binary whose disappearance invalidates the seed. `compilers` is what a load re-checks."""
@@ -186,7 +178,7 @@ def is_valid(manifest, fingerprint: str) -> bool:
     if manifest.get('format') != _SEED_FORMAT:
         return False  # older shape: replays too few cache lines, so re-probe instead of reusing it
     if not covers_core_langs(manifest.get('langs')):
-        return False  # a seed missing C or CXX can't serve a project that enables it
+        return False  # a seed missing C or CXX cannot serve a project that enables it
     if not _compilers_are_live(manifest):
         return False  # the toolset moved since the publish: detect again rather than seed a dead path
     probe = manifest.get('probe')
@@ -194,9 +186,9 @@ def is_valid(manifest, fingerprint: str) -> bool:
 
 
 def gc_stale(seed_root: str, log=lambda m: None):
-    """One cheap sweep of sibling seeds: drop any that can't be valid anymore - a legacy seed from an
-    older mama (no fingerprint recorded) or one whose compiler binary is gone (an upgraded/removed
-    toolset). A seed for a still-installed toolchain is untouched, so alternate-config seeds survive."""
+    """One cheap sweep of sibling seeds: drop any that cannot be valid anymore - a legacy seed from an
+    older mama (no fingerprint recorded) or one whose compiler binary is gone (an upgraded or removed
+    toolset). The sweep never touches a seed for a still-installed toolchain, so alternate-config seeds survive."""
     try: names = os.listdir(seed_root)
     except OSError: return
     for name in names:
@@ -213,7 +205,7 @@ def gc_stale(seed_root: str, log=lambda m: None):
 
 
 def load(seed_dir: str, ttl=BACKSTOP_TTL, clock=time.time):
-    """Return the manifest dict if a valid (present + not past the backstop TTL) seed exists, else None."""
+    """Return the manifest dict when the seed exists and is inside the backstop TTL, else None."""
     mpath = path_join(seed_dir, _MANIFEST)
     if not os.path.exists(mpath): return None
     try:
@@ -226,9 +218,9 @@ def load(seed_dir: str, ttl=BACKSTOP_TTL, clock=time.time):
 
 
 def inject(seed_dir: str, build_dir: str, build_files_dir: str, src_dir: str) -> bool:
-    """Make a fresh `build_dir` look already-configured so cmake skips ALL detection: copy the
-    captured toolchain files into CMakeFiles/<ver> + write a CMakeCache.txt with the
-    PLATFORM_INFO_INITIALIZED marker + CMAKE_HOME_DIRECTORY. Returns False and writes NO marker when
+    """Make a fresh `build_dir` look already-configured so cmake skips ALL detection. Copies the
+    captured toolchain files into CMakeFiles/<ver>, then writes a CMakeCache.txt with the
+    PLATFORM_INFO_INITIALIZED marker and CMAKE_HOME_DIRECTORY. Returns False and writes NO marker when
     the seed is empty, names no live compiler, or vanished mid-copy under a concurrent heal. The
     caller then detects normally, instead of trusting a marker with no compiler files."""
     manifest = load(seed_dir, ttl=float('inf'))
@@ -241,7 +233,7 @@ def inject(seed_dir: str, build_dir: str, build_files_dir: str, src_dir: str) ->
         try:
             shutil.copy2(src, path_join(build_files_dir, name)); copied += 1
         except OSError:
-            return False  # seed file vanished under us (a concurrent purge): bail, don't trust it
+            return False  # a concurrent purge removed the seed file: fall back to normal detection
     if not copied: return False
     cache = (f'CMAKE_PLATFORM_INFO_INITIALIZED:INTERNAL=1\n'
              f'CMAKE_HOME_DIRECTORY:INTERNAL={normalized_path(src_dir)}\n')
@@ -260,8 +252,8 @@ def purge(seed_dir: str):
 
 class Coordinator:
     """Builds ONE seed per fingerprint from a synthetic C+CXX probe, then injects it into every fresh build
-    dir. Probing instead of piggybacking on a real target is what makes it safe: the seed always covers both
-    core languages. In-process election; a cross-process race just probes twice for identical content."""
+    dir. The probe, not the first real target, is what makes it safe: the seed always covers both core
+    languages. The election is in-process. A cross-process race only probes twice for identical content."""
 
     def __init__(self, seed_root, fp_fn, paths_fn, probe_fn=None, seed_fn=None, enabled=True, clock=time.time,
                  wait_timeout=180.0, log_fn=None):
@@ -287,19 +279,19 @@ class Coordinator:
         return fp, os.path.exists(path_join(self._root, fp))
 
     def begin_session(self):
-        """Once per mama session (not per package): log the seed root and sweep stale seeds. Called from
-        the coordinator factory so it runs even when every build dir is already configured (prepare skipped)."""
+        """Once per mama session (not per package): log the seed root and sweep stale seeds. The coordinator
+        factory calls this, so it runs even when every build dir is already configured (prepare skipped)."""
         with self._lock:
             if self._gc_done: return
-            self._gc_done = True  # flag set under lock first -> exactly one thread sweeps, the rest skip
+            self._gc_done = True  # the lock guards the flag, so exactly one thread sweeps and the rest skip
         if not self._enabled:
             self._log('compiler-seed cache: disabled (nocache)'); return
         self._log(f'compiler-seed cache: {self._root}')
         gc_stale(self._root, self._log)
 
     def _try_use(self, target, fp) -> bool:
-        """Load this fp's seed and, if it's still valid, inject it. Purges a present-but-stale seed so a
-        clean one gets rebuilt (toolset moved, or a legacy seed with no fingerprint)."""
+        """Load this fp's seed and, when it is still valid, inject it. Purges a present-but-stale seed so
+        a clean one gets rebuilt (toolset moved, or a legacy seed with no fingerprint)."""
         sd = self.seed_dir(target)
         m = load(sd, clock=self._clock)
         if is_valid(m, fp) and inject(sd, *self._paths(target)):
@@ -309,7 +301,7 @@ class Coordinator:
 
     def prepare(self, target) -> str:
         """'use' (seed injected into the fresh build dir, cmake skips detection) or 'none' (detect
-        normally). The first caller per fingerprint runs the probe; the rest wait for it, then inject."""
+        normally). The first caller per fingerprint runs the probe. The rest wait for it, then inject."""
         if not self._enabled: return 'none'
         self.begin_session()
         fp = self._fp(target)

--- a/mama/buildsys/cmake/compiler_cache.py
+++ b/mama/buildsys/cmake/compiler_cache.py
@@ -15,20 +15,13 @@ _SHARED_FILES = ['CMakeSystem.cmake']
 _VS_FILES = ['VCTargetsPath.txt']  # VS-generator MSBuild probe result (reusable, toolset-bound)
 _MANIFEST = 'seed.json'
 # Cache entries the injected CMakeCache.txt must carry, replayed verbatim from the probe's own cache.
-#
-# CMakeDetermineCompilerABI writes the ABI pair to the CACHE, not to the compiler module. Seeding skips
-# that probe, so without the replay every install-RPATH add_executable fails with 'not supported ...
-# unless on an ELF-based platform'.
-#
-# The compiler and toolchain entries are here for a sharper reason. mama passes -DCMAKE_C_COMPILER and
-# -DCMAKE_CXX_COMPILER on every configure. When the injected cache omits them, cmake reports changed
-# variables, deletes the cache MID-CONFIGURE and re-runs. The second pass no longer applies
-# CMAKE_TOOLCHAIN_FILE, so a cross build silently re-detects as the host and compiles with host flags.
+# The ABI probe writes its result to the CACHE only, and seeding skips the probe, so without the
+# replay every install-RPATH executable fails. The compiler and toolchain entries must match the -D
+# options mama passes, or cmake wipes the cache MID-CONFIGURE and re-detects a cross build as the host.
 _REPLAY_CACHE_KEYS = ('CMAKE_EXECUTABLE_FORMAT', 'CMAKE_LIBRARY_ARCHITECTURE',
                       'CMAKE_C_COMPILER', 'CMAKE_CXX_COMPILER', 'CMAKE_TOOLCHAIN_FILE')
 
-# Bumped when the seed shape changes. An older seed has the SAME fingerprint but replays too few cache
-# lines, so is_valid rejects it and the probe runs again.
+# Bumped when the seed shape changes. is_valid rejects an older format, so the probe runs again.
 _SEED_FORMAT = 3
 BACKSTOP_TTL = 7 * 24 * 3600  # seconds. The fingerprint is the real gate. This TTL is only a backstop.
 
@@ -102,11 +95,9 @@ def compiler_from_module(build_files_dir: str, lang: str) -> str:
 
 def usable_compilers(build_files_dir: str) -> dict:
     """{lang: compiler path} for the core languages, or {} when any of them is unusable.
-
-    Mama writes a seed once and every later build dir reuses it. One bad seed therefore costs the slow
-    probe AND every build after it. cmake records an empty CMAKE_<lang>_COMPILER when detection fails,
-    and a build dir seeded from that compiles with "". Read the value back and stat it. A seed then
-    names a compiler this machine has, or mama writes no seed at all."""
+    cmake records an empty CMAKE_<lang>_COMPILER when detection fails, and every build dir seeded
+    from that compiles with "". Read the value back and stat it, so a seed always names a compiler
+    this machine has, or mama writes no seed at all."""
     compilers = {}
     for lang in _CORE_LANGS:
         compiler = compiler_from_module(build_files_dir, lang)
@@ -117,12 +108,9 @@ def usable_compilers(build_files_dir: str) -> dict:
 
 def read_replay_cache_lines(build_dir: str, compilers: dict = None) -> list:
     """_REPLAY_CACHE_KEYS lines verbatim from a configured dir's CMakeCache.txt, for inject() to replay.
-
-    A toolchain file that names the compiler leaves NO CMAKE_<lang>_COMPILER in the cache, because
-    cmake caches only what it detected itself. A seeded dir skips detection, so the cache stays empty
-    too. A CMakeLists that later runs `set(CMAKE_CXX_COMPILER $ENV{CXX})` with CXX unset then clears
-    the compiler, and every ninja rule compiles with "". `compilers` carries what usable_compilers()
-    read from the modules, so the cache always names the same compiler."""
+    cmake caches only what it detected itself, so a toolchain file or a seeded dir leaves NO
+    CMAKE_<lang>_COMPILER entry, and a project that resets the compiler from an unset env var then
+    compiles with "". `compilers` fills the missing entries, so the cache always names the compiler."""
     try: text = read_text_from(path_join(build_dir, 'CMakeCache.txt'))
     except OSError: text = ''
     lines = [ln for ln in text.splitlines() if ln.split(':', 1)[0] in _REPLAY_CACHE_KEYS]
@@ -134,15 +122,18 @@ def read_replay_cache_lines(build_dir: str, compilers: dict = None) -> list:
 
 
 def publish(seed_dir: str, build_files_dir: str, fingerprint='', probe='', build_dir='', clock=time.time) -> bool:
-    """Capture detection artifacts from a freshly-configured `build_files_dir`
-    (`<build>/CMakeFiles/<ver>`) into `seed_dir`. Returns False when the detection is not usable. Each
-    file lands via a temp + os.replace so a concurrent reader never copies a half-written file. The
-    manifest records three things. `fingerprint` lets a load re-verify the toolchain. `probe` names the
-    compiler binary whose disappearance invalidates the seed. `compilers` is what a load re-checks."""
+    """Capture detection artifacts from a freshly configured build dir into `seed_dir`. Returns False
+    when the detection is not usable. Each file lands via a temp + os.replace, so a concurrent
+    reader never copies a half-written file.
+    build_files_dir: the `<build>/CMakeFiles/<ver>` dir of a completed configure
+    fingerprint: recorded so a load can re-verify the toolchain
+    probe: the compiler binary whose disappearance invalidates the seed
+    build_dir: supplies the CMakeCache.txt lines that inject() replays
+    clock: time source, default is time.time
+    """
     langs = detected_langs(build_files_dir)
     compilers = usable_compilers(build_files_dir)
-    # never publish a half-detected toolchain, one missing a core language, or one naming a compiler
-    # this machine does not have
+    # never publish a half-detected toolchain or one naming a compiler this machine does not have
     if not covers_core_langs(langs) or detection_is_partial(build_files_dir) or not compilers: return False
     os.makedirs(seed_dir, exist_ok=True)
     copied = []
@@ -186,9 +177,8 @@ def is_valid(manifest, fingerprint: str) -> bool:
 
 
 def gc_stale(seed_root: str, log=lambda m: None):
-    """One cheap sweep of sibling seeds: drop any that cannot be valid anymore - a legacy seed from an
-    older mama (no fingerprint recorded) or one whose compiler binary is gone (an upgraded or removed
-    toolset). The sweep never touches a seed for a still-installed toolchain, so alternate-config seeds survive."""
+    """One cheap sweep of sibling seeds: drop any that cannot be valid anymore, a legacy seed with no
+    fingerprint or one whose compiler binary is gone. A seed for a still-installed toolchain survives."""
     try: names = os.listdir(seed_root)
     except OSError: return
     for name in names:
@@ -218,11 +208,10 @@ def load(seed_dir: str, ttl=BACKSTOP_TTL, clock=time.time):
 
 
 def inject(seed_dir: str, build_dir: str, build_files_dir: str, src_dir: str) -> bool:
-    """Make a fresh `build_dir` look already-configured so cmake skips ALL detection. Copies the
+    """Make a fresh `build_dir` look already configured, so cmake skips ALL detection. Copies the
     captured toolchain files into CMakeFiles/<ver>, then writes a CMakeCache.txt with the
-    PLATFORM_INFO_INITIALIZED marker and CMAKE_HOME_DIRECTORY. Returns False and writes NO marker when
-    the seed is empty, names no live compiler, or vanished mid-copy under a concurrent heal. The
-    caller then detects normally, instead of trusting a marker with no compiler files."""
+    PLATFORM_INFO_INITIALIZED marker and CMAKE_HOME_DIRECTORY. Returns False and writes NO marker
+    when the seed is empty, names no live compiler, or vanished mid-copy. The caller then detects normally."""
     manifest = load(seed_dir, ttl=float('inf'))
     if manifest and not _compilers_are_live(manifest): return False
     os.makedirs(build_files_dir, exist_ok=True)
@@ -237,8 +226,7 @@ def inject(seed_dir: str, build_dir: str, build_files_dir: str, src_dir: str) ->
     if not copied: return False
     cache = (f'CMAKE_PLATFORM_INFO_INITIALIZED:INTERNAL=1\n'
              f'CMAKE_HOME_DIRECTORY:INTERNAL={normalized_path(src_dir)}\n')
-    # ABI facts the skipped probe would set, plus the compiler/toolchain entries whose absence would
-    # make cmake reset the cache mid-configure and lose the toolchain file (see _REPLAY_CACHE_KEYS).
+    # ABI facts plus the compiler entries whose absence resets the cache mid-configure, see _REPLAY_CACHE_KEYS
     cache += ''.join(f'{line}\n' for line in manifest.get('cache_lines', []))
     with open(path_join(build_dir, 'CMakeCache.txt'), 'w', encoding='utf-8') as f:
         f.write(cache)
@@ -251,8 +239,8 @@ def purge(seed_dir: str):
 
 
 class Coordinator:
-    """Builds ONE seed per fingerprint from a synthetic C+CXX probe, then injects it into every fresh build
-    dir. The probe, not the first real target, is what makes it safe: the seed always covers both core
+    """Builds ONE seed per fingerprint from a synthetic C+CXX probe, then injects it into every fresh
+    build dir. The probe, not the first real target, makes it safe: the seed always covers both core
     languages. The election is in-process. A cross-process race only probes twice for identical content."""
 
     def __init__(self, seed_root, fp_fn, paths_fn, probe_fn=None, seed_fn=None, enabled=True, clock=time.time,
@@ -328,8 +316,7 @@ class Coordinator:
                 build_dir, build_files_dir = paths
                 ok = publish(self.seed_dir(target), build_files_dir, fingerprint=fp,
                              probe=self._probe(target), build_dir=build_dir, clock=self._clock)
-                # A refused publish spent the whole probe and gained nothing, so log it. Every build
-                # dir then detects its own toolchain, which is slow but always correct.
+                # a refused publish means every build dir detects its own toolchain: slow but correct, so log it
                 if not ok: self._log(f'compiler-seed probe rejected: {build_files_dir} named no usable compiler')
                 return ok
         except Exception as e:

--- a/mama/buildsys/cmake/configure.py
+++ b/mama/buildsys/cmake/configure.py
@@ -28,22 +28,21 @@ def _rerunnable_cmake_conf(cmd, cwd, allow_rerun, target:BuildTarget, delete_cma
             rerun = True
             delete_cmakecache = True
         elif System.windows:
-            # this happens every time MSVC compiler is updated. simple fix is to rerun cmake
+            # an MSVC compiler update triggers this every time, and a cmake rerun fixes it
             rerun |= line.startswith('  is not a full path to an existing compiler tool.')
         elif line.startswith('CMake Error: Error: generator :') or \
              line.startswith('CMake Error: The source'):
             rerun = True
             delete_cmakecache = True
 
-    # run CMake configure and handle output
     exit_status = SubProcess.run(cmd, cwd, env=env, io_func=handle_output)
 
     if rerun and allow_rerun:
         if target.config.print: console('Rerunning CMake configure')
         return _rerunnable_cmake_conf(cmd, cwd, False, target, delete_cmakecache=delete_cmakecache, env=env, out=out)
     if exit_status != 0:
-        # BuildError, not Exception: the cmake output above already says what's wrong, so this is
-        # reported as a clean one-liner instead of a traceback through mama's internals.
+        # BuildError, not Exception: the cmake output above already names the failure, so mama
+        # reports a clean one-liner instead of a traceback through its internals.
         raise util.BuildError(f'CMake configure failed for {target.name} (exit code {exit_status})')
     target.dep.save_enabled_sanitizers()
     target.dep.save_enabled_coverage()
@@ -51,10 +50,10 @@ def _rerunnable_cmake_conf(cmd, cwd, allow_rerun, target:BuildTarget, delete_cma
 
 def _set_compiler_paths(target:BuildTarget, opt:list[str]):
     """
-    Configures compilers for CMake, this needs to be done every time to prevent Ninja
-    or other backends incorrectly picking wrong compilers. CC/CXX are stripped from the
-    subprocess env by `compute_env` (not the global os.environ), so this is thread-safe.
-    A toolchain file picks the compiler itself, so mama must not name one too - see use_toolchain_file.
+    Name the compilers for cmake on every configure, so Ninja and other backends never pick the
+    wrong ones. `compute_env` strips CC/CXX from the subprocess env (not the global os.environ),
+    so this is thread-safe. A toolchain file picks the compiler itself, so mama must not name
+    one too - see use_toolchain_file.
     """
     if target.config.cmake_toolchain_file: return
     cc, cxx, ver = target.config.get_preferred_compiler_paths()
@@ -84,7 +83,7 @@ _BACKSLASH_PATH = re.compile(r'(?:\\[\w.\-+~$()]+)+')
 
 def _opts_to_defines(opts:list[str]) -> str:
     """`-D` flags for the cmake command line. Backslash PATHS become forward slashes because SubProcess
-    shlex-splits the command and would eat them: a mamafile passing a raw Windows path via
+    shlex-splits the command, which strips them: a raw Windows path a mamafile passes via
     add_cmake_options() silently arrives as C:ProjectsfoobinX.exe. cmake takes / on every platform."""
     opts_defines = ''
     for opt in opts:
@@ -125,21 +124,21 @@ _TOOLCHAIN_KEYS = ('CMAKE_TOOLCHAIN_FILE', 'CMAKE_SYSTEM_NAME', 'CMAKE_SYSTEM_PR
 
 
 def _toolchain_inputs(target:BuildTarget) -> dict:
-    """Cross-compile inputs that change compiler detection but aren't caught by cc/cxx stat. Keyed off the
-    whole platform opt set (an SDK move changes CMAKE_SYSROOT, not the 7 obvious keys). Empty dict for a
-    native build."""
+    """Cross-compile inputs that change compiler detection but the cc/cxx stat does not catch. Built from
+    the whole platform opt set, because an SDK move changes CMAKE_SYSROOT, not the 7 obvious keys. Empty
+    dict for a native build."""
     pairs = [o.partition('=') for o in _platform_opts(target)]  # one split per option, not two
     out = {k: v for k, _, v in pairs}
     out.update({k: v for k, _, v in (o.partition('=') for o in target.cmake_opts) if k in _TOOLCHAIN_KEYS})
-    # _platform_opts recorded the effective toolchain file; stat it so an edit in place invalidates too
+    # _platform_opts recorded the effective toolchain file. Stat it so an in-place edit also invalidates.
     tc = target.config.cmake_toolchain_file
     if tc: out['CMAKE_TOOLCHAIN_FILE'] = seedcache.compiler_stat(tc)
     return out
 
 
 def _seed_probe(target:BuildTarget) -> str:
-    """The compiler binary whose disappearance means the seed is stale (an upgraded/removed toolset).
-    For MSVC that's the toolset's cl.exe - which `get_preferred_compiler_paths` leaves empty - so resolve
+    """The compiler binary whose disappearance means the seed is stale (an upgraded or removed toolset).
+    For MSVC that is the toolset's cl.exe, which `get_preferred_compiler_paths` leaves empty, so resolve
     it explicitly. seedcache records it and GC checks it cheaply with os.path.exists."""
     config = target.config
     if config.msvc:
@@ -151,10 +150,10 @@ def _seed_probe(target:BuildTarget) -> str:
 
 def _seed_id(target:BuildTarget) -> str:
     """Platform-qualified seed id, e.g. `android-arm64-3f9c...`. The hash alone already covers platform
-    and arch, but a HOST seed reaching a cross build dir is catastrophic and silent - cmake sees
+    and arch, but a HOST seed reaching a cross build dir is catastrophic and silent. cmake sees
     CMAKE_PLATFORM_INFO_INITIALIZED, skips system determination, never runs the toolchain file, and the
-    project compiles with host flags. The directory name carries the platform so that mistake cannot
-    happen by hash collision and is obvious on disk."""
+    project compiles with host flags. The directory name carries the platform so a hash collision cannot
+    cause that mistake, and the platform is obvious on disk."""
     config = target.config
     fp = seedcache.compute_fingerprint(_seed_inputs(target))
     # Config-only, NOT dep.build_dir_name: this names a COMPILER seed, and a dep's args do not
@@ -186,13 +185,13 @@ def _seed_inputs(target:BuildTarget) -> dict:
 
 
 def _abi_stdlib(config) -> str:
-    """The -stdlib that reaches the CXX ABI probe, '' where it isn't a choice (only linux clang picks)."""
+    """The -stdlib that reaches the CXX ABI probe. '' where there is no choice (only linux clang picks one)."""
     return config.clang_stdlib if (config.linux and config.clang) else ''
 
 
 def _abi_flags(config) -> tuple:
-    """(C, CXX) flags that change what the ABI probe records as implicit link libs, so the seed must be
-    detected with them. A sanitizer pulls its runtime into both; -stdlib is C++-only (clang warns on C)."""
+    """(C, CXX) flags that change what the ABI probe records as implicit link libs, so the probe must
+    detect with them. A sanitizer pulls its runtime into both. -stdlib is C++-only (clang warns on C)."""
     san = [f'-fsanitize={config.sanitize}'] if (config.sanitize and not config.msvc) else []
     stdlib = [f'-stdlib={_abi_stdlib(config)}'] if _abi_stdlib(config) else []
     return ' '.join(san), ' '.join(san + stdlib)
@@ -204,8 +203,8 @@ _SEED_PROJECT = 'cmake_minimum_required(VERSION 3.15)\nproject(mama_seed C CXX)\
 @contextlib.contextmanager
 def _probe_toolchain(target:BuildTarget):
     """Detect the toolchain in a throwaway C+CXX project, not in whichever real target configures first (a
-    C-only one would seed no CXX). Yields (build_dir, build_files_dir), or None if it didn't cover both.
-    Context manager: the temp tree lives exactly until publish has copied it; mkdtemp avoids collisions."""
+    C-only one would seed no CXX). Yields (build_dir, build_files_dir), or None when the probe missed a language.
+    Context manager: the temp tree lives exactly until publish has copied it."""
     config = target.config
     c_abi, cxx_abi = _abi_flags(config)  # same ABI inputs as the real targets, per language
     flags = (f' -DCMAKE_C_FLAGS="{c_abi}"' if c_abi else '') + (f' -DCMAKE_CXX_FLAGS="{cxx_abi}"' if cxx_abi else '')
@@ -262,7 +261,7 @@ def _wipe_build_dir(target:BuildTarget):
 
 def _cache_entry(cache_text:str, key:str) -> str:
     """Value of a `KEY:TYPE=value` line in a CMakeCache ('' if absent). Anchored to the exact key with an
-    optional `:TYPE`, so CMAKE_GENERATOR won't pick up its CMAKE_GENERATOR_PLATFORM/_TOOLSET/_INSTANCE siblings."""
+    optional `:TYPE`, so CMAKE_GENERATOR skips its CMAKE_GENERATOR_PLATFORM/_TOOLSET/_INSTANCE siblings."""
     m = re.search(rf'^{re.escape(key)}(?::[^=\n]*)?=(.*)$', cache_text, re.MULTILINE)
     return m.group(1).strip() if m else ''
 
@@ -273,7 +272,7 @@ def cache_generator(cache_text:str) -> str:
 
 
 def generator_build_file_exists(build_dir:str, generator:str) -> bool:
-    """Does the build file THIS generator emits exist? Deliberately generator-specific: targets pick
+    """True when the build file THIS generator emits exists. Deliberately generator-specific: targets pick
     their own build system, so a leftover Makefile from an earlier Unix-Makefiles configure must NOT
     make a Ninja-configured dir look complete - `cmake --build` would then die on a missing build.ninja.
     An unrecognized generator is trusted (let cmake decide) rather than wrongly wiped."""
@@ -287,13 +286,13 @@ def generator_build_file_exists(build_dir:str, generator:str) -> bool:
 
 
 def is_cmake_cache_valid(build_dir:str) -> bool:
-    """True only if `build_dir` holds the artifacts of a configure that ran to COMPLETION - a plain existence
+    """True only when `build_dir` holds the artifacts of a configure that ran to COMPLETION. A plain existence
     check misses three poisoned shapes: truncated cache (no CMAKE_GENERATOR), no generated build file, and
     the other generator's stale leftover file. All three -> reconfigure."""
     cache = util.path_join(build_dir, 'CMakeCache.txt')
     if not os.path.exists(cache): return False
     try: generator = cache_generator(util.read_text_from(cache))
-    except OSError: return False  # unreadable cache is as good as missing -> reconfigure
+    except OSError: return False  # an unreadable cache counts as missing -> reconfigure
     if not generator: return False
     return generator_build_file_exists(build_dir, generator)
 
@@ -307,30 +306,30 @@ _TOOLCHAIN_FINGERPRINT_FILE = 'mama_toolchain.fingerprint'
 
 def _toolchain_fingerprint(target:BuildTarget) -> str:
     """Hash of THIS target's toolchain identity - compiler, generator, arch, platform, SDK, cross toolchain
-    (the same inputs the seed cache fingerprints). Recorded in the build dir by every completed configure, so
-    the NEXT configure can tell the dir was built against a toolchain that has since moved."""
+    (the same inputs the seed cache fingerprints). Every completed configure records it in the build dir,
+    so the NEXT configure can tell that the toolchain moved since the dir was built."""
     return seedcache.compute_fingerprint(_seed_inputs(target))
 
 
 def _read_toolchain_fingerprint(build_dir:str) -> str:
-    """Fingerprint the last completed configure of `build_dir` recorded; '' if none (never configured, or a
-    dir from before fingerprints were written)."""
+    """Fingerprint the last completed configure of `build_dir` recorded. '' if none (never configured, or a
+    dir from before mama wrote fingerprints)."""
     try: return util.read_text_from(util.path_join(build_dir, _TOOLCHAIN_FINGERPRINT_FILE)).strip()
     except OSError: return ''
 
 
 def _record_toolchain_fingerprint(build_dir:str, fingerprint:str):
-    """Persist the toolchain fingerprint next to the cache. Best-effort - a write failure just makes the next
+    """Persist the toolchain fingerprint next to the cache. Best-effort: a write failure makes the next
     run treat the dir as unfingerprinted (adopt), never an exception mid-configure."""
     try: util.write_text_to(util.path_join(build_dir, _TOOLCHAIN_FINGERPRINT_FILE), fingerprint)
     except OSError: pass
 
 
 def _toolchain_moved_unfingerprinted(build_dir:str, target:BuildTarget) -> bool:
-    """One-time heal for a dir configured before fingerprints were recorded: True only when the compiler the
-    cache was built with is DEFINITELY not the current one - the recorded path differs from the preferred
-    compiler, or no longer exists on disk. No explicit compiler (MSVC) or no cached compiler -> False: never
-    wipe on missing evidence, so shipping this can't mass-invalidate warm dirs whose toolchain is unchanged."""
+    """One-time heal for a dir that predates recorded fingerprints. True only when the compiler in the
+    cache is DEFINITELY not the current one: the recorded path differs from the preferred compiler, or
+    no longer exists on disk. No explicit compiler (MSVC) or no cached compiler -> False. Never wipe on
+    missing evidence, so this cannot mass-invalidate warm dirs whose toolchain is unchanged."""
     if target.config.cmake_toolchain_file:
         return False  # the cache holds the toolchain's own choice, which never equals ours
     cc_path, cxx_path, _ = target.config.get_preferred_compiler_paths()
@@ -342,7 +341,7 @@ def _toolchain_moved_unfingerprinted(build_dir:str, target:BuildTarget) -> bool:
         if not cached or not want: continue
         if util.normalized_path(cached) != util.normalized_path(want): return True  # compiler path moved
         return not os.path.exists(cached)  # same path but the binary is gone (e.g. store GC'd) -> moved
-    return False  # no compiler recorded in the cache -> nothing to compare, don't wipe
+    return False  # no compiler recorded in the cache -> nothing to compare, do not wipe
 
 
 def run_config(target:BuildTarget, out=None, _seed=True):
@@ -355,11 +354,11 @@ def run_config(target:BuildTarget, out=None, _seed=True):
         if current_sanitizers != previous_sanitizers:
             must_configure = True
 
-    # A build dir configured against a toolchain that has since MOVED - compiler/NDK/SDK path changed (e.g. a
-    # nix store rev bump relocates the Android NDK) - must be wiped, never soft-reconfigured: cmake keeps stale
-    # cache vars like CMAKE_SYSTEM_PROCESSOR, which then mis-drive the project's own CMakeLists. A recorded
-    # fingerprint that differs proves the move; a dir predating fingerprints falls back to its cached compiler
-    # path. An unfingerprinted dir with a matching/unknown toolchain is left alone, so this never mass-wipes.
+    # Wipe, never soft-reconfigure, a build dir whose toolchain has since MOVED - a changed compiler,
+    # NDK or SDK path (e.g. a nix store rev bump relocates the Android NDK). cmake keeps stale cache
+    # vars like CMAKE_SYSTEM_PROCESSOR, which then mis-drive the project's own CMakeLists. A recorded
+    # fingerprint that differs proves the move. A dir that predates fingerprints falls back to its cached
+    # compiler path. An unfingerprinted dir with a matching or unknown toolchain stays, so this never mass-wipes.
     toolchain_fingerprint = _toolchain_fingerprint(target)
     if os.path.exists(target.build_dir('CMakeCache.txt')):
         recorded = _read_toolchain_fingerprint(target.build_dir())
@@ -369,9 +368,9 @@ def run_config(target:BuildTarget, out=None, _seed=True):
             _note(target, out, 'toolchain changed since last configure - wiping build dir')
             _wipe_build_dir(target)
 
-    # A cache or a compiler detection left half-written by a killed configure poisons this run; drop both
-    # so it reconfigures clean instead of trusting what merely EXISTS. Detection is checked even with no
-    # cache at all: a kill mid-detection often saves none, and a `use` seed would re-add the marker.
+    # A half-written cache or compiler detection from a killed configure poisons this run. Drop both
+    # so it reconfigures clean instead of trusting what merely EXISTS. The detection check runs even
+    # with no cache at all: a kill mid-detection often saves none, and a `use` seed would re-add the marker.
     if seedcache.detection_is_partial(_build_files_dir(target)) \
        or (os.path.exists(target.build_dir('CMakeCache.txt')) and not is_cmake_cache_valid(target.build_dir())):
         _note(target, out, 'incomplete build dir (interrupted configure) - rebuilding it')
@@ -387,11 +386,11 @@ def run_config(target:BuildTarget, out=None, _seed=True):
     cmake_defines = _opts_to_defines(options)
     generator = _generator(target)
     src_dir = _seed_src_dir(target)
-    # Last, so cmake_opts can never override it by accident; set target.cmake_install_prefix instead.
+    # Last, so cmake_opts can never override it by accident. Set target.cmake_install_prefix instead.
     install_prefix = f'-DCMAKE_INSTALL_PREFIX="{target.cmake_install_prefix}"'
 
-    # Reuse cached compiler detection on a fresh build dir: prepare() injects a CMakeFiles seed +
-    # a PLATFORM_INFO_INITIALIZED CMakeCache so cmake skips ALL detection (~5s) (validated correct).
+    # Reuse cached compiler detection on a fresh build dir: prepare() injects a CMakeFiles seed and
+    # a PLATFORM_INFO_INITIALIZED CMakeCache, so cmake skips ALL detection (about 5s).
     cache_exists = os.path.exists(target.build_dir('CMakeCache.txt'))
     coord = _seed_coordinator(target)
     role = coord.prepare(target) if (_seed and not cache_exists) else 'none'
@@ -410,9 +409,8 @@ def run_config(target:BuildTarget, out=None, _seed=True):
             _wipe_build_dir(target)
             return run_config(target, out=out, _seed=False)
         raise
-    # Record the toolchain identity only after a configure that ran to completion, so the next run's move
-    # check compares against a dir that is actually consistent with this fingerprint (a failed configure
-    # leaves the previous/absent fingerprint, never a false baseline).
+    # Record the toolchain identity only after a completed configure, so the next run's move check
+    # never compares against a false baseline. A failed configure leaves the previous or absent fingerprint.
     _record_toolchain_fingerprint(target.build_dir(), toolchain_fingerprint)
 
 
@@ -424,8 +422,7 @@ _RERUNNABLE_ERRORS = (
 
 
 def is_rerunnable_error(output:str):
-    """ Checks output string if a rerunnable error occurred.
-        These are non-fatal errors that disappear with a simple cmake configure. """
+    """True when the output names a non-fatal error that a cmake configure rerun fixes."""
     return any(s in output for s in _RERUNNABLE_ERRORS)
 
 
@@ -471,9 +468,9 @@ def _generator(target:BuildTarget):
 
 
 def _make_program(target:BuildTarget) -> str:
-    """The build tool cmake drives. Ninja when the target enabled it, else whatever the platform
-    provides (only the Android NDK ships one). Asked from ONE place: appending the platform's make
-    here AND inside the platform's own option list passed CMAKE_MAKE_PROGRAM twice."""
+    """The build tool cmake drives. Ninja when the target enabled it, else what the platform
+    provides (only the Android NDK ships one). ONE call site only: naming the platform's make
+    here AND inside the platform's own option list passes CMAKE_MAKE_PROGRAM twice."""
     config:BuildConfig = target.config
     if target.enable_ninja_build: return config.ninja_path
     return config.platform.make_program(target)
@@ -486,10 +483,10 @@ def _default_options(target:BuildTarget):
     exceptions = target.enable_exceptions
 
     def add_flag(flag:str, value=''):
-        if not flag in cxxflags:  # add flag if not already set
+        if not flag in cxxflags:
             cxxflags[flag] = value
     def add_ldflag(flag:str, value=''):
-        if not flag in ldflags:  # add flag if not already set
+        if not flag in ldflags:
             ldflags[flag] = value
     def get_flags_string(flags:dict):
         res = ''
@@ -506,7 +503,7 @@ def _default_options(target:BuildTarget):
     if config.msvc:
         add_flag('/EHsc')
         add_flag('-D_HAS_EXCEPTIONS', '1' if exceptions else '0')
-        add_flag('-DWIN32', '1') # so yeah, only _WIN32 is defined by default, but opencv wants to see WIN32
+        add_flag('-DWIN32', '1') # MSVC only defines _WIN32 by default, but opencv wants WIN32
         add_flag('/MP') # multi-process build
     else:
         if target.gcc_clang_visibility_hidden:
@@ -536,7 +533,7 @@ def _default_options(target:BuildTarget):
             console(f'Enabling sanitizers: {config.sanitize}', color=Color.MAGENTA)
             ld_sanitize = f'-fsanitize={config.sanitize}'
             add_flag('-fsanitize', config.sanitize)
-            add_flag('-fno-sanitize-recover', config.sanitize) # fail the build on the first sanitizer error (UBSan recovers by default)
+            add_flag('-fno-sanitize-recover', config.sanitize) # fail on the first sanitizer error (UBSan recovers by default)
             add_flag('-fno-omit-frame-pointer')
             add_flag('-fPIE')
             add_ldflag('-pie') # -pie is a linker flag
@@ -586,9 +583,8 @@ def _default_options(target:BuildTarget):
             f'CMAKE_EXE_LINKER_FLAGS="{exe_ldflags}"',
             f'CMAKE_MODULE_LINKER_FLAGS="{exe_ldflags}"',
             f'CMAKE_SHARED_LINKER_FLAGS="{exe_ldflags}"',
-            # NOTE: CMAKE_STATIC_LINKER_FLAGS is intentionally omitted because
-            # it is passed to the archiver (ar), not the linker (ld),
-            # and ar does not understand linker flags like -Wl,--as-needed
+            # CMAKE_STATIC_LINKER_FLAGS is omitted on purpose: cmake passes it to the archiver (ar),
+            # not the linker (ld), and ar does not understand linker flags like -Wl,--as-needed
         ]
 
     make = _make_program(target)
@@ -637,7 +633,7 @@ def _buildsys_flags(target:BuildTarget):
     if config.msvc:
         flags = f'/v:m {mpf} /nologo'
     elif config.platform.build_system == 'xcode' and not (target.enable_unix_make or config.verbose):
-        flags = f'-quiet {mpf}'  # xcodebuild is extremely chatty unless it is told not to be
+        flags = f'-quiet {mpf}'  # xcodebuild floods the output unless -quiet is set
     else:
         flags = mpf
     return f'-- {flags}' if flags else ''

--- a/mama/buildsys/cmake/configure.py
+++ b/mama/buildsys/cmake/configure.py
@@ -49,12 +49,9 @@ def _rerunnable_cmake_conf(cmd, cwd, allow_rerun, target:BuildTarget, delete_cma
 
 
 def _set_compiler_paths(target:BuildTarget, opt:list[str]):
-    """
-    Name the compilers for cmake on every configure, so Ninja and other backends never pick the
-    wrong ones. `compute_env` strips CC/CXX from the subprocess env (not the global os.environ),
-    so this is thread-safe. A toolchain file picks the compiler itself, so mama must not name
-    one too - see use_toolchain_file.
-    """
+    """Name the compilers for cmake on every configure, so no backend picks the wrong ones.
+    `compute_env` strips CC/CXX from the subprocess env, so this is thread-safe. A toolchain file
+    picks the compiler itself, so mama must not name one too - see use_toolchain_file."""
     if target.config.cmake_toolchain_file: return
     cc, cxx, ver = target.config.get_preferred_compiler_paths()
     if cc:
@@ -82,9 +79,8 @@ _BACKSLASH_PATH = re.compile(r'(?:\\[\w.\-+~$()]+)+')
 
 
 def _opts_to_defines(opts:list[str]) -> str:
-    """`-D` flags for the cmake command line. Backslash PATHS become forward slashes because SubProcess
-    shlex-splits the command, which strips them: a raw Windows path a mamafile passes via
-    add_cmake_options() silently arrives as C:ProjectsfoobinX.exe. cmake takes / on every platform."""
+    """`-D` flags for the cmake command line. Backslash PATHS become forward slashes: SubProcess
+    shlex-splits the command, which silently strips them. cmake takes / on every platform."""
     opts_defines = ''
     for opt in opts:
         opts_defines += '-D' + _BACKSLASH_PATH.sub(lambda m: m.group(0).replace('\\', '/'), opt) + ' '
@@ -137,9 +133,8 @@ def _toolchain_inputs(target:BuildTarget) -> dict:
 
 
 def _seed_probe(target:BuildTarget) -> str:
-    """The compiler binary whose disappearance means the seed is stale (an upgraded or removed toolset).
-    For MSVC that is the toolset's cl.exe, which `get_preferred_compiler_paths` leaves empty, so resolve
-    it explicitly. seedcache records it and GC checks it cheaply with os.path.exists."""
+    """The compiler binary whose disappearance means the seed is stale. MSVC leaves the compiler
+    paths empty, so resolve the toolset's cl.exe explicitly. seedcache records it and GC stats it cheaply."""
     config = target.config
     if config.msvc:
         try: return util.normalized_path(config.get_msvc_cl64())
@@ -149,11 +144,9 @@ def _seed_probe(target:BuildTarget) -> str:
 
 
 def _seed_id(target:BuildTarget) -> str:
-    """Platform-qualified seed id, e.g. `android-arm64-3f9c...`. The hash alone already covers platform
-    and arch, but a HOST seed reaching a cross build dir is catastrophic and silent. cmake sees
-    CMAKE_PLATFORM_INFO_INITIALIZED, skips system determination, never runs the toolchain file, and the
-    project compiles with host flags. The directory name carries the platform so a hash collision cannot
-    cause that mistake, and the platform is obvious on disk."""
+    """Platform-qualified seed id, e.g. `android-arm64-3f9c...`. A HOST seed reaching a cross build
+    dir would make cmake skip system determination and compile with host flags, silently. The name
+    carries the platform, so a hash collision cannot cause that, and the platform is obvious on disk."""
     config = target.config
     fp = seedcache.compute_fingerprint(_seed_inputs(target))
     # Config-only, NOT dep.build_dir_name: this names a COMPILER seed, and a dep's args do not
@@ -172,9 +165,8 @@ def _seed_inputs(target:BuildTarget) -> dict:
         'cver': ver, 'sdk': os.environ.get('WindowsSDKVersion', ''),
         'toolchain': _toolchain_inputs(target),
         'stdlib': _abi_stdlib(config),  # libc++ vs libstdc++ changes the CXX ABI probe's implicit link libs
-        # The seed shape belongs to the toolchain identity of a build dir. An older seed wrote a cache
-        # with no CMAKE_<lang>_COMPILER, and a dir seeded from it keeps that hole forever. A new format
-        # flips every fingerprint once, so run_config wipes those dirs and seeds them again.
+        # The seed shape belongs to the toolchain identity of a build dir. A new format flips every
+        # fingerprint once, so run_config wipes the dirs an older seed shaped and seeds them again.
         'seedfmt': seedcache._SEED_FORMAT,
     }
     if config.msvc:  # MSVC leaves cc/cxx empty, so stat cl.exe directly - else a toolset upgrade is invisible
@@ -202,9 +194,9 @@ _SEED_PROJECT = 'cmake_minimum_required(VERSION 3.15)\nproject(mama_seed C CXX)\
 
 @contextlib.contextmanager
 def _probe_toolchain(target:BuildTarget):
-    """Detect the toolchain in a throwaway C+CXX project, not in whichever real target configures first (a
-    C-only one would seed no CXX). Yields (build_dir, build_files_dir), or None when the probe missed a language.
-    Context manager: the temp tree lives exactly until publish has copied it."""
+    """Detect the toolchain in a throwaway C+CXX project, not in whichever real target configures
+    first: a C-only one would seed no CXX. Yields (build_dir, build_files_dir), or None when the
+    probe missed a language. The temp tree lives exactly until publish has copied it."""
     config = target.config
     c_abi, cxx_abi = _abi_flags(config)  # same ABI inputs as the real targets, per language
     flags = (f' -DCMAKE_C_FLAGS="{c_abi}"' if c_abi else '') + (f' -DCMAKE_CXX_FLAGS="{cxx_abi}"' if cxx_abi else '')
@@ -246,9 +238,8 @@ def _seed_coordinator(target:BuildTarget) -> seedcache.Coordinator:
 
 
 def _note(target:BuildTarget, out, text:str):
-    """Report a build-dir decision on the target's OWN output, so mamabuild.log keeps the reason next to
-    the configure it explains. A bare warning() depends on the thread capture of the running phase. A
-    reason that misses the log leaves a slow reconfigure with nothing to explain it."""
+    """Report a build-dir decision on the target's OWN output, so the log keeps the reason next to
+    the configure it explains. A bare warning() depends on the thread capture of the running phase."""
     if target.config.print: warning_to(out, f'  - Target {target.name: <16} {text}')
 
 
@@ -272,10 +263,9 @@ def cache_generator(cache_text:str) -> str:
 
 
 def generator_build_file_exists(build_dir:str, generator:str) -> bool:
-    """True when the build file THIS generator emits exists. Deliberately generator-specific: targets pick
-    their own build system, so a leftover Makefile from an earlier Unix-Makefiles configure must NOT
-    make a Ninja-configured dir look complete - `cmake --build` would then die on a missing build.ninja.
-    An unrecognized generator is trusted (let cmake decide) rather than wrongly wiped."""
+    """True when the build file THIS generator emits exists. A leftover Makefile from another
+    generator must NOT make a Ninja-configured dir look complete, or `cmake --build` dies on a
+    missing build.ninja. An unrecognized generator is trusted rather than wrongly wiped."""
     gen = generator.lower()
     if 'ninja' in gen:         return os.path.exists(util.path_join(build_dir, 'build.ninja'))
     if 'makefiles' in gen:     return os.path.exists(util.path_join(build_dir, 'Makefile'))
@@ -305,9 +295,8 @@ _TOOLCHAIN_FINGERPRINT_FILE = 'mama_toolchain.fingerprint'
 
 
 def _toolchain_fingerprint(target:BuildTarget) -> str:
-    """Hash of THIS target's toolchain identity - compiler, generator, arch, platform, SDK, cross toolchain
-    (the same inputs the seed cache fingerprints). Every completed configure records it in the build dir,
-    so the NEXT configure can tell that the toolchain moved since the dir was built."""
+    """Hash of THIS target's toolchain identity, the same inputs the seed cache fingerprints. Every
+    completed configure records it, so the NEXT one can tell that the toolchain moved since."""
     return seedcache.compute_fingerprint(_seed_inputs(target))
 
 
@@ -326,10 +315,9 @@ def _record_toolchain_fingerprint(build_dir:str, fingerprint:str):
 
 
 def _toolchain_moved_unfingerprinted(build_dir:str, target:BuildTarget) -> bool:
-    """One-time heal for a dir that predates recorded fingerprints. True only when the compiler in the
-    cache is DEFINITELY not the current one: the recorded path differs from the preferred compiler, or
-    no longer exists on disk. No explicit compiler (MSVC) or no cached compiler -> False. Never wipe on
-    missing evidence, so this cannot mass-invalidate warm dirs whose toolchain is unchanged."""
+    """One-time heal for a dir that predates recorded fingerprints. True only when the cached
+    compiler is DEFINITELY not the current one: the recorded path differs from the preferred
+    compiler, or is gone from disk. Never wipe on missing evidence, so this cannot mass-invalidate warm dirs."""
     if target.config.cmake_toolchain_file:
         return False  # the cache holds the toolchain's own choice, which never equals ours
     cc_path, cxx_path, _ = target.config.get_preferred_compiler_paths()
@@ -354,11 +342,9 @@ def run_config(target:BuildTarget, out=None, _seed=True):
         if current_sanitizers != previous_sanitizers:
             must_configure = True
 
-    # Wipe, never soft-reconfigure, a build dir whose toolchain has since MOVED - a changed compiler,
-    # NDK or SDK path (e.g. a nix store rev bump relocates the Android NDK). cmake keeps stale cache
-    # vars like CMAKE_SYSTEM_PROCESSOR, which then mis-drive the project's own CMakeLists. A recorded
-    # fingerprint that differs proves the move. A dir that predates fingerprints falls back to its cached
-    # compiler path. An unfingerprinted dir with a matching or unknown toolchain stays, so this never mass-wipes.
+    # Wipe, never soft-reconfigure, a build dir whose toolchain has since MOVED: cmake keeps stale
+    # cache vars like CMAKE_SYSTEM_PROCESSOR, which mis-drive the project's own CMakeLists. A differing
+    # recorded fingerprint proves the move. A dir that predates fingerprints falls back to its cached compiler path.
     toolchain_fingerprint = _toolchain_fingerprint(target)
     if os.path.exists(target.build_dir('CMakeCache.txt')):
         recorded = _read_toolchain_fingerprint(target.build_dir())
@@ -368,9 +354,9 @@ def run_config(target:BuildTarget, out=None, _seed=True):
             _note(target, out, 'toolchain changed since last configure - wiping build dir')
             _wipe_build_dir(target)
 
-    # A half-written cache or compiler detection from a killed configure poisons this run. Drop both
-    # so it reconfigures clean instead of trusting what merely EXISTS. The detection check runs even
-    # with no cache at all: a kill mid-detection often saves none, and a `use` seed would re-add the marker.
+    # A half-written cache or compiler detection from a killed configure poisons this run, so drop both
+    # and reconfigure clean. The detection check runs even with no cache at all: a kill mid-detection
+    # often saves none, and a `use` seed would re-add the marker.
     if seedcache.detection_is_partial(_build_files_dir(target)) \
        or (os.path.exists(target.build_dir('CMakeCache.txt')) and not is_cmake_cache_valid(target.build_dir())):
         _note(target, out, 'incomplete build dir (interrupted configure) - rebuilding it')
@@ -447,10 +433,8 @@ def run_build(target:BuildTarget, install:bool, extraflags='', rerun=True, out=N
 
 
 def _unused_cli_flag(target:BuildTarget) -> str:
-    """Silence cmake's `Manually-specified variables were not used by the project` block. mama always
-    passes CMAKE_C_COMPILER, so every C++-only project reports it, and the warning says nothing about
-    that project. Kept under `verbose`, where it is the only signal that an add_cmake_options() name is
-    misspelled."""
+    """Silence cmake's unused-variables block: mama always passes CMAKE_C_COMPILER, so every C++-only
+    project reports it. Kept under `verbose`, the only signal that an add_cmake_options() name is misspelled."""
     return '' if target.config.verbose else '--no-warn-unused-cli '
 
 
@@ -468,9 +452,8 @@ def _generator(target:BuildTarget):
 
 
 def _make_program(target:BuildTarget) -> str:
-    """The build tool cmake drives. Ninja when the target enabled it, else what the platform
-    provides (only the Android NDK ships one). ONE call site only: naming the platform's make
-    here AND inside the platform's own option list passes CMAKE_MAKE_PROGRAM twice."""
+    """The build tool cmake drives: Ninja when the target enabled it, else what the platform
+    provides. ONLY this place names it, or cmake gets CMAKE_MAKE_PROGRAM twice."""
     config:BuildConfig = target.config
     if target.enable_ninja_build: return config.ninja_path
     return config.platform.make_program(target)
@@ -609,9 +592,9 @@ def _build_config(target:BuildTarget, install:bool):
 
 
 def _jobs(target:BuildTarget) -> int:
-    """Build parallelism for this target: a scheduler-sized `_build_jobs` (from the TU probe)
-    when set, else the global `config.jobs`. Per-target so concurrent builds never clobber
-    a shared `-j` value. The root runs alone after all deps, so it always gets full `config.jobs`."""
+    """Build parallelism for this target: a scheduler-sized `_build_jobs` when set, else the global
+    `config.jobs`. Per-target, so concurrent builds never clobber a shared `-j` value. The root
+    runs alone after all deps, so it always gets full `config.jobs`."""
     if target.dep.is_root: return target.config.jobs
     return target._build_jobs or target.config.jobs
 

--- a/mama/buildsys/cmake/mamacmake.py
+++ b/mama/buildsys/cmake/mamacmake.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from mama.platforms.registry import PLATFORMS
 
 
-# The CMake condition that identifies each platform, in the order mama.cmake tests them. The order is
-# the registry's, and it matters: android is also UNIX and iOS is also APPLE, so the specific guard
-# must come first. A consumer's CMakeLists cannot detect a platform missing from here.
+# The CMake condition per platform, tested in registry order: android is also UNIX and iOS is also
+# APPLE, so the specific guard comes first. A consumer cannot detect a platform missing from here.
 _GUARDS = {
     'android': 'ANDROID OR ANDROID_NDK',
     'windows': 'WIN32',
@@ -22,9 +21,9 @@ _GUARDS = {
 # Variables a consumer's CMakeLists has always been able to test, beyond the platform's own define.
 _EXTRA_VARS = {'ios': ('IOS',), 'macos': ('MACOS',), 'linux': ('LINUX',)}
 
-# The MAMA_CMAKE_ARCH pattern and the variable each arch sets. mama.cmake tests them in THIS order, so
-# x64 wins before x86 (which also matches x86_64) and mips64el before mips. Each pattern is a union of
-# what CMAKE_GENERATOR_PLATFORM, ANDROID_ARCH and CMAKE_SYSTEM_PROCESSOR report for that arch.
+# The MAMA_CMAKE_ARCH pattern and the variable each arch sets, tested in THIS order: x64 before x86,
+# which also matches x86_64, and mips64el before mips. Each pattern is a union of what
+# CMAKE_GENERATOR_PLATFORM, ANDROID_ARCH and CMAKE_SYSTEM_PROCESSOR report for that arch.
 _ARCH_MATCH = (
     ('x64',      'MAMA_ARCH_X64',   '(amd64)|(AMD64)|(IA64)|(x64)|(X64)|(x86_64)|(X86_64)'),
     ('x86',      'MAMA_ARCH_X86',   '(X86)|(x86)|(i386)|(i686)'),
@@ -46,10 +45,8 @@ def _platform_header(platform) -> str:
 
 
 def _arch_branches(platform, build_dir_defines) -> str:
-    """The per-arch body: set the arch variable and point MAMA_BUILD at that arch's build dir.
-
-    A platform with one arch needs no branch at all. With several, an unmatched arch is a FATAL_ERROR:
-    picking a build dir on a guess silently links the wrong architecture's libraries."""
+    """The per-arch body: set the arch variable and point MAMA_BUILD at that arch's build dir. An
+    unmatched arch is a FATAL_ERROR: a guessed build dir silently links the wrong architecture's libraries."""
     arches = [a for a in _ARCH_MATCH if a[0] in platform.supported_arches]
     if len(arches) == 1:
         arch, var, _ = arches[0]
@@ -69,10 +66,10 @@ def _arch_branches(platform, build_dir_defines) -> str:
 
 
 def platform_chain(build_dir_defines) -> str:
-    """The whole if/elseif chain over every platform mama supports, generated from the registry.
-
-    `build_dir_defines(build_dir)` returns the MAMA_BUILD lines for one build dir. Generated, so the
-    chain and BuildConfig can no longer drift apart: they read the same build_dirs table."""
+    """The whole if/elseif chain over every platform, generated from the registry, so the chain and
+    BuildConfig read the same build_dirs table and cannot drift apart.
+    build_dir_defines: callable that returns the MAMA_BUILD lines for one build dir
+    """
     chain = ''
     for i, platform in enumerate(PLATFORMS):
         test = 'if' if i == 0 else 'elseif'

--- a/mama/buildsys/cmake/mamacmake.py
+++ b/mama/buildsys/cmake/mamacmake.py
@@ -4,8 +4,8 @@ from mama.platforms.registry import PLATFORMS
 
 
 # The CMake condition that identifies each platform, in the order mama.cmake tests them. The order is
-# the registry's, and it matters: android is also UNIX and iOS is also APPLE, so the specific guard has
-# to come first. A platform missing from here cannot be detected by a consumer's CMakeLists.
+# the registry's, and it matters: android is also UNIX and iOS is also APPLE, so the specific guard
+# must come first. A consumer's CMakeLists cannot detect a platform missing from here.
 _GUARDS = {
     'android': 'ANDROID OR ANDROID_NDK',
     'windows': 'WIN32',
@@ -22,9 +22,9 @@ _GUARDS = {
 # Variables a consumer's CMakeLists has always been able to test, beyond the platform's own define.
 _EXTRA_VARS = {'ios': ('IOS',), 'macos': ('MACOS',), 'linux': ('LINUX',)}
 
-# How MAMA_CMAKE_ARCH is matched, and the variable each arch sets. Tested in THIS order, so x64 wins
-# before x86 (which also matches x86_64) and mips64el before mips. The patterns are a union of what
-# CMAKE_GENERATOR_PLATFORM, ANDROID_ARCH and CMAKE_SYSTEM_PROCESSOR each report for that arch.
+# The MAMA_CMAKE_ARCH pattern and the variable each arch sets. mama.cmake tests them in THIS order, so
+# x64 wins before x86 (which also matches x86_64) and mips64el before mips. Each pattern is a union of
+# what CMAKE_GENERATOR_PLATFORM, ANDROID_ARCH and CMAKE_SYSTEM_PROCESSOR report for that arch.
 _ARCH_MATCH = (
     ('x64',      'MAMA_ARCH_X64',   '(amd64)|(AMD64)|(IA64)|(x64)|(X64)|(x86_64)|(X86_64)'),
     ('x86',      'MAMA_ARCH_X86',   '(X86)|(x86)|(i386)|(i686)'),

--- a/mama/buildsys/cmake/options.py
+++ b/mama/buildsys/cmake/options.py
@@ -11,17 +11,12 @@ if TYPE_CHECKING:
 
 
 def use_toolchain_file(config:BuildConfig, toolchain:str) -> str:
-    """Record the toolchain file a platform picked and return its cmake option. Every platform that has
-    one routes through here, so `config.cmake_toolchain_file` answers "is a toolchain file in play" with
-    one bool read - nothing has to scan the option list.
-
-    It also decides whether mama may name the compiler. A toolchain file REWRITES that choice. The
-    Android NDK's takes our `bin/aarch64-linux-android29-clang`, puts `bin/clang` in the cache and
-    drives the target with `--target=` instead. Same compiler, different string - and the string is all
-    cmake compares. On a build dir that already holds a cache (a warm dir, or one the compiler seed
-    pre-populated) our -DCMAKE_C_COMPILER then reads as a CHANGED variable, so cmake deletes the cache
-    and re-runs. That second pass loses the seeded platform info and re-detects, so a cross build
-    compiles with host flags."""
+    """Record the toolchain file a platform picked and return its cmake option. Every platform that
+    has one routes through here, so `config.cmake_toolchain_file` answers "is a toolchain file in
+    play" with one bool read. The record also stops mama from naming the compiler: a toolchain file
+    REWRITES that choice to its own string, and the string is all cmake compares. On a build dir
+    that already holds a cache, our -DCMAKE_C_COMPILER then reads as a CHANGED variable. cmake
+    then wipes the cache mid-configure, loses the seeded platform info and re-detects as the host."""
     config.cmake_toolchain_file = toolchain
     return f'CMAKE_TOOLCHAIN_FILE="{toolchain}"'
 
@@ -38,20 +33,17 @@ def _toolchain_file(target:BuildTarget, platform:Platform, tc:Toolchain) -> str:
     return tc.toolchain_file
 
 
-# The cross binutils a toolchain names explicitly. cmake derives them from the compiler path when
-# the toolchain does not name them, which picks the host's wherever find-root restricts the search.
+# Cross binutils named explicitly: cmake otherwise derives them from the compiler path, which picks
+# the host's wherever find-root restricts the search.
 _BINUTILS = ('ar', 'readelf', 'strip', 'ranlib')
 
 
 def platform_opts(target:BuildTarget) -> list:
     """Render the active platform's Toolchain into cmake options.
 
-    This is the ONLY place a platform fact becomes a cmake option. A platform describes what it needs
-    (see mama/platforms/toolchain.py) and never formats a `-D` flag, so a second build system reads the
-    same description and writes its own.
-
-    Config-level only, no project flags, so the seed probe and the seed fingerprint can both use it and
-    stay target-independent."""
+    This is the ONLY place a platform fact becomes a cmake option. A platform never formats a `-D`
+    flag, so a second build system reads the same facts and writes its own. Config-level only, no
+    project flags, so the seed probe and the seed fingerprint can both use it and stay target-independent."""
     config:BuildConfig = target.config
     platform = config.platform
     tc = platform.toolchain()
@@ -60,9 +52,8 @@ def platform_opts(target:BuildTarget) -> list:
     if platform.platform_define: opts.append(f'{platform.platform_define}=TRUE')
     if tc.host_toolset: opts.append(f'CMAKE_GENERATOR_TOOLSET=host={tc.host_toolset}')
     if platform.is_cross:
-        # EVERY cross platform emits both. The toolchain file cannot carry the processor alone: the
-        # compiler seed writes CMAKE_PLATFORM_INFO_INITIALIZED, cmake then skips system determination,
-        # the toolchain file never runs, and the processor falls back to the host's.
+        # EVERY cross platform emits both. On a seeded build dir cmake skips system determination, the
+        # toolchain file never runs, and a processor it alone carries falls back to the host's.
         opts.append(f'CMAKE_SYSTEM_NAME={tc.system_name}')
         if tc.system_processor: opts.append(f'CMAKE_SYSTEM_PROCESSOR={tc.system_processor}')
     opts += list(tc.extra_opts)

--- a/mama/buildsys/cmake/options.py
+++ b/mama/buildsys/cmake/options.py
@@ -15,20 +15,20 @@ def use_toolchain_file(config:BuildConfig, toolchain:str) -> str:
     one routes through here, so `config.cmake_toolchain_file` answers "is a toolchain file in play" with
     one bool read - nothing has to scan the option list.
 
-    It also decides whether mama may name the compiler. A toolchain file REWRITES that choice: the
-    Android NDK's takes our `bin/aarch64-linux-android29-clang` and puts `bin/clang` in the cache,
-    driving the target with `--target=` instead. Same compiler, different string - and the string is all
+    It also decides whether mama may name the compiler. A toolchain file REWRITES that choice. The
+    Android NDK's takes our `bin/aarch64-linux-android29-clang`, puts `bin/clang` in the cache and
+    drives the target with `--target=` instead. Same compiler, different string - and the string is all
     cmake compares. On a build dir that already holds a cache (a warm dir, or one the compiler seed
     pre-populated) our -DCMAKE_C_COMPILER then reads as a CHANGED variable, so cmake deletes the cache
-    and re-runs. That second pass loses the seeded platform info and re-detects, which is how a cross
-    build ends up compiling with host flags."""
+    and re-runs. That second pass loses the seeded platform info and re-detects, so a cross build
+    compiles with host flags."""
     config.cmake_toolchain_file = toolchain
     return f'CMAKE_TOOLCHAIN_FILE="{toolchain}"'
 
 
 def _toolchain_file(target:BuildTarget, platform:Platform, tc:Toolchain) -> str:
     """The toolchain file this build uses. A mamafile can override the platform's own through the
-    target attribute the platform names, eg `cmake_ndk_toolchain`."""
+    target attribute the platform names, for example `cmake_ndk_toolchain`."""
     attr = platform.toolchain_override_attr
     override = getattr(target, attr, '') if attr else ''
     if override:
@@ -39,7 +39,7 @@ def _toolchain_file(target:BuildTarget, platform:Platform, tc:Toolchain) -> str:
 
 
 # The cross binutils a toolchain names explicitly. cmake derives them from the compiler path when
-# they are not given, which picks the host's wherever the find-root modes restrict its own search.
+# the toolchain does not name them, which picks the host's wherever find-root restricts the search.
 _BINUTILS = ('ar', 'readelf', 'strip', 'ranlib')
 
 
@@ -60,9 +60,9 @@ def platform_opts(target:BuildTarget) -> list:
     if platform.platform_define: opts.append(f'{platform.platform_define}=TRUE')
     if tc.host_toolset: opts.append(f'CMAKE_GENERATOR_TOOLSET=host={tc.host_toolset}')
     if platform.is_cross:
-        # EVERY cross platform emits both. Leaving the processor to the toolchain file is what broke
-        # android: the compiler seed writes CMAKE_PLATFORM_INFO_INITIALIZED, cmake then skips system
-        # determination, the toolchain file never runs, and the processor falls back to the host's.
+        # EVERY cross platform emits both. The toolchain file cannot carry the processor alone: the
+        # compiler seed writes CMAKE_PLATFORM_INFO_INITIALIZED, cmake then skips system determination,
+        # the toolchain file never runs, and the processor falls back to the host's.
         opts.append(f'CMAKE_SYSTEM_NAME={tc.system_name}')
         if tc.system_processor: opts.append(f'CMAKE_SYSTEM_PROCESSOR={tc.system_processor}')
     opts += list(tc.extra_opts)

--- a/mama/dependency_chain.py
+++ b/mama/dependency_chain.py
@@ -18,8 +18,8 @@ def _get_cmake_path_list(paths):
 
 
 def _get_exported_libs(target):
-    """The exported libs this platform can actually link. A versioned ELF name (libfoo.so.1.2.3) is a
-    real link target, so it passes wherever plain .so does."""
+    """The exported libs this platform can link. A versioned ELF name (libfoo.so.1.2.3) is a
+    real link target, so it passes where a plain .so does."""
     allowed = target.config.platform.lib_extensions()
     versioned = '.so' in allowed
     return [lib for lib in target.exported_libs if lib and
@@ -27,10 +27,10 @@ def _get_exported_libs(target):
 
 
 def _get_hierarchical_libs(root: BuildDependency):
-    """Exported libs of `root` and every dependency below it, in Unix link order (a lib comes after
-    everything that references it). Walks get_flat_deps - which already dedups with the [parent][child]
-    keep-last ordering - instead of a raw recursive DFS, which re-appended a shared dep's libs once per
-    path through the graph (a shared lib repeated dozens of times on one link line)."""
+    """Exported libs of `root` and every dep below it, in Unix link order: a lib comes after
+    everything that references it. Walks get_flat_deps, which dedups with the keep-last
+    [parent][child] order. A raw recursive DFS re-appended the libs of a shared dep once per
+    path through the graph, so one link line repeated a shared lib dozens of times."""
     deps = []
     syslibs = []
     for dep in get_flat_deps(root):
@@ -40,11 +40,11 @@ def _get_hierarchical_libs(root: BuildDependency):
 
 
 def _get_flattened_deps(root: BuildDependency):
-    # deps have to be sorted in [parent] [child] order for Unix linkers
+    # a Unix linker needs [parent] [child] order
     ordered = []
     def add_unique_items(deps: List[BuildDependency]):
         for child in deps:
-            if child in ordered: # already in deps list, so we need to move it lower
+            if child in ordered: # already listed: move it lower
                 ordered.remove(child)
             ordered.append(child)
             add_unique_items(child.get_children())
@@ -53,20 +53,20 @@ def _get_flattened_deps(root: BuildDependency):
 
 
 def get_flat_deps(root: BuildDependency):
-    """ Gets flat dependencies, including root """
+    """ Return the flat deps, including root. """
     return [root] + _get_flattened_deps(root)
 
 
 def get_flat_child_deps(dep: BuildDependency):
-    """ Gets flat child dependencies of dep, excluding dep itself """
+    """ Return the flat child deps of dep, without dep itself. """
     return _get_flattened_deps(dep)
 
 
 def mark_unbuilt_target_deps(root: BuildDependency, config: BuildConfig):
-    """`build target=X` builds only X - but a dep X NEEDS with nothing on disk must build too, or X compiles
-    against an include dir that doesn't exist. Scoped to X's own subtree: marking every unbuilt dep in the
-    workspace would build unrelated targets, and a mamafile that shells out to `mama build target=Y` would
-    then re-enter itself - a fork bomb."""
+    """`build target=X` builds only X. A dep that X needs with nothing on disk must also build, or X
+    compiles against an include dir that does not exist. The scope is the subtree of X. A mark on every
+    unbuilt dep in the workspace would build unrelated targets, and a mamafile that runs
+    `mama build target=Y` would then re-enter itself - a fork bomb."""
     target = find_dependency(root, config.target)
     if target is None: return
     for dep in get_flat_child_deps(target):
@@ -81,13 +81,13 @@ _BUILD_DIR_MARKERS = ('CMakeCache.txt', 'mama-dependencies.cmake', 'mama_exporte
 
 
 def sweep_orphaned_build_dirs(root: BuildDependency, config: BuildConfig) -> int:
-    """`clean all` promises to clean EVERYTHING for this platform, but the tree walk can't reach a dep
-    whose source is gone (an earlier clean removed its shim, so it parses no mamafile and declares no
-    children) - those children's build dirs would then survive every future clean. Enumerate from disk
-    as well, deleting only dirs that carry a mama marker file. Returns how many were removed.
+    """`clean all` must clean EVERYTHING for this platform, but the tree walk cannot reach a dep whose
+    source is gone. An earlier clean removed its shim, so it parses no mamafile and declares no
+    children. The build dirs of those children would then survive every future clean. So also
+    enumerate from disk, and delete only dirs that carry a mama marker file. Return the removed count.
 
-    One dep can hold several build dirs of ONE config, because a dep the consumer added with args=[...]
-    names its own (linux, linux-lgpl). An unreachable dep's args are unknown, so list what is on disk and
+    One dep can hold several build dirs of ONE config, because a dep added with args=[...] names its
+    own (linux, linux-lgpl). The args of an unreachable dep are unknown, so list what is on disk and
     ask build_names which dirs belong to this config."""
     workspace = os.path.dirname(root.dep_dir)
     config_dir = root.build_dir_name  # the root carries no dep args, so this is the config's own dir name
@@ -110,9 +110,8 @@ def sweep_orphaned_build_dirs(root: BuildDependency, config: BuildConfig) -> int
 
 def get_deps_only_targets(root: BuildDependency, deps_only_target_name: str, config: BuildConfig):
     """
-    For `deps_only` with a specific target, returns (flat_deps, flat_deps_reverse)
-    containing only the dependencies of the named target.
-    Also marks those deps for rebuild and cleans them if needed.
+    For `deps_only` with a target name, return (flat_deps, flat_deps_reverse) with only
+    the deps of that target. Also mark those deps for rebuild, and clean them when needed.
     """
     deps_only_dep = find_dependency(root, deps_only_target_name)
     flat_deps = _get_flattened_deps(deps_only_dep)
@@ -128,15 +127,15 @@ def get_deps_only_targets(root: BuildDependency, deps_only_target_name: str, con
 
 class DepsOnlyScope:
     """`deps_only` for the unified scheduler: which deps may configure and build. Every dep still LOADs,
-    because the graph is only discovered by loading it. Without a target name the scope root is the
-    project root, so every dependency builds and the root does not. With a target name the scope root is
-    that target, so only the deps below it build. A named target also forces its deps to rebuild, and a
+    because only a load discovers the graph. Without a target name the scope root is the project root,
+    so every dependency builds and the root does not. With a target name the scope root is that
+    target, so only the deps below it build. A named target also forces its deps to rebuild, and a
     `rebuild` cleans them first. This matches get_deps_only_targets on the classic path."""
 
     def __init__(self, config: BuildConfig, target_name: str = None):
         self.config = config
         self.target_name = target_name.lower() if target_name else None
-        self.found = target_name is None  # a named target must turn up somewhere in the tree
+        self.found = target_name is None  # a named target must appear somewhere in the tree
         self._under = {}  # dep -> True when the dep is the scope root or below it
 
     def _is_scope_root(self, dep: BuildDependency) -> bool:
@@ -157,9 +156,9 @@ class DepsOnlyScope:
         return self.is_inside(dep) and not self._is_scope_root(dep)
 
     def promote(self, dep: BuildDependency) -> List[BuildDependency]:
-        """A dep first discovered outside the scope, now reached through it - a shared dep of both the
-        named target and an unrelated branch. Mark it and everything already discovered below it, and
-        return the deps that gained build work."""
+        """A dep that the walk first found outside the scope and now reaches through it - a shared dep
+        of both the named target and an unrelated branch. Mark it and everything already found below
+        it, and return the deps that gained build work."""
         if self.is_inside(dep): return []
         self._under[dep] = True
         gained = [dep]
@@ -184,8 +183,8 @@ class DepsOnlyScope:
 
 
 def get_deps_that_depend_on_target(root: BuildDependency, target: BuildDependency, deps = []) -> List[BuildDependency]:
+    """ Return all dependencies that depend on the target. """
     discovered_new = False
-    """ Gets all dependencies that depend on the target """
     def depth_first_search_for_target(dep: BuildDependency):
         nonlocal discovered_new, target, deps
         depends = False
@@ -203,8 +202,7 @@ def get_deps_that_depend_on_target(root: BuildDependency, target: BuildDependenc
         deps.append(root)
         discovered_new = True
 
-    # now that we have the initial deps,
-    # we need to further expand it to include second level dependencies
+    # expand the initial deps to include second-level dependencies
     while discovered_new:
         discovered_new = False
         for d in deps:
@@ -221,16 +219,14 @@ def _get_mama_dependencies_cmake(root: BuildDependency, build:str):
 
 
 def _mama_cmake_path(root: BuildDependency):
-    if not root.src_dir: # for artifactory pkgs, there is no src_dir
+    if not root.src_dir: # an artifactory pkg has no src_dir
         return f'{root.build_dir}/mama.cmake'
     return f'{root.src_dir}/mama.cmake'
 
 
 def _save_mama_cmake_and_dependencies_cmake(root: BuildDependency):
-    # save the {build}/mama-dependencies.cmake
     _save_dependencies_cmake(root)
-    # the following is the proxy `mysource/mama.cmake` file
-    # which will reference each mama-dependencies.cmake depending on platform
+    # the proxy `mysource/mama.cmake` references each mama-dependencies.cmake per platform
     _save_mama_cmake(root)
 
 
@@ -243,15 +239,14 @@ def _get_compile_commands_path(dep: BuildDependency):
 
     # choose the latest one
     if src_exists and bin_exists and os.path.getmtime(src_build_cmds) > os.path.getmtime(bin_build_cmds):
-        # for src_dir paths we use `${workspaceFolder}` macro:
+        # a src_dir path uses the `${workspaceFolder}` macro
         return '${workspaceFolder}/build/compile_commands.json'
     if bin_exists:
-        # for build dir paths, check if build dir is relative to src dir
         if dep.build_dir.startswith(dep.src_dir):
-            # if so, we chop off the src dir and use `${workspaceFolder}/`
+            # remove the src dir prefix and use `${workspaceFolder}/`
             rel_build_dir = f'${{workspaceFolder}}{dep.build_dir[len(dep.src_dir):]}/compile_commands.json'
             return rel_build_dir
-        return bin_build_cmds # absolute path for build dir paths
+        return bin_build_cmds # absolute path for a build dir outside src
     return None
 
 
@@ -268,11 +263,11 @@ def _find_matching_platform_config(dep: BuildDependency, configurations):
         return not any(tag in name and tag != compiler for tag in _COMPILER_TAGS)
 
     def match_text(conf):
-        """intelliSenseMode ('linux-gcc-x64') is structured and carries the arch; name is free text."""
+        """intelliSenseMode ('linux-gcc-x64') is structured and carries the arch. name is free text."""
         return f'{conf.get("intelliSenseMode", "")} {conf["name"]}'.lower()
 
-    # most specific first: platform+arch+compiler, then platform+compiler,
-    # then the old platform+arch / platform passes, skipping foreign-compiler configs
+    # most specific first: platform+arch+compiler, then platform+compiler, then
+    # platform+arch, then platform alone. Skip foreign-compiler configs.
     for require_compiler, require_arch in ((True, True), (True, False), (False, True), (False, False)):
         for conf in configurations:
             name = match_text(conf)
@@ -291,8 +286,8 @@ def _save_vscode_compile_commands(dep: BuildDependency):
         return
     if not dep.is_root:
         return
-    # ASAN/TSAN/coverage are temporary diagnostic builds living in a suffixed build dir
-    # (eg linux-asan). Don't repoint the IDE away from the canonical build on every such run.
+    # ASAN/TSAN/coverage are temporary diagnostic builds that live in a suffixed build dir
+    # (eg linux-asan). Do not repoint the IDE away from the canonical build on every such run.
     if dep.config.sanitize or dep.config.coverage:
         return
 
@@ -304,7 +299,7 @@ def _save_vscode_compile_commands(dep: BuildDependency):
     if not commands_path:
         return
 
-    # we have a valid path for compile_commands.json, now link it into c_cpp_properties.json
+    # link the compile_commands.json path into c_cpp_properties.json
     cpp_props_text = read_text_from(cpp_props_path)
     import json
     props = json.loads(cpp_props_text)
@@ -312,13 +307,11 @@ def _save_vscode_compile_commands(dep: BuildDependency):
 
     platform_config = _find_matching_platform_config(dep, configurations)
 
-    # make a copy of the first config and rename it to the platform name
     if not platform_config and len(configurations) > 0:
         platform_config = configurations[0].copy()
         platform_config['name'] = f'{dep.config.name()} {dep.config.arch}'
         configurations.append(platform_config)
 
-    # set the compile commands for this platform
     if platform_config:
         platform_config["compileCommands"] = commands_path
 
@@ -372,7 +365,6 @@ def _save_dependencies_cmake(root: BuildDependency):
         includes_defs.append(includes_def)
         text += package_text
 
-    # and finally, set the MAMA_INCLUDES and MAMA_LIBS
     includes = ' '.join(includes_defs)
     libs = f'${{{root.name}_LIBS}}' # use the root package to get the full flat list of deps
     text += \
@@ -385,12 +377,12 @@ set(MAMA_LIBS     ${{MAMA_LIBS}}     {libs})
 
 
 def _save_mama_cmake(root: BuildDependency):
-    """The `mysource/mama.cmake` proxy. Generated from the platform registry, so it can no longer
-    drift from the build dir names BuildConfig itself uses."""
+    """The `mysource/mama.cmake` proxy. Generated from the platform registry, so it cannot
+    drift from the build dir names that BuildConfig itself uses."""
     config:BuildConfig = root.config
 
     def build_dir_defines(build_dir):
-        # verbose include directives, because CLion has a hard time detecting macro paths
+        # verbose include directives, because CLion often fails to detect macro paths
         build_dir = build_names.build_dir_name(config, platform_dir=build_dir)
         include = _get_mama_dependencies_cmake(root, build_dir)
         return f'set(MAMA_BUILD "{build_dir}")' + (f'\n        {include}' if include else '')
@@ -400,27 +392,19 @@ def _save_mama_cmake(root: BuildDependency):
 
 def load_dependency_chain(root: BuildDependency):
     """
-    This is main entrypoint for building the dependency chain.
-    All dependencies must be resolved at this stage.
+    Main entry point: load the whole dependency chain, so every dep resolves.
+    Parallel load is the default, and `serial` opts out. load() and add_child are thread-safe.
 
-    With parallel_load=True, parents submit child loads to this executor and
-    then block on their futures while still holding a worker slot. The default
-    ThreadPoolExecutor() is bounded (~min(32, cpu_count+4)) so a moderately
-    deep dep tree can starve waiting for slots. We pick a max_workers high
-    enough that this doesn't happen for any realistic project.
+    Under parallel_load, parents submit child loads to this executor and then
+    block on the futures while they still hold a worker slot. The default
+    ThreadPoolExecutor() is bounded (~min(32, cpu_count+4)), so a moderately
+    deep dep tree can starve on slots. The max_workers here is high enough
+    for any realistic project.
 
-    For `update` runs we auto-enable parallel_load so concurrent git fetches
-    share an SSH multiplexed master. The actual fetch concurrency is capped
-    at `parallel_max` (default 20) by a semaphore inside Git.run_git.
-
-    NOTE on parallel_load: existing helpers like BuildDependency.add_child
-    and BuildDependency.load are not strictly thread-safe (the existing
-    `currently_loading` busy-wait has a TOCTOU window). For most projects
-    this is benign because concurrent loads of the SAME dep are rare. Pass
-    `serial` on the command line to disable parallel loading if you hit
-    issues.
+    Concurrent git fetches share an SSH multiplexed master. A semaphore
+    inside Git.run_git caps the fetch concurrency at 8, whatever
+    `parallel_max` asks for (see ssh_multiplex.init_fetch_semaphore).
     """
-    # Parallel by default (`serial` opts out): load() + add_child are now thread-safe.
     if not root.config.serial_load:
         root.config.parallel_load = True
 
@@ -429,7 +413,7 @@ def load_dependency_chain(root: BuildDependency):
     root.config.update_stats.start()
     with concurrent.futures.ThreadPoolExecutor(max_workers=256) as e:
         def load_dependency(dep: BuildDependency):
-            abort.check()  # a queued load must not start cloning while the build is stopping
+            abort.check()  # a queued load must not start a clone during a build abort
             if dep.already_loaded:
                 return dep.should_rebuild
 
@@ -483,17 +467,17 @@ def print_dependencies(root: BuildDependency):
 def execute_task_chain(flat_deps_reverse: List[BuildDependency]):
     for dep in flat_deps_reverse:
         if not os.path.exists(_mama_cmake_path(dep)):
-            _save_mama_cmake_and_dependencies_cmake(dep) # save a dummy mama.cmake before build
+            _save_mama_cmake_and_dependencies_cmake(dep) # save a dummy mama.cmake before the build
 
         if dep.config.verbose:
             console(f'  - Execute Tasks: {dep.name}', color=Color.BLUE)
 
-        # validate we're not building twice
+        # a dep must not execute twice
         if dep.already_executed:
             error(f"Critical Error: '{dep.name}' executed by child project")
             raise RuntimeError(f"Cyclical Dependency detected for '{dep.name}'")
 
-        # go through all child deps and make sure they executed
+        # every child dep must have executed first
         for c in dep.get_children():
             if not c.already_executed:
                 error(f"Critical Error: child '{c.name}' has not been executed before executing target '{dep.name}'")
@@ -502,7 +486,7 @@ def execute_task_chain(flat_deps_reverse: List[BuildDependency]):
         _save_mama_cmake_and_dependencies_cmake(dep)
         dep.target._execute_tasks()
 
-        # saves a helper autocomplete includes txt file to make adding .vscode include paths easier
+        # link compile_commands.json into .vscode/c_cpp_properties.json
         _save_vscode_compile_commands(dep)
 
         if dep.config.verbose and not dep.config.test:
@@ -527,15 +511,15 @@ def _make_display(config):
 
 # Shared by the two parallel runners (execute_task_chain_parallel, execute_unified).
 def _phase_label(dep, kind) -> str:
-    # 'load' opens optimistically (clone if no tree yet, else check) then _run_phase relabels it to
-    # what load() actually did (dep.load_action: check/clone/pulling); others show verbatim.
+    # 'load' opens optimistically: clone when no tree exists yet, else check. _run_phase then
+    # relabels it to what load() did (dep.load_action: check/clone/pulling). Others show verbatim.
     if kind == 'load': return 'clone' if not dep.is_real_clone() else 'check'
     return kind
 
 
 def _run_phase(display, dep, kind, body, build_slot, detail='', final=False):
-    """Run one scheduler phase for `dep` on its single dep-level display task (keyed by name so all
-    phases share one line): route this thread's console output + subprocess CPU + build barrier into
+    """Run one scheduler phase for `dep` on its single display task, keyed by name so all phases
+    share one line. Route the console output, subprocess CPU and build barrier of this thread into
     it, run `body(sink)`, then end the phase. `final=True` (the build) commits the merged summary."""
     # Gate EVERY transition (load -> configure -> build) before the display task opens. A stopping
     # build then starts no new phase, and marks no phase that never ran as a failed one.
@@ -568,9 +552,9 @@ def _build_body(dep, sink):
 
 
 def _stable_cpu_sampler(measure, clock, window=0.5):
-    """Gate `measure()` (CPU% since its last call) to >=`window`-second re-samples, caching between.
-    The scheduler polls at irregular sub-100ms-to-1s gaps; over a tiny window cpu_percent(interval=None)
-    reads a meaningless spiky 0% or 100%, so only re-measure once a real window has elapsed."""
+    """Gate `measure()` (CPU% since its last call) to re-samples at least `window` seconds apart,
+    and cache between. The scheduler polls at irregular sub-second gaps. Over a tiny window
+    cpu_percent(interval=None) reads a meaningless 0% or 100%, so re-measure only after a full window."""
     state = {'t': clock(), 'val': 0.0}
     def sample():
         now = clock()
@@ -580,16 +564,16 @@ def _stable_cpu_sampler(measure, clock, window=0.5):
     return sample
 
 
-# Build-job overprovisioning (max reserved cores = core_budget * this). MSVC/MSBuild tolerates 2x; on Linux
-# the build is memory-bound (below) - GCC/make already saturates the cores - so overprovisioning beyond the
-# RAM-capped budget only risks OOM. _GB_PER_COMPILE is a heavy-C++ TU's peak RSS; total RAM / it caps how
-# many parallel compiles we allow so a swarm can't take down a memory-limited box (a WSL-killer).
+# Build-job overprovisioning: max reserved cores = core_budget * this. MSVC/MSBuild tolerates 2x. On
+# Linux GCC/make already saturates the cores, so overprovisioning past the RAM-capped budget only risks
+# OOM. _GB_PER_COMPILE is the peak RSS of a heavy C++ TU. Total RAM divided by it caps the parallel
+# compile count, so a compile swarm cannot crash a memory-limited box (for example WSL).
 _OVERPROVISION_WIN, _OVERPROVISION_UNIX = 2.0, 1.0
 _GB_PER_COMPILE = 1.5
 
 
 def _mem_capped_budget(jobs: int) -> int:
-    """Cap the core budget by RAM so parallel heavy C++ compiles can't OOM. Never below 1 or above `jobs`."""
+    """Cap the core budget by RAM so parallel heavy C++ compiles cannot OOM. Never below 1 or above `jobs`."""
     import psutil
     gb = psutil.virtual_memory().total / (1024 ** 3)
     return max(1, min(jobs, int(gb / _GB_PER_COMPILE)))
@@ -602,7 +586,7 @@ def _make_scheduler(config, **extra):
     cpu = psutil.cpu_count() or 4
     psutil.cpu_percent(interval=None)  # prime the sampler (first call always returns 0.0)
     win = system.System.windows
-    budget = config.jobs if win else _mem_capped_budget(config.jobs)  # Linux: don't OOM on parallel C++ compiles
+    budget = config.jobs if win else _mem_capped_budget(config.jobs)  # Linux: avoid OOM on parallel C++ compiles
     extra.setdefault('overprovision', _OVERPROVISION_WIN if win else _OVERPROVISION_UNIX)
     return Scheduler(max_configure=min(cpu * 2, 32), core_budget=budget, abort_hook=SubProcess.terminate_all,
                      cpu_sampler=_stable_cpu_sampler(lambda: psutil.cpu_percent(interval=None), time.monotonic),
@@ -611,8 +595,8 @@ def _make_scheduler(config, **extra):
 
 def _handle_failure(display, failed):
     """First failed job -> replay its captured output (TTY) + the reason, then RETURN so the caller can
-    still print the aggregate diagnostics summary before exiting nonzero. A Ctrl+C abort prints a terse
-    interrupted line (no replay/summary) and exits immediately."""
+    still print the aggregate diagnostics summary before the nonzero exit. A Ctrl+C abort prints a terse
+    interrupted line (no replay/summary) and exits at once."""
     if isinstance(failed.error, KeyboardInterrupt):
         console('  [BUILD INTERRUPTED]  stopped by Ctrl+C', color=Color.RED)
         exit(-1)
@@ -623,9 +607,9 @@ def _handle_failure(display, failed):
 
 
 def _report_error(err: BaseException, verbose: bool):
-    """A BuildError is the user's build or url breaking, not a mama bug: the cmake/compiler/git report
-    already explains it, so print that alone. A traceback here would bury it under mama's own call
-    stack. Anything else IS unexpected - keep the traceback (and keep it for BuildError under verbose)."""
+    """A BuildError means the build or url of the user broke, not mama. The cmake/compiler/git report
+    explains it, so print that alone. A traceback here would bury it under mama's own call stack.
+    Anything else IS unexpected: keep the traceback (and keep it for BuildError under verbose)."""
     import traceback
     if isinstance(err, abort.BuildAborted):
         error(f'  {err}'); return  # a stopped job, not a failure: the FIRST failure printed the reason
@@ -636,7 +620,7 @@ def _report_error(err: BaseException, verbose: bool):
 
 
 def _deploy_run_postpass(deps, config):
-    """Deploy/run/test post-pass: target-specific, cheap, kept serial and children-first."""
+    """Deploy/run/test post-pass: target-specific, cheap, and it stays serial and children-first."""
     for dep in deps:
         dep.target._execute_deploy_tasks()
         dep.target._execute_run_tasks()
@@ -707,7 +691,7 @@ def print_sched_debug(root: BuildDependency):
         try: tu, via = t._count_tu()
         except Exception as e: tu, via = -1, f'ERR:{type(e).__name__}'
         probe = t._probe_build_jobs()
-        reserve = t._reserved_cores()  # canonical reserve (== actual -j); was a stale jobs//2 formula
+        reserve = t._reserved_cores()  # canonical reserve (== actual -j)
         flags = []
         if t._has_custom_build(): flags.append('custom-build')   # -> configure skips probe -> -j=config.jobs
         if d.nothing_to_build: flags.append('nothing_to_build')
@@ -725,10 +709,10 @@ _DIAG_LIMIT = 8  # compiler warnings/errors surfaced per target in the post-buil
 
 
 def _print_diagnostics(display, deps, failed_name=None):
-    """Post-build: surface the compiler warnings/errors the live display swallowed on a successful
-    build (parallel builds only replay output on failure). Up to _DIAG_LIMIT per target, errors first.
-    `failed_name` (the target that broke the build) is listed FIRST, so the reason to fix is the last
-    thing on screen instead of being buried under unrelated siblings' warnings."""
+    """Post-build: show the compiler warnings/errors the live display hid on a successful build
+    (a parallel build only replays output on failure). Up to _DIAG_LIMIT per target, errors first.
+    `failed_name` (the target that broke the build) sorts FIRST, so the warnings of unrelated
+    siblings do not bury it."""
     ordered = sorted(deps, key=lambda d: d.name != failed_name) if failed_name else deps
     printed = False
     for dep in ordered:
@@ -743,11 +727,11 @@ def _print_diagnostics(display, deps, failed_name=None):
 
 
 # buildstats (stage 1): a normalized horizontal bar per package, segmented load/configure/build.
-_BAR_FILL = 40  # the slowest package fills this width; the rest scale down proportionally
-_BUILDSTATS_FLOOR = 0.33  # omit packages faster than this - they're noise on the chart
+_BAR_FILL = 40  # the slowest package fills this width, the rest scale proportionally
+_BUILDSTATS_FLOOR = 0.33  # omit packages faster than this - they are noise on the chart
 _BAR = (('load', Color.BLUE), ('configure', Color.MAGENTA), ('build', Color.GREEN))
 _GLYPHS_SHADE = ('░', '▒', '▓')  # light/medium/dark blocks (UTF-8 terminals)
-_GLYPHS_ASCII = ('-', '=', '#')  # legacy code-page fallback (Windows cp1252 can't encode the blocks)
+_GLYPHS_ASCII = ('-', '=', '#')  # legacy code-page fallback (Windows cp1252 cannot encode the blocks)
 _glyphs_cache = None
 
 
@@ -757,8 +741,8 @@ def _can_encode_blocks(encoding) -> bool:
 
 
 def _bar_glyphs():
-    """Block shades on a UTF-8 terminal, ASCII on a legacy code page. Decided ONCE - the output
-    encoding is constant per process, so there's no point re-testing it per report or per row."""
+    """Block shades on a UTF-8 terminal, ASCII on a legacy code page. Decided ONCE: the output
+    encoding is constant per process, so a re-test per report or per row is waste."""
     global _glyphs_cache
     if _glyphs_cache is None:
         _glyphs_cache = _GLYPHS_SHADE if _can_encode_blocks(getattr(sys.stdout, 'encoding', None) or 'ascii') \
@@ -767,8 +751,8 @@ def _bar_glyphs():
 
 
 def _buildstats_bar(times: dict, total: float, max_total: float, glyphs) -> str:
-    """Bar whose length scales with total/max_total; inside, load/configure/build take shares of that
-    length (shaded, coloured). Right-padded to full width so the trailing total aligns across rows."""
+    """A bar whose length scales with total/max_total. Inside it, load/configure/build take shares of
+    that length (shaded, colored). Right-padded to full width so the trailing total aligns across rows."""
     bar_len = max(1, round(total / max_total * _BAR_FILL)) if max_total > 0 else 0
     out, used, last = [], 0, len(_BAR) - 1
     for i, ((kind, color), ch) in enumerate(zip(_BAR, glyphs)):
@@ -780,7 +764,7 @@ def _buildstats_bar(times: dict, total: float, max_total: float, glyphs) -> str:
 
 def print_buildstats(deps):
     """`buildstats`: one normalized bar per package (load / configure / build), slowest first, with its
-    total wall time. Packages faster than _BUILDSTATS_FLOOR seconds are omitted so the chart stays relevant."""
+    total wall time. The chart omits packages faster than _BUILDSTATS_FLOOR seconds, so it stays relevant."""
     label = 'Build times'
     rows = []
     for d in deps:
@@ -858,7 +842,7 @@ def _print_clang_insights(config, deps, label, dep):
         warning('buildstats: deep per-file insights need Clang -ftime-trace; build with `clang` for the breakdown')
         return
     start = config._buildstats_start
-    scoped = [dep] if dep else deps  # a <target> -> just its build dir; else every package's
+    scoped = [dep] if dep else deps  # a <target>: only its build dir, else every package's
     paths = []
     for d in scoped:
         bd = d.build_dir
@@ -877,9 +861,9 @@ def _command_verb(config) -> str:
 
 
 def _toolchain_name(config) -> str:
-    """'clang 18.1 libstdc++' / 'gcc 14.3' / 'msvc 14.44' - what this run actually builds with. Named
-    from the RESOLVED compiler, not config.clang/gcc: those describe the host, so a cross build read
-    'gcc 21.0' for the android NDK's clang. '' when unresolvable - a banner must never fail a build."""
+    """'clang 18.1 libstdc++' / 'gcc 14.3' / 'msvc 14.44' - what this run builds with. Named from the
+    RESOLVED compiler, not config.clang/gcc. Those describe the host, so a cross build would read
+    'gcc 21.0' for the clang of the android NDK. '' when unresolved: a banner must never fail a build."""
     try:
         if config.msvc:
             toolset = os.path.basename(config.get_msvc_tools_path().rstrip('\\/'))  # 14.44.35207 -> 14.44
@@ -906,8 +890,8 @@ def _platform_name(config) -> str:
 
 def print_build_banner(config, count=None):
     """One-line preview above the first task line: version, command, target count, platform, toolchain.
-    `count` is None on the unified path - its graph grows as deps load, so the total isn't known until
-    it's over."""
+    `count` is None on the unified path. Its graph grows as deps load, so the total is unknown until
+    the run ends."""
     targets = f' {count} target(s)' if count is not None else ''
     platform = _platform_name(config)
     toolchain = _toolchain_name(config)
@@ -917,18 +901,18 @@ def print_build_banner(config, count=None):
 
 
 def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
-    """Dynamic DAG scheduler interleaving cloning with configure+build: each dep is a LOAD job whose
-    completion GROWS the graph with its children's LOAD/CONFIGURE/BUILD jobs; a dep's CONFIGURE waits
-    on its own LOAD + its children's BUILDs. So leaf nodes build while deeper deps still clone. Used
-    for a plain full build (main() falls back to the old path otherwise); deploy/run/test stay serial.
-    The ROOT is loaded up front, before the display: everything below it needs what its settings() picks.
-    A `deps_only` run passes a DepsOnlyScope: every dep still loads, but only the deps the scope includes
-    get a CONFIGURE and a BUILD job."""
+    """Dynamic DAG scheduler that interleaves clones with configure and build. Each dep is a LOAD job
+    whose completion GROWS the graph with the LOAD/CONFIGURE/BUILD jobs of its children. The CONFIGURE
+    of a dep waits on its own LOAD and on the BUILDs of its children, so leaf nodes build while deeper
+    deps still clone. A plain full build uses this path, and main() falls back to the old path
+    otherwise. Deploy/run/test stay serial. The ROOT loads up front, before the display: everything
+    below it needs what its settings() picks. A `deps_only` run passes a DepsOnlyScope. Every dep
+    still loads, but only the deps the scope includes get a CONFIGURE and a BUILD job."""
     import time
     from .build_scheduler import Job, LOAD, CONFIGURE, BUILD, assign_priorities
     config = root.config
     ssh_multiplex.init_fetch_semaphore(config.parallel_max)
-    # Outside the display on purpose: root settings() output has to land on the terminal, not in a
+    # Outside the display on purpose: root settings() output must land on the terminal, not in a
     # captured task line, or a mis-picked toolchain/artifactory server is invisible to debug.
     root.load()
     print_build_banner(config)  # root settings() has now locked compiler + stdlib
@@ -945,8 +929,8 @@ def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
         return [L] + (make_build_jobs(dep) if builds(dep) else [])
 
     def make_build_jobs(dep):
-        """The dep's CONFIGURE + BUILD pair: configure waits on its own load and on the builds of every
-        child known so far, and _do_load's grow() adds the rest as the graph discovers them."""
+        """The CONFIGURE + BUILD pair of the dep: configure waits on its own load and on the builds of
+        every child known so far, and grow() in _do_load adds the rest as the graph discovers them."""
         C = Job((dep, 'C'), CONFIGURE, (lambda d=dep: _do_configure(d)), node=dep,
                 deps={load_jobs[dep], *(bld_jobs[c] for c in dep.get_children() if c in bld_jobs)})
         B = Job((dep, 'B'), BUILD, (lambda d=dep: _do_build(d)), deps={C}, node=dep,
@@ -969,8 +953,8 @@ def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
                 assign_priorities(list(cfg_jobs.values()) + list(bld_jobs.values()))  # re-rank the critical path (trunk)
                 return new
             sched.grow(grow)
-        # the root's load is already done: a no-op replay. A dep the scope excludes never gets another
-        # phase, so its load is the final one and has to commit the summary line.
+        # the load of the root is already done: a no-op replay. A dep the scope excludes never gets
+        # another phase, so its load is the final one and must commit the summary line.
         _run_phase(display, dep, 'load', body, sched.build_slot, final=not builds(dep))
 
     def _do_configure(d):
@@ -1004,14 +988,14 @@ def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
     _print_build_summary(built, time.monotonic() - start)
     _print_diagnostics(display, built)
     if config.buildstats:
-        print_buildstats(flat)  # every dep loaded, so the load bars are worth showing even for excluded deps
+        print_buildstats(flat)  # every dep loaded, so show the load bars even for excluded deps
         _print_build_insights(config, built)
     if scope is not None: scope.widen_for_deploy()
     _deploy_run_postpass(reversed(built), config)
 
 
 def find_dependency(root: BuildDependency, name: str) -> BuildDependency:
-    """ This is mainly used for finding root target or specific command line target """
+    """ Find the root target or a specific command line target by name. """
     if root.name.lower() == name.lower():
         return root
     for dep in root.get_children():

--- a/mama/dependency_chain.py
+++ b/mama/dependency_chain.py
@@ -27,10 +27,8 @@ def _get_exported_libs(target):
 
 
 def _get_hierarchical_libs(root: BuildDependency):
-    """Exported libs of `root` and every dep below it, in Unix link order: a lib comes after
-    everything that references it. Walks get_flat_deps, which dedups with the keep-last
-    [parent][child] order. A raw recursive DFS re-appended the libs of a shared dep once per
-    path through the graph, so one link line repeated a shared lib dozens of times."""
+    """Exported libs of `root` and every dep below it, in Unix link order: a lib comes after everything
+    that references it. get_flat_deps dedups keep-last, so a shared dep appears once, not once per path."""
     deps = []
     syslibs = []
     for dep in get_flat_deps(root):
@@ -63,10 +61,9 @@ def get_flat_child_deps(dep: BuildDependency):
 
 
 def mark_unbuilt_target_deps(root: BuildDependency, config: BuildConfig):
-    """`build target=X` builds only X. A dep that X needs with nothing on disk must also build, or X
-    compiles against an include dir that does not exist. The scope is the subtree of X. A mark on every
-    unbuilt dep in the workspace would build unrelated targets, and a mamafile that runs
-    `mama build target=Y` would then re-enter itself - a fork bomb."""
+    """`build target=X` builds only X, so an unbuilt dep below X must also build, or X compiles against
+    a missing include dir. The scope stays the subtree of X: a wider mark would build unrelated targets,
+    and a mamafile that runs `mama build target=Y` would then re-enter itself - a fork bomb."""
     target = find_dependency(root, config.target)
     if target is None: return
     for dep in get_flat_child_deps(target):
@@ -82,13 +79,9 @@ _BUILD_DIR_MARKERS = ('CMakeCache.txt', 'mama-dependencies.cmake', 'mama_exporte
 
 def sweep_orphaned_build_dirs(root: BuildDependency, config: BuildConfig) -> int:
     """`clean all` must clean EVERYTHING for this platform, but the tree walk cannot reach a dep whose
-    source is gone. An earlier clean removed its shim, so it parses no mamafile and declares no
-    children. The build dirs of those children would then survive every future clean. So also
-    enumerate from disk, and delete only dirs that carry a mama marker file. Return the removed count.
-
-    One dep can hold several build dirs of ONE config, because a dep added with args=[...] names its
-    own (linux, linux-lgpl). The args of an unreachable dep are unknown, so list what is on disk and
-    ask build_names which dirs belong to this config."""
+    source is gone and so declares no children. Enumerate from disk instead, and delete only dirs that
+    carry a mama marker file. A dep added with args names its own build dirs (linux, linux-lgpl), so
+    build_names decides which dirs belong to this config. Return the removed count."""
     workspace = os.path.dirname(root.dep_dir)
     config_dir = root.build_dir_name  # the root carries no dep args, so this is the config's own dir name
     removed = 0
@@ -109,10 +102,8 @@ def sweep_orphaned_build_dirs(root: BuildDependency, config: BuildConfig) -> int
 
 
 def get_deps_only_targets(root: BuildDependency, deps_only_target_name: str, config: BuildConfig):
-    """
-    For `deps_only` with a target name, return (flat_deps, flat_deps_reverse) with only
-    the deps of that target. Also mark those deps for rebuild, and clean them when needed.
-    """
+    """For `deps_only` with a target name, return (flat_deps, flat_deps_reverse) of only that target's
+    deps. Also mark those deps for rebuild, and clean them when needed."""
     deps_only_dep = find_dependency(root, deps_only_target_name)
     flat_deps = _get_flattened_deps(deps_only_dep)
     flat_deps_reverse = list(reversed(flat_deps))
@@ -127,10 +118,9 @@ def get_deps_only_targets(root: BuildDependency, deps_only_target_name: str, con
 
 class DepsOnlyScope:
     """`deps_only` for the unified scheduler: which deps may configure and build. Every dep still LOADs,
-    because only a load discovers the graph. Without a target name the scope root is the project root,
-    so every dependency builds and the root does not. With a target name the scope root is that
-    target, so only the deps below it build. A named target also forces its deps to rebuild, and a
-    `rebuild` cleans them first. This matches get_deps_only_targets on the classic path."""
+    because only a load discovers the graph. The scope root is the named target, else the project root,
+    and only the deps below it build. A named target also forces its deps to rebuild, and a `rebuild`
+    cleans them first. This matches get_deps_only_targets on the classic path."""
 
     def __init__(self, config: BuildConfig, target_name: str = None):
         self.config = config
@@ -156,9 +146,8 @@ class DepsOnlyScope:
         return self.is_inside(dep) and not self._is_scope_root(dep)
 
     def promote(self, dep: BuildDependency) -> List[BuildDependency]:
-        """A dep that the walk first found outside the scope and now reaches through it - a shared dep
-        of both the named target and an unrelated branch. Mark it and everything already found below
-        it, and return the deps that gained build work."""
+        """Mark a shared dep, first found outside the scope and now reached through it, plus everything
+        already found below it. Return the deps that gained build work."""
         if self.is_inside(dep): return []
         self._under[dep] = True
         gained = [dep]
@@ -166,9 +155,8 @@ class DepsOnlyScope:
         return gained
 
     def prepare(self, dep: BuildDependency):
-        """`deps_only <target>` rebuilds that target's deps, so force the rebuild before configure, and
-        clean first when the command is a `rebuild`. `deps_only` with no target keeps the normal
-        up-to-date check, so an unchanged dep stays cached."""
+        """`deps_only <target>` rebuilds that target's deps: force the rebuild before configure, and clean
+        first on a `rebuild`. With no target the normal up-to-date check keeps an unchanged dep cached."""
         if not self.target_name: return
         if self.config.clean:
             dep.clean()
@@ -176,9 +164,8 @@ class DepsOnlyScope:
         dep.should_rebuild = True
 
     def widen_for_deploy(self):
-        """After the build, the deps of a named target must still deploy and upload. Those tasks gate on
-        `config.target`, which still names the excluded target, so widen it - the same reset main() does
-        on the classic path."""
+        """After the build, deploy and upload still gate on `config.target`, which names the excluded
+        target, so widen it. main() does the same reset on the classic path."""
         if self.target_name: self.config.target = 'all'
 
 
@@ -266,8 +253,7 @@ def _find_matching_platform_config(dep: BuildDependency, configurations):
         """intelliSenseMode ('linux-gcc-x64') is structured and carries the arch. name is free text."""
         return f'{conf.get("intelliSenseMode", "")} {conf["name"]}'.lower()
 
-    # most specific first: platform+arch+compiler, then platform+compiler, then
-    # platform+arch, then platform alone. Skip foreign-compiler configs.
+    # most specific first: platform+arch+compiler down to platform alone, skipping foreign-compiler configs
     for require_compiler, require_arch in ((True, True), (True, False), (False, True), (False, False)):
         for conf in configurations:
             name = match_text(conf)
@@ -286,8 +272,7 @@ def _save_vscode_compile_commands(dep: BuildDependency):
         return
     if not dep.is_root:
         return
-    # ASAN/TSAN/coverage are temporary diagnostic builds that live in a suffixed build dir
-    # (eg linux-asan). Do not repoint the IDE away from the canonical build on every such run.
+    # sanitizer/coverage builds are temporary diagnostics: do not repoint the IDE away from the canonical build
     if dep.config.sanitize or dep.config.coverage:
         return
 
@@ -334,8 +319,6 @@ def _get_dependency_cmake_defines(dep: BuildDependency):
     # reference name_LIB if it equals name_LIBS
     if own_libs_list == all_libs_list:
         all_libs_list = f'${{{name}_LIB}}'
-    #console(f'{name} own_libs: {own_libs_list}')
-    #console(f'{name} all_libs: {all_libs_list}')
     return f'${{{name}_INCLUDES}}', \
 f'''
 # Package {name}
@@ -392,18 +375,12 @@ def _save_mama_cmake(root: BuildDependency):
 
 def load_dependency_chain(root: BuildDependency):
     """
-    Main entry point: load the whole dependency chain, so every dep resolves.
-    Parallel load is the default, and `serial` opts out. load() and add_child are thread-safe.
-
-    Under parallel_load, parents submit child loads to this executor and then
-    block on the futures while they still hold a worker slot. The default
-    ThreadPoolExecutor() is bounded (~min(32, cpu_count+4)), so a moderately
-    deep dep tree can starve on slots. The max_workers here is high enough
-    for any realistic project.
-
-    Concurrent git fetches share an SSH multiplexed master. A semaphore
-    inside Git.run_git caps the fetch concurrency at 8, whatever
+    Main entry point: load the whole dependency chain. Parallel load is the default, and `serial` opts
+    out. load() and add_child are thread-safe. Parents block on child futures while they hold a worker
+    slot. The default bounded ThreadPoolExecutor can starve on a deep tree, so max_workers is high.
+    A semaphore inside Git.run_git caps the SSH-multiplexed fetch concurrency at 8, whatever
     `parallel_max` asks for (see ssh_multiplex.init_fetch_semaphore).
+    root: the root BuildDependency, whose loads discover the rest of the graph
     """
     if not root.config.serial_load:
         root.config.parallel_load = True
@@ -434,9 +411,8 @@ def load_dependency_chain(root: BuildDependency):
             load_dependency(root)
         except BuildError as err:  # a bad url or a dropped clone: the report is complete, a traceback buries it
             _report_error(err, root.config.verbose)
-            # Stop the other loads before the exit. SystemExit leaves this `with`, and the pool's
-            # shutdown(wait=True) then runs the ENTIRE queued backlog. That is minutes of clones for a
-            # build that already failed. After the stop, each queued load returns at once.
+            # Stop the other loads before the exit: the pool's shutdown(wait=True) would otherwise run the
+            # ENTIRE queued backlog, minutes of clones for a failed build. After the stop each queued load returns at once.
             SubProcess.terminate_all('load failed')  # the report above already names the target
             exit(-1)
     root.config.update_stats.stop()
@@ -492,8 +468,7 @@ def execute_task_chain(flat_deps_reverse: List[BuildDependency]):
         if dep.config.verbose and not dep.config.test:
             if dep.is_root_or_config_target():
                 print_dependencies(dep)
-            # else:
-            #     print_dependencies(dep) # TODO: different output for non-root targets
+            # TODO: different output for non-root targets
 
 
 def _make_display(config):
@@ -511,18 +486,15 @@ def _make_display(config):
 
 # Shared by the two parallel runners (execute_task_chain_parallel, execute_unified).
 def _phase_label(dep, kind) -> str:
-    # 'load' opens optimistically: clone when no tree exists yet, else check. _run_phase then
-    # relabels it to what load() did (dep.load_action: check/clone/pulling). Others show verbatim.
+    # 'load' opens optimistically (clone when no tree exists, else check), and _run_phase relabels it to what load() did
     if kind == 'load': return 'clone' if not dep.is_real_clone() else 'check'
     return kind
 
 
 def _run_phase(display, dep, kind, body, build_slot, detail='', final=False):
-    """Run one scheduler phase for `dep` on its single display task, keyed by name so all phases
-    share one line. Route the console output, subprocess CPU and build barrier of this thread into
-    it, run `body(sink)`, then end the phase. `final=True` (the build) commits the merged summary."""
-    # Gate EVERY transition (load -> configure -> build) before the display task opens. A stopping
-    # build then starts no new phase, and marks no phase that never ran as a failed one.
+    """Run one scheduler phase for `dep` on its single name-keyed display task, routing this thread's
+    console output, subprocess CPU and build barrier into it. `final=True` (the build) commits the merged summary."""
+    # gate every transition before the display task opens: a stopping build starts no phase and marks no unrun phase failed
     abort.check()
     tid = dep.name
     sink = lambda line: display.feed(tid, line)
@@ -552,9 +524,8 @@ def _build_body(dep, sink):
 
 
 def _stable_cpu_sampler(measure, clock, window=0.5):
-    """Gate `measure()` (CPU% since its last call) to re-samples at least `window` seconds apart,
-    and cache between. The scheduler polls at irregular sub-second gaps. Over a tiny window
-    cpu_percent(interval=None) reads a meaningless 0% or 100%, so re-measure only after a full window."""
+    """Gate `measure()` (CPU% since its last call) to re-samples at least `window` seconds apart, and cache
+    between. Over the scheduler's irregular sub-second gaps cpu_percent reads a meaningless 0% or 100%."""
     state = {'t': clock(), 'val': 0.0}
     def sample():
         now = clock()
@@ -564,10 +535,8 @@ def _stable_cpu_sampler(measure, clock, window=0.5):
     return sample
 
 
-# Build-job overprovisioning: max reserved cores = core_budget * this. MSVC/MSBuild tolerates 2x. On
-# Linux GCC/make already saturates the cores, so overprovisioning past the RAM-capped budget only risks
-# OOM. _GB_PER_COMPILE is the peak RSS of a heavy C++ TU. Total RAM divided by it caps the parallel
-# compile count, so a compile swarm cannot crash a memory-limited box (for example WSL).
+# Overprovisioning: max reserved cores = core_budget * this. MSBuild tolerates 2x, but on Linux make already
+# saturates the cores. _GB_PER_COMPILE is the peak RSS of a heavy C++ TU and caps the parallel compiles by total RAM.
 _OVERPROVISION_WIN, _OVERPROVISION_UNIX = 2.0, 1.0
 _GB_PER_COMPILE = 1.5
 
@@ -594,9 +563,8 @@ def _make_scheduler(config, **extra):
 
 
 def _handle_failure(display, failed):
-    """First failed job -> replay its captured output (TTY) + the reason, then RETURN so the caller can
-    still print the aggregate diagnostics summary before the nonzero exit. A Ctrl+C abort prints a terse
-    interrupted line (no replay/summary) and exits at once."""
+    """Replay the first failed job's captured output plus the reason, then RETURN so the caller still
+    prints the aggregate diagnostics before the nonzero exit. A Ctrl+C abort exits at once."""
     if isinstance(failed.error, KeyboardInterrupt):
         console('  [BUILD INTERRUPTED]  stopped by Ctrl+C', color=Color.RED)
         exit(-1)
@@ -607,9 +575,8 @@ def _handle_failure(display, failed):
 
 
 def _report_error(err: BaseException, verbose: bool):
-    """A BuildError means the build or url of the user broke, not mama. The cmake/compiler/git report
-    explains it, so print that alone. A traceback here would bury it under mama's own call stack.
-    Anything else IS unexpected: keep the traceback (and keep it for BuildError under verbose)."""
+    """A BuildError means the user's build or url broke: print its report alone, because a traceback would
+    bury it under mama's own call stack. Anything else keeps the traceback (BuildError too under verbose)."""
     import traceback
     if isinstance(err, abort.BuildAborted):
         error(f'  {err}'); return  # a stopped job, not a failure: the FIRST failure printed the reason
@@ -663,9 +630,8 @@ def execute_task_chain_parallel(flat_deps_reverse: List[BuildDependency]):
 
 
 def _reserve_weight(dep) -> int:
-    """Cores reserved for a build job AT LAUNCH. The root is ungated and runs alone, and a custom
-    build() reserves from inside cmake_build() (the barrier): both launch free (0). A default build
-    reserves its capped cores."""
+    """Cores reserved for a build job AT LAUNCH. The ungated root and a custom build(), which reserves
+    from inside cmake_build() (the barrier), launch free (0). A default build reserves its capped cores."""
     if dep.is_root or dep.target._has_custom_build(): return 0
     return dep.target._reserved_cores()
 
@@ -709,10 +675,9 @@ _DIAG_LIMIT = 8  # compiler warnings/errors surfaced per target in the post-buil
 
 
 def _print_diagnostics(display, deps, failed_name=None):
-    """Post-build: show the compiler warnings/errors the live display hid on a successful build
-    (a parallel build only replays output on failure). Up to _DIAG_LIMIT per target, errors first.
-    `failed_name` (the target that broke the build) sorts FIRST, so the warnings of unrelated
-    siblings do not bury it."""
+    """Post-build: show the compiler warnings/errors the live display hid on a successful build, up to
+    _DIAG_LIMIT per target, errors first. `failed_name` (the target that broke the build) sorts FIRST,
+    so the warnings of unrelated siblings do not bury it."""
     ordered = sorted(deps, key=lambda d: d.name != failed_name) if failed_name else deps
     printed = False
     for dep in ordered:
@@ -721,7 +686,7 @@ def _print_diagnostics(display, deps, failed_name=None):
         if not printed: console('\n  Compiler diagnostics:', color=Color.BLUE); printed = True
         counts = ', '.join(f'{n} {w}(s)' for n, w in ((n_err, 'error'), (n_warn, 'warning')) if n)
         console(f'  {dep.name}: {counts}' + ('   <-- BUILD FAILED HERE' if dep.name == failed_name else ''))
-        for sev, text in diags:  # a cmake block spans lines; keep its body indented under the header
+        for sev, text in diags:  # a cmake block spans lines, so keep its body indented under the header
             (error if sev == 'error' else warning)(f'    {text}'.replace('\n', '\n      '))
         if n_err + n_warn > len(diags): console(f'    ... (+{n_err + n_warn - len(diags)} more)')
 
@@ -784,9 +749,8 @@ def print_buildstats(deps):
 
 
 def _build_insights_session(config, root: BuildDependency):
-    """MSVC `buildstats`: a live vcperf /timetrace session wrapping the build. Linux `buildstats`: record the
-    build start time so the post-build report collects only the clang -ftime-trace JSONs written this run.
-    Otherwise a null context."""
+    """MSVC `buildstats`: a live vcperf /timetrace session wrapping the build. Linux `buildstats`: record
+    the start time so the report collects only this run's clang -ftime-trace JSONs. Else a null context."""
     import contextlib, time
     if not config.buildstats:
         return contextlib.nullcontext()
@@ -861,9 +825,9 @@ def _command_verb(config) -> str:
 
 
 def _toolchain_name(config) -> str:
-    """'clang 18.1 libstdc++' / 'gcc 14.3' / 'msvc 14.44' - what this run builds with. Named from the
-    RESOLVED compiler, not config.clang/gcc. Those describe the host, so a cross build would read
-    'gcc 21.0' for the clang of the android NDK. '' when unresolved: a banner must never fail a build."""
+    """'clang 18.1 libstdc++' / 'gcc 14.3' - what this run builds with, named from the RESOLVED compiler.
+    config.clang/gcc describe the host, so a cross build would misname the compiler of the android NDK.
+    '' when unresolved: a banner must never fail a build."""
     try:
         if config.msvc:
             toolset = os.path.basename(config.get_msvc_tools_path().rstrip('\\/'))  # 14.44.35207 -> 14.44
@@ -890,8 +854,7 @@ def _platform_name(config) -> str:
 
 def print_build_banner(config, count=None):
     """One-line preview above the first task line: version, command, target count, platform, toolchain.
-    `count` is None on the unified path. Its graph grows as deps load, so the total is unknown until
-    the run ends."""
+    `count` is None on the unified path, whose graph grows as deps load, so the total is unknown."""
     targets = f' {count} target(s)' if count is not None else ''
     platform = _platform_name(config)
     toolchain = _toolchain_name(config)
@@ -901,19 +864,17 @@ def print_build_banner(config, count=None):
 
 
 def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
-    """Dynamic DAG scheduler that interleaves clones with configure and build. Each dep is a LOAD job
-    whose completion GROWS the graph with the LOAD/CONFIGURE/BUILD jobs of its children. The CONFIGURE
-    of a dep waits on its own LOAD and on the BUILDs of its children, so leaf nodes build while deeper
-    deps still clone. A plain full build uses this path, and main() falls back to the old path
-    otherwise. Deploy/run/test stay serial. The ROOT loads up front, before the display: everything
-    below it needs what its settings() picks. A `deps_only` run passes a DepsOnlyScope. Every dep
+    """Dynamic DAG scheduler that interleaves clones with configure and build: each completed LOAD grows
+    the graph with its children's jobs, and a CONFIGURE waits on its own LOAD plus its children's BUILDs,
+    so leaves build while deeper deps still clone. A plain full build uses this path, and main() falls
+    back to the classic path otherwise. Deploy/run/test stay serial. The ROOT loads up front, because
+    everything below it needs what its settings() picks. Under a `deps_only` DepsOnlyScope every dep
     still loads, but only the deps the scope includes get a CONFIGURE and a BUILD job."""
     import time
     from .build_scheduler import Job, LOAD, CONFIGURE, BUILD, assign_priorities
     config = root.config
     ssh_multiplex.init_fetch_semaphore(config.parallel_max)
-    # Outside the display on purpose: root settings() output must land on the terminal, not in a
-    # captured task line, or a mis-picked toolchain/artifactory server is invisible to debug.
+    # outside the display on purpose: root settings() output must land on the terminal, or a mis-picked toolchain is invisible
     root.load()
     print_build_banner(config)  # root settings() has now locked compiler + stdlib
     config.update_stats.start()
@@ -953,8 +914,7 @@ def execute_unified(root: BuildDependency, scope: DepsOnlyScope = None):
                 assign_priorities(list(cfg_jobs.values()) + list(bld_jobs.values()))  # re-rank the critical path (trunk)
                 return new
             sched.grow(grow)
-        # the load of the root is already done: a no-op replay. A dep the scope excludes never gets
-        # another phase, so its load is the final one and must commit the summary line.
+        # the root's load is a no-op replay, and an excluded dep's load is its final phase, so it commits the summary line
         _run_phase(display, dep, 'load', body, sched.build_slot, final=not builds(dep))
 
     def _do_configure(d):

--- a/mama/init_project.py
+++ b/mama/init_project.py
@@ -87,7 +87,7 @@ def patch_existing_cmakelists(project_name, cmakefile):
 
     found_project = False
     for i in range(len(lines)):
-        if bool(re.match('project\\s?\\(', lines[i], re.I)): # Match "project(" or "PROJECT (" 
+        if bool(re.match('project\\s?\\(', lines[i], re.I)): # match "project(" or "PROJECT ("
             at = i+1
             lines[at:at] = [
                 '\n',
@@ -114,7 +114,7 @@ def patch_existing_cmakelists(project_name, cmakefile):
 
             idx = line.find(')')
             if idx == -1:
-                lines.insert(i+1, '    ${MAMA_LIBS}\n') # multiline target_line_libraries
+                lines.insert(i+1, '    ${MAMA_LIBS}\n') # multiline target_link_libraries
                 console(f'  Inserted ${{MAMA_LIBS}} at line {i+2}')
             else:
                 lines[i] = line[:idx] + ' ${MAMA_LIBS}' + line[idx:] # add just before closing )
@@ -130,7 +130,7 @@ def patch_existing_cmakelists(project_name, cmakefile):
 
 
 def find_cpp_main(src_dir):
-    # use top-level glob in src/ to match anything with "main" in the name and .cpp extension
+    # match any top-level src/ file with "main" in the name and a .cpp extension
     for entry in os.listdir(src_dir):
         if entry.endswith('.cpp') and 'main' in entry.lower():
             return path_join(src_dir, entry)

--- a/mama/main.py
+++ b/mama/main.py
@@ -250,9 +250,9 @@ def run_coverage_report(target: BuildTarget):
 
 
 def mamabuild(args, source_dir=os.getcwd()):
-    """ Main entry point for MamaBuild. Parses the command line arguments and executes the requested actions.
-        - args: list of command line arguments, without the script name. Ex: ['build', 'target=all', 'debug']
-        - source_dir: the directory to treat as the main project source
+    """Main entry point for MamaBuild. Parses the command line arguments and executes the requested actions.
+    - args: list of command line arguments, without the script name, e.g. ['build', 'target=all', 'debug']
+    - source_dir: the directory to treat as the main project source
     """
     if sys.version_info < (3, 10):
         console('FATAL ERROR: MamaBuild requires Python 3.10 or higher')
@@ -360,9 +360,8 @@ def mamabuild(args, source_dir=os.getcwd()):
         flat_deps = get_flat_deps(root) # root, dep2, deepest_dep
         flat_deps_reverse = list(reversed(flat_deps)) # deepest_dep, dep2, root
 
-        # `build/upload/deploy X` runs X and what X needs - not the whole tree. An out-of-scope dep would
-        # do no build work but still reach _run_packaging(), which re-packages a target that was never
-        # built and asserts on missing libs. Upload/deploy of the deps is still gated per-target.
+        # `build/upload/deploy X` runs X and what X needs, not the whole tree. An out-of-scope dep builds
+        # nothing yet still reaches _run_packaging(), which asserts on missing libs. Deploy stays gated per-target.
         targeted = ((config.build or config.upload or config.deploy)
                     and config.has_target() and not config.targets_all() and not config.deps_only)
         if targeted and dep is not None:
@@ -396,9 +395,8 @@ def mamabuild(args, source_dir=os.getcwd()):
             chain = ' -> '.join([d.name for d in flat_deps_reverse])
             console(f'Executing task chain for build:\n    {chain}', Color.BLUE)
 
-        # Parallel by default, only an explicit `serial` selects the serial runner. A one-dep graph has
-        # nothing to overlap, but the parallel scheduler owns the live display, and the serial runner
-        # would dump raw cmake output instead.
+        # Parallel by default, only an explicit `serial` selects the serial runner. Even a one-dep graph
+        # goes parallel: that scheduler owns the live display, and the serial runner dumps raw cmake output.
         if config.serial_load:
             execute_task_chain(flat_deps_reverse)
         else:

--- a/mama/main.py
+++ b/mama/main.py
@@ -48,7 +48,7 @@ def print_usage():
     console('    install-clang-<ver> - configures and installs clang-<ver> for ubuntu, ex: install-clang-18')
     console('    install-gcc-<ver>   - configures and installs gcc-<ver> for ubuntu, ex: install-gcc-13')
     console('    install-msbuild     - configures and installs MSBuild for linux')
-    console('    install-ndk-<ver>   - configures and installs Android NDK <ver> for linux or windows (ex: install-ndk-25b)')
+    console('    install-ndk-<ver>   - configures and installs Android NDK <ver> for linux or windows (ex: install-ndk-25c)')
     console('    install-raspi       - installs the Raspberry Pi arm64 cross toolchain (ubuntu/debian)')
     console('    install-raspi32     - installs the legacy Raspberry Pi armv7 cross toolchain')
     console('  args:')
@@ -66,14 +66,14 @@ def print_usage():
     console('    android    - build for android')
     console('    android-N  - build for android targeting specific API level, ex: android-26')
     console('    ndk-<ver>  - build for android targeting specific NDK version, ex: ndk-28 or ndk-28.2')
-    console('    clang      - prefer clang for linux (default on linux/macos/ios/android)')
+    console('    clang      - prefer clang for linux (default on macos/ios/android)')
     console('    gcc        - prefer gcc for linux')
     console('    fortran    - enable automatic fortran detection (or configure this in mamafile)')
     console('    release    - (default) CMake configuration RelWithDebInfo')
     console('    debug      - CMake configuration Debug')
     console('    arch=x86   - Override cross-compiling architecture: (x86, x64, arm, arm64)')
     console('    x86        - Shorthand for arch=x86, all shorthands: x86 x64 arm arm64')
-    console('    jobs=N     - Max number of parallel compilations. (default=system.core.count)')
+    console('    jobs=N     - Max number of parallel compilations. (default=system.core.count, minus one on linux)')
     console('    target=P   - Name of the target')
     console('    all        - Short for target=all')
     console('    with_tests - Forces CMake option -DENABLE_TESTS=ON and -DBUILD_TESTS=ON')
@@ -102,7 +102,7 @@ def print_usage():
     console('    mama build android-26 arm      Cross compile to armv7 android NDK API level 26')
     console('    mama update                    Update all dependencies by doing git pull and build.')
     console('    mama clean                     Cleans main project only.')
-    console('    mama clean x86 opencv          Cleans main project only.')
+    console('    mama clean x86 opencv          Cleans the x86 build of target opencv.')
     console('    mama clean all                 Cleans EVERYTHING in the dependency chain for current arch.')
     console('    mama rebuild                   Cleans, update and build main project only.')
     console('    mama rebuild deps_only         Cleans and rebuilds all dependencies, but not the main project.')
@@ -133,7 +133,7 @@ def open_project(config: BuildConfig, root_dependency: BuildDependency):
     if not found:
         raise KeyError(f'No project named {name}')
 
-    # `mama open <shim>` has no source dir to open; tell the user how to materialize one.
+    # `mama open <shim>` has no source dir to open. Tell the user how to fetch one.
     if found.is_artifactory_shim():
         warning(f'Target {found.name} is an artifactory shim - no source files available locally.')
         console(f'To fetch source, run: mama unshallow {found.name}')
@@ -165,12 +165,12 @@ def _find_ide_project(platform, dep: BuildDependency) -> str:
     return max(matches, key=os.path.getmtime) if matches else ''
 
 
-_RETIRED_ARGS = {'buildtimes': 'buildstats'}  # removed flags worth naming, so they don't read as a target
+_RETIRED_ARGS = {'buildtimes': 'buildstats'}  # removed flags worth naming, so they do not read as a target
 
 
 def set_target_from_unused_args(config: BuildConfig):
     """An unrecognized bare word is the target name, so `mama rebuild ReCpp` works. An option-shaped arg
-    (`jobz=4`, `-foo`) can never be one, so it's a typo - fail here, not 20s later as 'target not found'."""
+    (`jobz=4`, `-foo`) can never be one, so it is a typo - fail here, not 20s later as 'target not found'."""
     for arg in config.unused_args:
         if arg in _RETIRED_ARGS:  # else a removed flag reads as a target and fails with 'target not found'
             console(f"ERROR: '{arg}' was removed, use '{_RETIRED_ARGS[arg]}' instead")
@@ -187,9 +187,9 @@ def set_target_from_unused_args(config: BuildConfig):
 
 def _can_unify(config: BuildConfig) -> bool:
     """True for a build/update the unified clone+build scheduler handles: a full tree, or a `deps_only`
-    run, which the scheduler scopes to the named target's dependencies as the graph grows. Targeted /
-    list / dirty / mama_init / serial runs need the classic load->execute path (which resolves the whole
-    tree up front for target lookup and filtering)."""
+    run, which the scheduler scopes to the named target's dependencies as the graph grows. Targeted,
+    list, dirty, mama_init and serial runs need the classic load->execute path, which resolves the
+    whole tree up front for target lookup and filtering."""
     return (not config.serial_load and (config.build or config.update)
             and (config.no_specific_target() or config.deps_only) and not config.list
             and not config.dirty and not config.mama_init)
@@ -198,7 +198,7 @@ def _can_unify(config: BuildConfig) -> bool:
 def check_config_target(config: BuildConfig, root: BuildDependency):
     if config.has_target() and not config.targets_all():
         dep = find_dependency(root, config.target)
-        if dep is None:  # list what IS valid: the name was likely a typo'd target or a misspelled flag
+        if dep is None:  # list what IS valid: the name is likely a misspelled target or flag
             names = ', '.join(sorted(d.name for d in get_flat_deps(root)))
             console(f"ERROR: specified target='{config.target}' not found! Available targets: {names}")
             exit(-1)
@@ -214,7 +214,7 @@ def print_package_exports(dep: BuildDependency):
 
 
 def mama_dirty(root: BuildDependency, dep: BuildDependency):
-    """ Marks `dep` as dirty and also marks all projects that depend on `dep` as dirty """
+    """ Mark `dep` dirty, and also every project that depends on `dep` """
     dirty_chain = get_deps_that_depend_on_target(root, dep)
     if root.config.print:
         used_by = ", ".join([d.name for d in dirty_chain]) if dirty_chain else 'none'
@@ -235,15 +235,13 @@ def run_coverage_report(target: BuildTarget):
         gcov_path = os.path.realpath(target.config.cc_path).replace('gcc', 'gcov')
         if os.path.exists(gcov_path):
             gcov_exec = f'--gcov-executable "{gcov_path}" '
-    # this is too verbose for CI
-    #verbose = '--verbose ' if target.config.verbose else ''
     cmd = 'gcovr --gcov-ignore-errors all --gcov-ignore-parse-errors all ' \
         + '--sort uncovered-percent ' \
         + gcov_exec \
         + f'--root "{root}" "{target.build_dir()}"'
     try:
-        # throw if coverage fails, but don't exit with error, so we don't break CI on coverage report failures
-        # instead stdout must be checked for coverage report success or failure separately
+        # a report failure must not break CI, so log the error instead of an exit.
+        # CI checks stdout for the report result separately.
         status, _ = execute_piped_echo(cwd=target.source_dir(), cmd=cmd, echo=True)
         if status != 0:
             warning(f'WARNING: gcovr exited {status} - coverage report may be incomplete')
@@ -252,7 +250,7 @@ def run_coverage_report(target: BuildTarget):
 
 
 def mamabuild(args, source_dir=os.getcwd()):
-    """ Main entry point for MamaBuild. Parses command line arguments and executes the requested actions. 
+    """ Main entry point for MamaBuild. Parses the command line arguments and executes the requested actions.
         - args: list of command line arguments, without the script name. Ex: ['build', 'target=all', 'debug']
         - source_dir: the directory to treat as the main project source
     """
@@ -276,7 +274,7 @@ def mamabuild(args, source_dir=os.getcwd()):
 
     name = os.path.basename(source_dir)
     local_src = LocalSource(name, source_dir, mamafile=None, always_build=False, args=[])
-    workspace = None # figure out the workspace from the root mamafile.py
+    workspace = None # the root mamafile.py decides the workspace later
     root = BuildDependency(None, config, workspace, local_src)
 
     if config.unused_args:
@@ -324,24 +322,24 @@ def mamabuild(args, source_dir=os.getcwd()):
         print_sched_debug(root)
         return
 
-    # Full build/update and deps_only -> unified clone+configure+build scheduler; everything else
-    # (which needs the fully-loaded tree up front for lookup/filtering) -> classic load->execute path.
+    # Full build/update and deps_only -> unified clone+configure+build scheduler. Everything else
+    # needs the fully loaded tree up front for lookup/filtering -> classic load->execute path.
     if _can_unify(config):
         execute_unified(root, DepsOnlyScope(config, deps_only_target_name) if config.deps_only else None)
         dep = root
-        flat_deps = get_flat_deps(root)  # the graph is fully grown by now; keep it defined for the code below
+        flat_deps = get_flat_deps(root)  # the graph is fully grown by now, keep this defined for the code below
     else:
         load_dependency_chain(root)
         check_config_target(config, root)
 
-        # clean is not a build: dirs wiped during load, so packaging them fabricates an empty package or
-        # dies in a mamafile assert ('libX.so not found'). rebuild sets build=True, so it still runs.
+        # clean is not a build: the load wiped the dirs, so a packaging pass fabricates an empty package
+        # or fails a mamafile assert ('libX.so not found'). rebuild sets build=True, so it still runs.
         if config.clean_only():
             if config.targets_all(): sweep_orphaned_build_dirs(root, config)  # deps with no source on disk
             return
 
         # Only now is the tree loaded, so X's subtree is known: revive the deps X needs but that have
-        # nothing on disk. _should_build can't do this at load time - deps have no parent link then.
+        # nothing on disk. _should_build cannot do this at load time - deps have no parent link then.
         if (config.build or config.update) and config.has_target() and not config.targets_all():
             mark_unbuilt_target_deps(root, config)
 
@@ -362,9 +360,9 @@ def mamabuild(args, source_dir=os.getcwd()):
         flat_deps = get_flat_deps(root) # root, dep2, deepest_dep
         flat_deps_reverse = list(reversed(flat_deps)) # deepest_dep, dep2, root
 
-        # `build/upload/deploy X` runs X and what X needs - not the whole tree. An out-of-scope dep did
-        # no build work but still reached _run_packaging(), re-packaging a target that was never built
-        # (and asserting on libs that don't exist). Upload/deploy of the deps is still gated per-target.
+        # `build/upload/deploy X` runs X and what X needs - not the whole tree. An out-of-scope dep would
+        # do no build work but still reach _run_packaging(), which re-packages a target that was never
+        # built and asserts on missing libs. Upload/deploy of the deps is still gated per-target.
         targeted = ((config.build or config.upload or config.deploy)
                     and config.has_target() and not config.targets_all() and not config.deps_only)
         if targeted and dep is not None:
@@ -380,7 +378,7 @@ def mamabuild(args, source_dir=os.getcwd()):
                 flat_deps_reverse.remove(root)
 
         if config.list:
-            # if listing, then mark all deps for no-build
+            # a list run builds nothing, so mark every dep no-build
             for d in flat_deps:
                 d.target.nothing_to_build()
 
@@ -398,9 +396,9 @@ def mamabuild(args, source_dir=os.getcwd()):
             chain = ' -> '.join([d.name for d in flat_deps_reverse])
             console(f'Executing task chain for build:\n    {chain}', Color.BLUE)
 
-        # Parallel by default; only an explicit `serial` opts out. A one-dep graph has nothing to
-        # overlap, but the scheduler owns the live display - falling back to the serial runner for it
-        # dumped raw cmake output instead, so `build <target>` looked nothing like a full build.
+        # Parallel by default, only an explicit `serial` selects the serial runner. A one-dep graph has
+        # nothing to overlap, but the parallel scheduler owns the live display, and the serial runner
+        # would dump raw cmake output instead.
         if config.serial_load:
             execute_task_chain(flat_deps_reverse)
         else:

--- a/mama/mamafile_version.py
+++ b/mama/mamafile_version.py
@@ -24,10 +24,9 @@ def scan_mamafile(mamafile_text: str) -> VersionScan:
     return a name the UPLOAD side never publishes. So it reports what it saw, and `trusted_version`
     refuses.
 
-    Parses the file instead of a text scan. `ast.parse` costs about 0.14ms on a real mamafile, on a path
-    that already spends 100ms or more on the network. It is also EXACT. A line scan counts a docstring
-    that documents `self.version` as an assignment, then refuses the real pin next to it. The line scan
-    stays as the fallback for a mamafile this Python cannot parse."""
+    Parses with ast, which is cheap and EXACT. A line scan counts a docstring that documents
+    `self.version` as an assignment, then refuses the real pin next to it. The line scan stays as the
+    fallback for a mamafile this Python cannot parse."""
     try:
         return _scan_ast(ast.parse(mamafile_text))
     except (SyntaxError, ValueError):

--- a/mama/mamafile_version.py
+++ b/mama/mamafile_version.py
@@ -1,13 +1,5 @@
-"""What version a mamafile declares, read WITHOUT running the file.
-
-Mama names an artifactory package before it clones anything, so the download side cannot execute a
-mamafile to learn its `self.version`. It reads the declaration instead. The upload side does run the
-file, so the two sides agree only while the declaration is a shape a reader can resolve. This module
-owns that judgement: it reports what a mamafile says, decides whether to trust it, and says so once when
-it refuses.
-
-None of this is git-specific. `Git.fetch_self_version_from_remote` fetches the text for a dep that has
-no clone yet, and then asks this module what the text means. See docs/roadmap-target-version.md."""
+"""What version a mamafile declares, read WITHOUT running the file, so the download side can name an
+artifactory package before the clone. See docs/roadmap-target-version.md."""
 
 from __future__ import annotations
 import ast, os, re
@@ -32,7 +24,7 @@ def scan_mamafile(mamafile_text: str) -> VersionScan:
     return a name the UPLOAD side never publishes. So it reports what it saw, and `trusted_version`
     refuses.
 
-    Parses the file rather than grepping it. `ast.parse` costs about 0.14ms on a real mamafile, on a path
+    Parses the file instead of a text scan. `ast.parse` costs about 0.14ms on a real mamafile, on a path
     that already spends 100ms or more on the network. It is also EXACT. A line scan counts a docstring
     that documents `self.version` as an assignment, then refuses the real pin next to it. The line scan
     stays as the fallback for a mamafile this Python cannot parse."""
@@ -126,8 +118,8 @@ def _scan_lines(mamafile_text: str) -> VersionScan:
 
 
 def _warn_unusable(dep, source: str, reason: str):
-    """One warning per dep per run. Both readers reach the same mamafile, and a warning repeated per
-    probe teaches the reader to skip it."""
+    """One warning per dep per run. Both scans reach the same mamafile, and a warning repeated per
+    probe teaches the user to skip it."""
     if getattr(dep, 'warned_bad_version', False) or not dep.config.print: return
     dep.warned_bad_version = True
     warning(f'  - Target {dep.name: <16} {os.path.basename(source)} {reason}, so mama cannot read it ' +

--- a/mama/package.py
+++ b/mama/package.py
@@ -64,8 +64,7 @@ def export_include(target: BuildTarget, include_path: str, build_dir: bool,
     include_path = target_root_path(target, include_path, build_dir=build_dir)
     if os.path.exists(include_path):
         if as_includes_root:
-            # Export the parent of this include, so a consumer writes
-            # #include <mylib/file.h> and not <src/mylib/file.h>.
+            # export the parent of this include, so a consumer writes #include <mylib/file.h>, not <src/mylib/file.h>
             includes_root = include_path
             if type(as_includes_root) == str:
                 alias_name = str(as_includes_root) # the user passed the alias, e.g. 'mylib'
@@ -74,8 +73,7 @@ def export_include(target: BuildTarget, include_path: str, build_dir: bool,
             include_path = normalized_path(include_path + '/../')
             target.includes_root = (include_path, includes_root, alias_name)
         if not include_path in target.exported_includes:
-            # an as_includes_root export ships one subdir of the parent it records, so the parent
-            # covers nothing else. Compare against the subdir it really ships.
+            # an as_includes_root export records the parent but ships one subdir, so compare against that subdir
             root_path, root_src, _ = target.includes_root
             shipped = [root_src if e == root_path else e for e in target.exported_includes]
             overlap = _overlapping_include(shipped, include_path)
@@ -84,9 +82,8 @@ def export_include(target: BuildTarget, include_path: str, build_dir: bool,
                         'One export covers those headers already.')
             target.exported_includes.append(include_path)
         return True
-    # A named include path that is not on disk is a packaging fault, the same as a missing lib.
-    # The caller then runs default_package_includes(), which can pick a shallower `include` dir.
-    # That ships a package whose headers no consumer can reach, so report the miss here.
+    # A named include path that is not on disk is a packaging fault, like a missing lib. The fallback
+    # default_package_includes() can pick a shallower dir and ship headers no consumer can reach, so report it.
     warning(f'export_include failed to find: {include_path}')
     return False
 

--- a/mama/package.py
+++ b/mama/package.py
@@ -32,16 +32,16 @@ def target_root_path(target: BuildTarget, path: str, build_dir: bool):
 
 
 def get_lib_basename(lib: str|tuple):
-    """The name a lib is identified by, for dedup and for the papa manifest. A tuple is
-    (path, alias). An Apple framework has no file of its own, so it IS its own name."""
+    """The name that identifies a lib, for dedup and for the papa manifest. A tuple is
+    (path, alias). An Apple framework has no file of its own, so the string itself is the name."""
     if isinstance(lib, tuple): return os.path.basename(lib[0])
     if lib.startswith('-framework '): return lib
     return os.path.basename(lib)
 
 
 def get_unique_libnames(items: list):
-    added = set() # to track already added items
-    unique = list() # it must be a list to preserve order of items
+    added = set()
+    unique = list() # a list, to preserve the item order
     for item in items:
         basename = get_lib_basename(item)
         if not basename in added:
@@ -64,11 +64,11 @@ def export_include(target: BuildTarget, include_path: str, build_dir: bool,
     include_path = target_root_path(target, include_path, build_dir=build_dir)
     if os.path.exists(include_path):
         if as_includes_root:
-            # add parent of this include as the exported include, 
-            # so we can #include <mylib/file.h> instead of <src/mylib/file.h>
+            # Export the parent of this include, so a consumer writes
+            # #include <mylib/file.h> and not <src/mylib/file.h>.
             includes_root = include_path
             if type(as_includes_root) == str:
-                alias_name = str(as_includes_root) # assume user passed in 'mylib'
+                alias_name = str(as_includes_root) # the user passed the alias, e.g. 'mylib'
             else:
                 alias_name = os.path.basename(include_path) # take '{src}/include/mylib' -> 'mylib'
             include_path = normalized_path(include_path + '/../')
@@ -111,10 +111,7 @@ def export_lib(target: BuildTarget, relative_path: str, build_dir: bool):
 
 
 def set_export_libs_and_products(target: BuildTarget, libs_and_deps: List[str]):
-    """
-    Sets target's exported_libs and build_products from previously serialized
-    list of libraries and dependencies
-    """
+    """Sets the target's exported_libs and build_products from a serialized list of libs and deps."""
     libs_and_deps = cleanup_libs_list(libs_and_deps)
     only_libs = []
     for lib in libs_and_deps:
@@ -125,7 +122,7 @@ def set_export_libs_and_products(target: BuildTarget, libs_and_deps: List[str]):
 
 
 def cleanup_libs_list(libs: List[str]):
-    """Cleans up libs list by removing invalid entries"""
+    """Strips whitespace and drops `.lib.recipe` entries."""
     cleaned = []
     for lib in libs:
         lib = lib.strip()
@@ -134,9 +131,7 @@ def cleanup_libs_list(libs: List[str]):
     return cleaned
 
 
-# NOTE: clean_intermediate_files is a suggestion !
 def clean_intermediate_files(target: BuildTarget):
-    # never clean root or always_build targets
     if target.dep.always_build or target.dep.is_root:
         return
 
@@ -146,11 +141,10 @@ def clean_intermediate_files(target: BuildTarget):
     if target.clean_intermediate_files:
         if config.verbose: warning('  clean_intermediate [target.clean_intermediate_files]')
         should_clean = True
-    # always clean the intermediate files if we just did an upload operation
     elif config.upload:
         if config.verbose: warning('  clean_intermediate [config.upload]')
         should_clean = True
-    # do automatic cleaning if we did not do a targeted build -- this was an automatic build from source
+    # no targeted build: this was an automatic dependency build from source
     elif (config.build or config.rebuild or config.update) and config.no_specific_target():
         if config.verbose: warning('  clean_intermediate [dependency build cleanup]')
         should_clean = True
@@ -172,19 +166,18 @@ def export_libs(target: BuildTarget, path, pattern_substrings: List[str], build_
     libs = glob_with_name_match(root_path, pattern_substrings)
     libs = cleanup_libs_list(libs)
 
-    # ignore root_path/deploy
     root_deploy = root_path + '/deploy/'
     libs = [l for l in libs if not l.startswith(root_deploy)]
 
     target.exported_libs += libs
     target.exported_libs = get_unique_libnames(target.exported_libs)
 
-    # ordering needs to be applied for ALL exported libs, incase they were added in multiple steps
+    # apply the order to ALL exported libs, because earlier export steps added libs too
     if order:
         def lib_index(lib):
             for i in range(len(order)):
                 if order[i] in lib: return i
-            return len(order)  # if this lib name does not match, put it at the end of the list
+            return len(order)  # an unmatched lib sorts last
         def sort_key(lib):
             return lib_index(lib)
         target.exported_libs.sort(key=sort_key)
@@ -221,7 +214,6 @@ def find_syslib(target: BuildTarget, name: str, apt: bool, required: bool):
     elif platform.syslib_is_searchable:
         roots = [ "/usr/lib" ]
 
-        # They may be located in different places
         if 'LD_LIBRARY_PATH' in os.environ:
             roots += os.environ['LD_LIBRARY_PATH'].split(':')
 
@@ -236,31 +228,30 @@ def find_syslib(target: BuildTarget, name: str, apt: bool, required: bool):
                 lambda: f'{root}/lib{name}.so.2',
                 lambda: f'{root}/lib{name}.a' ]:
                 if os.path.exists(candidate()):
-                    return name # example: we found `libdl.so`, so just return `dl` for the linker
+                    return name # found e.g. `libdl.so`, so return `dl` for the linker
         if not required: return None
         if apt: raise IOError(f'Error {target.name} failed to find REQUIRED SysLib: {name}  Try `sudo apt install {apt}`')
         raise IOError(f'Error {target.name} failed to find REQUIRED SysLib: {name}  Try installing it with apt.')
     else:
-        return name # just export it. expect system linker to find it.
+        return name # export as-is and expect the system linker to find it
 
 
 def export_syslib(target: BuildTarget, name: str, apt: bool, required: bool):
     """
-    - target: The build target where to add the export syslib
+    - target: The build target that exports the syslib
     - name: Name of the system library, eg: lzma
-    - apt: if true, then apt suggestion is given
-    - required: if true, then an exception is thrown if syslib is not found
+    - apt: Name of the apt package to suggest when the search fails
+    - required: If true, a missing syslib raises an exception
     """
     try:
         lib = find_syslib(target, name, apt, required)
         if lib:
-            # console(f'Exporting syslib: {name}:{lib}')
             target.exported_syslibs.append(lib)
             target.exported_syslibs = get_unique_libnames(target.exported_syslibs)
             return True
     except IOError:
         if target.config.clean:
-            # just export it. expect system linker to find it.
+            # export as-is and expect the system linker to find it
             target.exported_syslibs.append(name)
             target.exported_syslibs = get_unique_libnames(target.exported_syslibs)
             return True
@@ -271,7 +262,7 @@ def export_syslib(target: BuildTarget, name: str, apt: bool, required: bool):
 
 
 def _reset_syslib_name(syslib: str):
-    """ Resets the syslib name from `/usr/lib/x86_64-linux-gnu/liblzma.so` to `lzma` """
+    """Resets a syslib name from `/usr/lib/x86_64-linux-gnu/liblzma.so` to `lzma`."""
     fname = os.path.basename(syslib)
     if fname.startswith('lib'):
         if fname.endswith('.so'):
@@ -289,6 +280,6 @@ def reload_syslibs(target: BuildTarget, syslibs: List[str]):
         else:
             libname = _reset_syslib_name(syslib)
             lib = find_syslib(target, libname, apt=None, required=False)
-            if not lib: lib = syslib # not found, fall back to original syslib
+            if not lib: lib = syslib # not found, keep the original syslib
             reloaded.append(lib)
     target.exported_syslibs = reloaded

--- a/mama/papa_deploy.py
+++ b/mama/papa_deploy.py
@@ -49,10 +49,8 @@ def _gather_includes(target:BuildTarget, recurse):
 
 
 def _gather_libs(target:BuildTarget, recurse):
-    # gather all libs from the root target
     libs = [(target,l) for l in target.exported_libs]
 
-    # and for children, only gather dynamic libs if recurse is set
     if recurse:
         def get_dylibs(t:BuildTarget):
             for l in t.exported_libs:
@@ -135,8 +133,8 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
 def find_duplicate_trees(files:list) -> list:
     """(dir a, dir b, [file names]) for every pair of directories that hold the same file content twice.
     QCoro installs its headers into include/qcoro AND include/qcoro6/qcoro, so a package that exports the
-    whole include dir ships both. That doubles the archive and gives the consumer two copies to keep in
-    sync. files: (relative path, full path) for every file to compare."""
+    whole include dir ships both. That doubles the archive and gives the consumer two copies of every
+    header. files: (relative path, full path) for every file to compare."""
     by_name = {}
     for rel, full in files:
         by_name.setdefault((os.path.basename(rel), os.path.getsize(full)), []).append((rel, full))
@@ -183,7 +181,7 @@ def _warn_about_duplicate_include_trees(target:BuildTarget, package_full_path:st
 
 
 def _compiler_stamp(config) -> str:
-    """'gcc14.3' / 'clang18.1', '' if the platform can't name one - a diagnostic, never a deploy failure."""
+    """'gcc14.3' / 'clang18.1', or '' when the platform cannot name one. A diagnostic, never a deploy failure."""
     try: return config.compiler_version()
     except Exception: return ''
 
@@ -207,8 +205,8 @@ def papa_deploy_to(target:BuildTarget, package_full_path:str,
     if not os.path.exists(package_full_path): # check to avoid Access Denied errors
         os.makedirs(package_full_path, exist_ok=True)
 
-    # set up project and dependencies. `C` = compiler that built these libs (same string as the archive name),
-    # so a load can spot a gcc tree landing in a clang build.
+    # `C` records the compiler that built these libs, the same string as in the archive name,
+    # so a load can spot a gcc tree in a clang build.
     descr = [ f'P {target.name}' ]
     compiler = _compiler_stamp(config)
     if compiler: descr.append(f'C {compiler}')
@@ -231,7 +229,6 @@ def papa_deploy_to(target:BuildTarget, package_full_path:str,
         descr.append(f'L {relpath}')
         outpath = normalized_join(package_full_path, relpath)
         os.makedirs(os.path.dirname(outpath), exist_ok=True)
-        #outpath = package_full_path
         if detail_echo: console(f'    L ({libtarget.name+")": <16}  {relpath}')
         if lib != outpath:
             if config.verbose: console(f'    copy {lib}\n      -> {outpath}')
@@ -256,7 +253,6 @@ def papa_deploy_to(target:BuildTarget, package_full_path:str,
 
     write_text_to(os.path.join(package_full_path, 'papa.txt'), '\n'.join(descr))
 
-    # write summary
     if config.print:
         console(f'  PAPA Deployed: {len(includes)} includes, {len(libs)} libs, {len(syslibs)} syslibs, {len(assets)} assets')
 
@@ -276,7 +272,7 @@ class PapaFileInfo:
         self.papa_dir = os.path.dirname(papa_file)
 
         self.project_name = None
-        self.compiler = None # 'gcc14.3' / 'clang18.1'; None for packages predating the C record
+        self.compiler = None # 'gcc14.3' / 'clang18.1'. None for a package that predates the C record
         self.dependencies = []
         self.includes = []
         self.libs = []

--- a/mama/papa_deploy.py
+++ b/mama/papa_deploy.py
@@ -102,9 +102,8 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
     def is_header(path:str) -> bool:
         name = os.path.basename(path)
         if name.endswith(suffixes): return True
-        # Qt and QCoro name a stub header after the class it declares, with no extension, as in
-        # `#include <QCoro/QCoroTask>`. Ship one only when the header it forwards to is in the tree,
-        # so a LICENSE or an AUTHORS file never ships.
+        # Qt-style stub headers carry no extension (`#include <QCoro/QCoroTask>`). Ship one only when
+        # the header it forwards to is in the tree, so a LICENSE or an AUTHORS file never ships.
         return '.' not in name and name.lower() in stems
 
     exported = []  # export dir names already handled, so one name never ships twice
@@ -116,9 +115,8 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
         src_dir, dst_dir, record = _include_deploy(target, includes_root, abs_include)
         first = deploy_dirs.setdefault(os.path.basename(dst_dir).lower(), dst_dir)
         if first != dst_dir:
-            # QCoro/ next to qcoro/ is ONE dir on Windows and macOS. The merge also puts a stub header
-            # beside the header it forwards to, which is how `#include "qcorotask.h"` resolves.
-            # Only one spelling survives on Linux, so the package tells the author which one won.
+            # Two dirs whose names differ only by case are ONE dir on Windows and macOS, and the merge puts
+            # a stub header beside its target. Only one spelling survives on Linux, so name the winner.
             dst_dir = first
             warning(f'  PAPA Deploy {target.name}: merged {record[2:]} into include/{os.path.basename(first)}.' + \
                     ' A consumer must write the surviving spelling.')
@@ -132,9 +130,9 @@ def _append_includes(target:BuildTarget, package_full_path, detail_echo, descr, 
 
 def find_duplicate_trees(files:list) -> list:
     """(dir a, dir b, [file names]) for every pair of directories that hold the same file content twice.
-    QCoro installs its headers into include/qcoro AND include/qcoro6/qcoro, so a package that exports the
-    whole include dir ships both. That doubles the archive and gives the consumer two copies of every
-    header. files: (relative path, full path) for every file to compare."""
+    A project that installs its headers into two include dirs doubles the archive and gives the consumer
+    two copies of every header.
+    - files: (relative path, full path) for every file to compare"""
     by_name = {}
     for rel, full in files:
         by_name.setdefault((os.path.basename(rel), os.path.getsize(full)), []).append((rel, full))
@@ -193,10 +191,8 @@ def papa_deploy_to(target:BuildTarget, package_full_path:str,
     detail_echo = config.print and target.is_current_target() and (not config.test)
     if detail_echo: console(f'  - PAPA Deploy {package_full_path}')
 
-    # Defense-in-depth: never write into a directory holding a shim marker. A
-    # misconfigured caller could pass the shim's build_dir directly, which would
-    # corrupt the artifactory snapshot (papa.txt + unzipped tree) the next mama
-    # run depends on. The proper deploy-skip lives in _execute_deploy_tasks.
+    # Defense-in-depth: never write into a directory holding a shim marker. A misconfigured caller could
+    # pass the shim's build_dir and corrupt the artifactory snapshot. The deploy-skip lives in _execute_deploy_tasks.
     if has_shim_marker(package_full_path):
         raise RuntimeError(f'papa_deploy refused: {package_full_path} contains a mama_shim marker.')
 

--- a/mama/papa_upload.py
+++ b/mama/papa_upload.py
@@ -157,12 +157,9 @@ def validate_archive(package_full_path: str, papa: PapaFileInfo, archive_path: s
 
 def _download_can_find_this_version(target:BuildTarget) -> bool:
     """True when the version this upload names is the one a DOWNLOAD would look for.
-
-    The two sides read the version differently. An upload runs the mamafile and uses the value in
-    memory. A download reads the file as text, because it must name the package before it clones
-    anything. A mamafile that computes the version, or assigns it twice, makes the two disagree. Mama
-    would then publish an archive no consumer can ever ask for, and every build would miss the cache
-    with no error to explain it. Refuse the upload instead."""
+    An upload runs the mamafile and uses the value in memory. A download reads the file as text, because
+    it must name the package before the clone. A computed or twice-assigned version makes the two disagree,
+    and mama would publish an archive no consumer can ever ask for. Refuse the upload instead."""
     executed = target.version or ''
     readable = pinned_version(target.dep)
     if executed == readable: return True
@@ -173,9 +170,9 @@ def _download_can_find_this_version(target:BuildTarget) -> bool:
 
 
 def papa_upload_to(target:BuildTarget, package_full_path:str):
-    """
-    - target: The configured and packaged target
-    - package_full_path: Full path to the deployed PAPA package
+    """Archives the deployed PAPA package, validates it, and uploads it to the artifactory server.
+    - target: the configured and packaged target
+    - package_full_path: full path to the deployed PAPA package
     """
     if not _download_can_find_this_version(target):
         return

--- a/mama/papa_upload.py
+++ b/mama/papa_upload.py
@@ -16,8 +16,8 @@ _CHUNK_SIZE = 1024*1024  # big enough to keep DEFLATE fed, small enough that the
 
 
 def _archive_entries(rel_path:str, full_path:str):
-    """(src, rel, size) for one papa record; a dir flattens into its tree, dir entries included so the
-    zip keeps its structure. size is None for a dir, else stat'd once here and reused as the bar weight."""
+    """(src, rel, size) for one papa record. A dir flattens into its tree, with dir entries kept so the
+    zip keeps its structure. size is None for a dir, else read once here and reused as the bar weight."""
     if not os.path.isdir(full_path):
         return [(full_path, rel_path, os.path.getsize(full_path))]
     entries = []
@@ -59,13 +59,13 @@ def _archive_groups(papa:PapaFileInfo, package_full_path:str):
 
 
 def _archive_total_size(groups:list) -> int:
-    """Uncompressed bytes the zip will hold; drives both the bar and the compression level."""
+    """Uncompressed bytes the zip will hold. Drives both the bar and the compression level."""
     return sum(size or 0 for _, entries in groups for _, _, size in entries)
 
 
 def _compress_level(total:int) -> int:
-    """Level 8 buys a couple percent of size for minutes of CPU once a package passes 100MB, and PAPA
-    packages are dominated by a few bloated static libs. Stay at 8 while it is cheap, drop to 6 above."""
+    """Level 8 buys a couple percent of size for minutes of CPU once a package passes 100MB, because a
+    few bloated static libs dominate a PAPA package. Stay at 8 while it is cheap and drop to 6 above."""
     return 6 if total > 100*1024*1024 else 8
 
 
@@ -82,8 +82,8 @@ def _write_file(zip:zipfile.ZipFile, src:str, rel:str, bar:ProgressBar):
 
 
 def _write_archive(zip:zipfile.ZipFile, groups:list, config, indent:str, total:int):
-    """Writes every entry into the zip. Verbose keeps its per-record lines; regular verbosity gets a
-    progress bar, since a big package (protobuf ships ~100 libs) otherwise looks frozen for minutes."""
+    """Writes every entry into the zip. Verbose keeps its per-record lines. Regular verbosity gets a
+    progress bar, because a big package (protobuf ships ~100 libs) otherwise looks frozen for minutes."""
     show_bar = config.print and not config.verbose
     bar = ProgressBar(total, indent) if show_bar else None
     for label, entries in groups:
@@ -174,8 +174,8 @@ def _download_can_find_this_version(target:BuildTarget) -> bool:
 
 def papa_upload_to(target:BuildTarget, package_full_path:str):
     """
-    - target: Target which was configured and packaged
-    - package_full_path: Full path to deployed PAPA package
+    - target: The configured and packaged target
+    - package_full_path: Full path to the deployed PAPA package
     """
     if not _download_can_find_this_version(target):
         return
@@ -195,9 +195,8 @@ def papa_upload_to(target:BuildTarget, package_full_path:str):
     if config.verbose:
         console(f'    archiving {papa_file}\n {"":10}-> {archive_path}')
 
-    # archive needs to be created manually to only include the files in papa.txt
+    # build the archive by hand, so it holds only the files papa.txt names
     papa = PapaFileInfo(papa_file)
-    # create a zip archive with papa.includes, papa.libs and papa.assets
     temp_archive = archive_path + '.tmp'
     groups = _archive_groups(papa, package_full_path)
     total = _archive_total_size(groups)
@@ -206,7 +205,6 @@ def papa_upload_to(target:BuildTarget, package_full_path:str):
         if config.verbose: console(f'      root {package_full_path} ({get_file_size_str(total)}, deflate {level})')
         _write_archive(zip, groups, config, f'  - {target.name: <16} ', total)
 
-    # move the intermediate archive to the final location
     if os.path.exists(archive_path):
         os.remove(archive_path)
     shutil.move(temp_archive, archive_path)

--- a/mama/parse_mamafile.py
+++ b/mama/parse_mamafile.py
@@ -4,14 +4,12 @@ from .utils.system import console
 from .util import path_join, read_text_from, write_text_to, file_sha1
 
 def parse_mamafile(config, target_class, mamafile):
+    """Run `mamafile` and return (name, class) of its first `target_class` subclass."""
     if not mamafile or not os.path.exists(mamafile):
         return None, None
-    #console(f'loaded_mamafile: {mamafile}')
-
     loaded_globals = runpy.run_path(mamafile)
     for key, value in loaded_globals.items():
         if inspect.isclass(value) and issubclass(value, target_class):
-            # print(f'found {key}(BuildTarget): {value}')
             return key, value
     raise RuntimeError(f'No BuildTarget class found in mamafile: {mamafile}')
 
@@ -28,11 +26,11 @@ def _write_tag(tagfile, mtime, content_hash):
 
 
 def update_modification_tag(config, file, tagfile):
-    """True when `file` changed since its tag was written, and refreshes the tag.
+    """True when `file` changed since the last tag write. Refreshes the tag.
 
     Two layers. The mtime answers first and costs one stat, so an unchanged file opens nothing. Only a
     moved mtime reads the file, and the sha1 then decides. git rewrites a checked-out file with the same
-    bytes, and the mtime alone rebuilt every dep that read it."""
+    bytes, so the mtime alone would rebuild every dep that read the file."""
     if not os.path.exists(file):
         return False
 
@@ -52,12 +50,12 @@ def update_modification_tag(config, file, tagfile):
     if config.verbose: console(f'Update tagfile: {tagfile}')
     return True
 
-## Return: TRUE if mamafile.py was modified
 def update_mamafile_tag(config, mamafile, build_dir):
+    """True when mamafile.py changed since the last run."""
     mamafiletag = path_join(build_dir, 'mamafile_tag')
     return update_modification_tag(config, mamafile, mamafiletag)
 
-## Return: TRUE if CMakeLists.txt was modified
 def update_cmakelists_tag(config, cmakelists, build_dir):
+    """True when CMakeLists.txt changed since the last run."""
     cmakeliststag = path_join(build_dir, 'cmakelists_tag')
     return update_modification_tag(config, cmakelists, cmakeliststag)

--- a/mama/platforms/android.py
+++ b/mama/platforms/android.py
@@ -90,8 +90,10 @@ class Android(Platform):
 
 
     def init_toolchain(self, toolchain_dir=None, toolchain_file=None):
-        """A root mamafile points mama at an explicit NDK CMake toolchain file. The NDK itself is
-        still discovered, because the toolchain file alone does not name the clang binaries."""
+        """Use an explicit NDK CMake toolchain file. The NDK itself is still discovered, because
+        the toolchain file alone does not name the clang binaries.
+        toolchain_file: path to the NDK CMake toolchain file to use
+        """
         if toolchain_file: self.set_toolchain_path(toolchain_file)
         self.init_default()
 
@@ -212,8 +214,7 @@ Or define env ANDROID_HOME with path to Android SDK root with valid NDK-s.''')
 
     def make_program(self, target=None) -> str:
         """The NDK ships its own make for hosts that have none. Linux always has one, so '' there
-        lets the build system find it. This is the ONLY place android names a make program. Naming
-        it here AND in the generic option builder passed the option to cmake twice."""
+        lets the build system find it. ONLY this place names a make program, or cmake gets it twice."""
         if System.windows: platform_dir = 'windows-x86_64'
         elif System.macos: platform_dir = 'darwin-x86_64'
         else: return ''

--- a/mama/platforms/android.py
+++ b/mama/platforms/android.py
@@ -28,10 +28,10 @@ class Android(Platform):
 
     def __init__(self, config):
         super().__init__(config)
-        self.toolchain_file = None  ## possibility to override the toolchain file
+        self.toolchain_file = None  ## explicit toolchain file, set by a root mamafile. None uses the NDK's own
         self.android_sdk_path = ''
         self.android_ndk_path = ''
-        self.android_api = 'android-29' # 29: Android 10.0 (2020)
+        self.android_api = 'android-29' # API 29: Android 10 (2019)
         self.android_ndk_stl = 'c++_shared' # LLVM libc++
         self.ndk_version = ''
 
@@ -81,7 +81,7 @@ class Android(Platform):
 
     def banner_name(self) -> str:
         ndk = os.path.basename(self.android_ndk().rstrip('/\\'))
-        # android_api is already 'android-36', so it names the platform on its own
+        # android_api already contains the platform name, eg 'android-29'
         return ' '.join(p for p in (self.android_api, self.config.arch, f'ndk-{ndk}' if ndk else '') if p)
 
 
@@ -120,9 +120,9 @@ class Android(Platform):
     def init_ndk_path(self):
         ndk_build = 'ndk-build.cmd' if System.windows else 'ndk-build'
 
-        # using NDK paths to find SDK and NDK
+        # find both paths from an NDK env var first
         ndk_paths = []
-        if not self.ndk_version: # skip if NDK version is explicitly requested via `ndk-<ver>` argument
+        if not self.ndk_version: # an explicit ndk-<ver> argument pins the version, so skip the env var search
             Android._append_env(ndk_paths, 'ANDROID_NDK_LATEST_HOME')
             Android._append_env(ndk_paths, 'ANDROID_NDK_HOME')
             Android._append_env(ndk_paths, 'ANDROID_NDK_ROOT')
@@ -130,20 +130,18 @@ class Android(Platform):
 
             for ndk_path in ndk_paths:
                 if ndk_path and os.path.exists(f'{ndk_path}/{ndk_build}'):
-                    # figure out the Sdk path
-                    # usually SDK=/Android/ and ANDROID_NDK_ROOT=/Android/ndk/26.1.10909125
-                    # on linux we use /opt/android-sdk/ndk/26.1.10909125 but we might not have SDK there
+                    # derive the SDK root from the NDK path, usually <SDK>/ndk/26.1.10909125 -> <SDK>
                     sdk_path = os.getenv('ANDROID_HOME') or os.getenv('ANDROID_SDK_ROOT')
                     if not sdk_path and os.path.exists(f'{ndk_path}/../../platforms'):
                         sdk_path = util.forward_slashes(os.path.abspath(f'{ndk_path}/../..'))
                     if not sdk_path and os.path.exists(f'{ndk_path}/../platforms'):
                         sdk_path = util.forward_slashes(os.path.abspath(f'{ndk_path}/..'))
-                    if not sdk_path: # default to modern NDK structure /Android/ndk/26.1.10909125 --> /Android/
+                    if not sdk_path: # default to the modern layout <SDK>/ndk/<version>
                         sdk_path = util.forward_slashes(os.path.abspath(f'{ndk_path}/../..'))
                     self._set_ndk_sdk_paths(ndk_path, sdk_path)
                     return
 
-        # find SDK and NDK by using SDK root
+        # otherwise scan the known SDK roots for an NDK
         sdk_paths = []
         Android._append_env(sdk_paths, 'ANDROID_HOME')
         Android._append_env(sdk_paths, 'ANDROID_SDK_ROOT')
@@ -173,15 +171,15 @@ class Android(Platform):
             if os.path.exists(f'{sdk_path}/ndk-bundle/{ndk_build}'):
                 self._set_ndk_sdk_paths(sdk_path + '/ndk-bundle', sdk_path)
                 return
-            # newer NDK with multiple ndk versions:
+            # newer NDK layout with multiple versions under ndk/
             elif os.path.exists(f'{sdk_path}/ndk'):
                 subdirs = os.listdir(f'{sdk_path}/ndk')
-                subdirs.sort(reverse=True) # newer version always first
+                subdirs.sort(reverse=True) # newest version first
                 for subdir in subdirs:
                     if self.ndk_version and not subdir.startswith(self.ndk_version):
                         if self.config.verbose:
                             warning(f'Skipping NDK version {subdir} since it does not match the requested version {self.ndk_version}')
-                        continue # skip if subdir doesn't match the requested NDK version
+                        continue
                     if os.path.exists(f'{sdk_path}/ndk/{subdir}/{ndk_build}'):
                         self.ndk_version = subdir
                         self._set_ndk_sdk_paths(f'{sdk_path}/ndk/{subdir}', sdk_path)
@@ -214,8 +212,8 @@ Or define env ANDROID_HOME with path to Android SDK root with valid NDK-s.''')
 
     def make_program(self, target=None) -> str:
         """The NDK ships its own make for hosts that have none. Linux always has one, so '' there
-        lets the build system find it. This is the ONLY place android names a make program: naming it
-        here AND in the generic option builder passed it to cmake twice."""
+        lets the build system find it. This is the ONLY place android names a make program. Naming
+        it here AND in the generic option builder passed the option to cmake twice."""
         if System.windows: platform_dir = 'windows-x86_64'
         elif System.macos: platform_dir = 'darwin-x86_64'
         else: return ''

--- a/mama/platforms/generic_yocto.py
+++ b/mama/platforms/generic_yocto.py
@@ -28,20 +28,20 @@ class GenericYocto(Platform):
 
     def __init__(self, config):
         super().__init__(config)
-        self.toolchain_file = ''  ## for a Docker based build, this is the aarch64_toolchain.cmake
-        self.toolchain_dir = ''
-        self.compilers = ''  ## dir holding g++, gcc and ld
-        self.cc_prefix = '' ## e.g. '{self.compilers}aarch64-poky-linux-'
-        self.sdk_path = ''  ## Path to SDK libs root
-        self.sysroot_path = ''  ## Path to system libs root
-        self.include_paths = []  ## Path to additional include dirs
-        self.version = '' ## GCC Version
-        self.sdk_version = (1,0,0) ## SDK version tuple, e.g. (5, 0, 4) for version 5.0.4
+        self.toolchain_file = ''  ## the resolved cmake toolchain file. init_toolchain() sets it
+        self.toolchain_dir = ''   ## the SDK root that discovery accepted
+        self.compilers = ''       ## dir holding g++, gcc and ld
+        self.cc_prefix = ''       ## eg '{compilers}aarch64-poky-linux-'
+        self.sdk_path = ''        ## sysroots/<sdk_name>, holds the cross compilers
+        self.sysroot_path = ''    ## sysroots/<sysroot_name>, holds the target libs
+        self.include_paths = []   ## extra include dirs for the target
+        self.version = ''         ## gcc version, eg '11.4.0'
+        self.sdk_version = (1,0,0)  ## SDK version tuple, eg (5, 0, 4)
 
 
     def __init_subclass__(cls, **kwargs):
-        """Derive the board's defines from its name, so a board declares the name once. YOCTO_LINUX
-        goes out for every generic Yocto board, on top of the board's own define."""
+        """Derive the board's defines from its name, so a board declares the name once. Every
+        generic Yocto board gets YOCTO_LINUX next to its own define."""
         super().__init_subclass__(**kwargs)
         if cls.name and not cls.platform_define:
             cls.platform_define = cls.name.upper()
@@ -49,8 +49,8 @@ class GenericYocto(Platform):
 
 
     def _resolved(self):
-        """Run SDK discovery if it has not run yet, then return self. Reading a path field before
-        that silently hands back ''."""
+        """Run SDK discovery if it has not run yet, then return self. A path field read before
+        discovery is silently ''."""
         if not self.compilers: self.init_default()
         return self
 
@@ -70,8 +70,8 @@ class GenericYocto(Platform):
 
 
     def distro_version(self) -> tuple:
-        """The SDK version, eg (5, 0, 4). Unlike every other platform this carries no name, and the
-        artifactory archive name has always been built from it that way."""
+        """The SDK version, eg (5, 0, 4). Unlike every other platform this carries no name. The
+        artifactory archive name expects that shape."""
         return self._resolved().sdk_version
 
 
@@ -87,8 +87,8 @@ class GenericYocto(Platform):
 
     @staticmethod
     def expand_versioned_sdks(paths: list) -> list:
-        """Expands each path with its versioned SDK installs, e.g. /opt/imx8mp-sdk/1.4.0,
-        newest first, so a versioned install wins over a flat legacy layout at the same root."""
+        """Expand each path with its versioned SDK installs, eg /opt/imx8mp-sdk/1.4.0, newest first.
+        A versioned install wins over a flat legacy layout at the same root."""
         expanded = []
         for path in paths:
             if os.path.isdir(path):
@@ -96,7 +96,7 @@ class GenericYocto(Platform):
                 for name in os.listdir(path):
                     if name and all(p.isdigit() for p in name.split('.')):
                         versions.append(name)
-                # listdir order is not guaranteed cross-platform, sort newest first
+                # listdir order is not guaranteed, so sort newest first
                 versions.sort(key=lambda n: [int(p) for p in n.split('.')], reverse=True)
                 expanded += [path_join(path, v) for v in versions]
             expanded.append(path)
@@ -111,14 +111,13 @@ class GenericYocto(Platform):
             raise RuntimeError(f'{self.name} only supported on Linux')
 
         paths = ([toolchain_dir] if toolchain_dir else []) + list(self.search_paths)
-        # fallback env for user configuration, e.g. XILINX_SDK_HOME
+        # fallback env var for user configuration, eg XILINX_SDK_HOME
         envs = list(self.search_envs) or [f'{self.platform_define}_SDK_HOME']
         for env in envs:
             self.append_env_path(paths, env)
         paths = GenericYocto.expand_versioned_sdks(paths)
 
         for path in paths:
-            # Check for Yocto structure
             yocto_sdkpath = os.path.abspath(f'{path}/sysroots/{self.sdk_name}')
             yocto_sysroot = os.path.abspath(f'{path}/sysroots/{self.sysroot_name}')
             yocto_compiler = f'{yocto_sdkpath}/{self.compiler_name}'
@@ -129,30 +128,29 @@ class GenericYocto(Platform):
             found_compiler = os.path.exists(yocto_compiler)
             found_sysroot = os.path.exists(yocto_sysroot)
             if found_compiler and found_sysroot:
-                self.sdk_path     = yocto_sdkpath # e.g. {path}/sysroots/x86_64-pokysdk-linux
-                self.sysroot_path = yocto_sysroot # e.g. {path}/sysroots/cortexa53-crypto-poky-linux
+                self.sdk_path     = yocto_sdkpath # eg {path}/sysroots/x86_64-pokysdk-linux
+                self.sysroot_path = yocto_sysroot # eg {path}/sysroots/cortexa53-crypto-poky-linux
                 self.toolchain_dir = os.path.abspath(path)
 
-                # if original `toolchain_dir` was chosen, then prefer toolchain_file
+                # the explicit toolchain_file pairs only with the explicit toolchain_dir
                 if toolchain_file and path == toolchain_dir:
                     self._set_toolchain_file(toolchain_file)
                 else:
                     self._set_toolchain_file(f'{self.toolchain_dir}/{self.default_toolchain}')
 
-                self.compilers = os.path.dirname(yocto_compiler) + '/' # e.g. f'{self.sdk_path}/usr/bin/aarch64-poky-linux/'
-                # replace -gcc at the end with '-' to get the prefix
-                # e.g '{self.sdk_path}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-
+                self.compilers = os.path.dirname(yocto_compiler) + '/' # eg {sdk_path}/usr/bin/aarch64-poky-linux/
+                # eg {sdk_path}/usr/bin/aarch64-poky-linux/aarch64-poky-linux-
                 self.cc_prefix = self.compilers + os.path.basename(self.compiler_name).replace('-gcc', '-')
                 self.include_paths = [ f'{self.sysroot_path}/usr/include' ]
                 self.version = self.config.get_gcc_clang_fullversion(yocto_compiler, dumpfullversion=True)
                 break
 
-            # add some helpful debug messages on potentially broken toolchain configurations
+            # one half found usually means a broken SDK install, so report which half is missing
             if self.config.print and found_compiler != found_sysroot:
                 if found_compiler: warning(f'Found compiler at {yocto_compiler} but sysroot not found at {yocto_sysroot}')
                 else:              warning(f'Found sysroot at {yocto_sysroot} but compiler not found at {yocto_compiler}')
 
-        # fallback
+        # no SDK matched: an explicit toolchain_file may still work on its own
         if not self.toolchain_file and toolchain_file:
             if not self._set_toolchain_file(toolchain_file):
                 raise FileNotFoundError(f'Toolchain file not found: {toolchain_file}')
@@ -179,13 +177,13 @@ class GenericYocto(Platform):
 
 
     def _autodetect_version(self, toolchain_dir):
-        """Autodetect the version of the Yocto SDK from the toolchain_dir name."""
+        """The SDK version parsed from the toolchain_dir name, else (1, 0, 0)."""
         if not toolchain_dir:
             return (1, 0, 0)
         last_part = os.path.basename(toolchain_dir)
-        if last_part.count('.') == 2: # e.g. 'toolchain-1.0.0' or '5.0.4'
-            parts = re.split(r'[-_ +]', last_part) # split using separators
-            # find last part that starts with a digit and looks like a version number, e.g. '1.0' or '5.0.4'
+        if last_part.count('.') == 2: # eg 'toolchain-1.0.0' or '5.0.4'
+            parts = re.split(r'[-_ +]', last_part)
+            # take the last part that starts with a digit, eg '5.0.4'
             version = [p for p in parts if p and '.' in p and p[0].isdigit()][-1]
             return tuple(int(x) for x in version.split('.') if x.isdigit())
         return (1, 0, 0)
@@ -201,8 +199,8 @@ class GenericYocto(Platform):
 
     def _build_toolchain(self) -> Toolchain:
         prefix = self.cc_prefix  # discovery already ran: Platform.toolchain() calls init_default() first
-        # find_root_program NEVER, so the build system takes the cross binutils named here, and the
-        # target's own libs and headers instead of the host's
+        # find_root_program NEVER, so the build system takes the cross binutils named here. Setting
+        # it also resolves libs and headers in the target root, never the host's
         return Toolchain(system_name=self.system_name, system_processor=self.system_processor(),
                          system_version='1', cc=f'{prefix}gcc', cxx=f'{prefix}g++', version=self.version,
                          tool_prefix=prefix, sysroot=self.sysroot_path, find_root_program='NEVER',
@@ -217,7 +215,7 @@ class GenericYocto(Platform):
 
 
     def get_gnu_build_env(self, environ: dict = {}):
-        sysroot = f'--sysroot={self.sysroot()}'  # accessor: it resolves the SDK if nothing has yet
+        sysroot = f'--sysroot={self.sysroot()}'  # the accessor runs SDK discovery on first use
         environ['LDFLAGS'] = sysroot
         environ['CFLAGS'] = sysroot
         environ['CXXFLAGS'] = sysroot

--- a/mama/platforms/generic_yocto.py
+++ b/mama/platforms/generic_yocto.py
@@ -70,7 +70,7 @@ class GenericYocto(Platform):
 
 
     def distro_version(self) -> tuple:
-        """The SDK version, eg (5, 0, 4). Unlike every other platform this carries no name. The
+        """The SDK version, eg (5, 0, 4), with no name unlike every other platform. The
         artifactory archive name expects that shape."""
         return self._resolved().sdk_version
 
@@ -104,8 +104,10 @@ class GenericYocto(Platform):
 
 
     def init_toolchain(self, toolchain_dir=None, toolchain_file=None):
-        """Find the SDK. An explicit `toolchain_dir` is searched first, then the board's own paths,
-        then whatever its env vars name."""
+        """Find the SDK in the board's own paths, then in whatever its env vars name.
+        toolchain_dir: an explicit SDK root, searched first
+        toolchain_file: an explicit cmake toolchain file, paired with the explicit toolchain_dir
+        """
         # TODO: expand support to enable Windows host cross-compilation?
         if not System.linux:
             raise RuntimeError(f'{self.name} only supported on Linux')
@@ -209,8 +211,7 @@ class GenericYocto(Platform):
 
 
     def get_ld_flags(self, add_ld_flag: Callable[[str, str], None]):
-        # -Wl,--as-needed keeps an embedded binary from linking libraries it never calls, which
-        # bloats it and can break at runtime on a resource-constrained device
+        # --as-needed keeps an embedded binary from linking libraries it never calls, which bloats it
         add_ld_flag('-Wl,--as-needed')
 
 

--- a/mama/platforms/ios.py
+++ b/mama/platforms/ios.py
@@ -60,5 +60,4 @@ class Ios(Platform):
         # Xcode SDK selection has no build-system-neutral form, so it goes through the escape hatch
         return Toolchain(system_name=self.system_name, system_processor=self.system_processor(),
                          extra_opts=('IOS_PLATFORM=OS', 'CMAKE_XCODE_EFFECTIVE_PLATFORMS=-iphoneos',
-                                     'CMAKE_OSX_ARCHITECTURES=arm64',  # ALWAYS ARM64
-                                     'CMAKE_OSX_SYSROOT=iphoneos'))
+                                     'CMAKE_OSX_ARCHITECTURES=arm64', 'CMAKE_OSX_SYSROOT=iphoneos'))

--- a/mama/platforms/mips.py
+++ b/mama/platforms/mips.py
@@ -18,7 +18,7 @@ class Mips(Platform):
     default_arch = 'mipsel'
     supported_arches = ('mips', 'mipsel', 'mips64', 'mips64el')
     # mipsel keeps the bare `mips` dir, because it is the default and every existing package uses it.
-    # The other three used to share it, so a big-endian build overwrote a little-endian one in place.
+    # Every other arch gets its own dir, so two endian variants never overwrite each other in place.
     build_dirs = {'mipsel': 'mips', 'mips': 'mipsbe', 'mips64': 'mips64', 'mips64el': 'mips64el'}
     platform_define = 'MIPS'
     compile_defines = {'MIPS': '1'}
@@ -117,8 +117,7 @@ class Mips(Platform):
         prefix = self.compiler_prefix()
         return Toolchain(system_name=self.system_name, system_processor=self.system_processor(),
                          system_version='1', cc=f'{prefix}gcc', cxx=f'{prefix}g++', tool_prefix=prefix,
-                         # ONLY, not NEVER: a MIPS toolchain ships its own binutils and cmake must find
-                         # them in the toolchain, never the host's
+                         # ONLY, not NEVER: the toolchain ships its own binutils, never use the host's
                          find_root_program='ONLY',
                          toolchain_file=self.toolchain_file or '', toolchain_file_is_complete=True)
 

--- a/mama/platforms/mips.py
+++ b/mama/platforms/mips.py
@@ -35,7 +35,7 @@ class Mips(Platform):
 
 
     def compiler_prefix(self) -> str:
-        """`<bin>/<arch>-linux-gnu-`, eg `/opt/mipsel-openwrt-linux/bin/mipsel-openwrt-linux-`."""
+        """`<bin>/<arch>-linux-gnu-`, eg `/usr/bin/mipsel-linux-gnu-`."""
         if not self.gcc_prefix: self.init_default()
         return self.gcc_prefix
 
@@ -67,7 +67,7 @@ class Mips(Platform):
         if self.gcc_prefix and self.toolchain_file == toolchain_file and self.toolchain_dir == toolchain_dir:
             return
 
-        self.toolchain_file = toolchain_file # additional toolchain to specify sysroot details
+        self.toolchain_file = toolchain_file # an optional toolchain file that adds sysroot details
 
         # a toolchain dir should have a bin/ subdir with the compiler
         if toolchain_dir:
@@ -75,13 +75,13 @@ class Mips(Platform):
             if os.path.exists(f'{toolchain_dir}/bin/{arch}-linux-gnu-gcc'):
                 self._set_toolchain_dir(f'{toolchain_dir}/bin/{arch}-linux-gnu-',
                                        f'{toolchain_dir}/lib', f'{toolchain_dir}/include')
-                return # success
+                return
 
-        # check for a system installed one as fallback. It may also be at `/usr/mipsel-linux-gnu`
+        # then try a system installed toolchain. Its libs may live at /usr/mipsel-linux-gnu
         if os.path.exists(f'/usr/bin/{arch}-linux-gnu-gcc'):
             self._set_toolchain_dir(f'/usr/bin/{arch}-linux-gnu-',
                                    f'/usr/{arch}-linux-gnu/lib', f'/usr/{arch}-linux-gnu/include')
-            return # success
+            return
 
         raise EnvironmentError('No MIPS toolchain compilers detected, '+
                                f'try "sudo apt-get install g++-{arch}-linux-gnu"')

--- a/mama/platforms/platform.py
+++ b/mama/platforms/platform.py
@@ -8,8 +8,7 @@ if TYPE_CHECKING:
 
 
 # The canonical processor name per mama arch. This names what the TARGET runs on, never the host.
-# If the host value leaks in, a project that branches on it compiles host instructions into a
-# cross build. googletest adds -march=x86-64-v3 as soon as it reads x86_64.
+# If the host value leaks in, a project that branches on it compiles host instructions into a cross build.
 SYSTEM_PROCESSORS = {
     'arm64': 'aarch64', 'arm': 'armv7-a', 'x64': 'x86_64', 'x86': 'i686',
     'mips': 'mips', 'mipsel': 'mipsel', 'mips64': 'mips64', 'mips64el': 'mips64el',
@@ -36,12 +35,10 @@ class Platform:
     """One target platform: what to build FOR, and how to find the tools that build it.
 
     Every platform mama supports is a subclass. Exactly one instance lives at `config.platform`.
-    A subclass overrides only what differs from the defaults below. `Linux` overrides a few
-    members. `Android` overrides the most.
+    A subclass overrides only what differs from the defaults below.
 
     A platform describes facts. It never formats a build-system option. `mama/buildsys/` renders
-    `toolchain()` into whatever the active build system needs, so a second build system costs no
-    change here.
+    `toolchain()` into whatever the active build system needs, so a second build system costs no change here.
     """
 
     ## --- identity, declared by the subclass ---
@@ -62,12 +59,11 @@ class Platform:
     cxx20_flag = 'c++20'       ## `c++2a` where the toolchain predates the final C++20 name
     ## clang dropped -dumpfullversion, so only ask a gcc-based toolchain for the full x.y.z version
     compiler_dumpfullversion = True
-    ## A system library differs per platform. Apple links '-framework Foundation'. Linux has a real
-    ## file to find under /usr/lib. Every other platform leaves it to the system linker.
+    ## Apple links a system library as '-framework X'. Linux finds a real file. The rest leave it to the linker.
     syslib_is_framework = False
     syslib_is_searchable = False
-    ## The IDE project extensions this platform's own generator emits, newest format first, and the
-    ## command that opens one. An empty tuple means mama falls back to VSCode.
+    ## The IDE project extensions this platform's generator emits, newest first, and the command that
+    ## opens one. An empty tuple means mama falls back to VSCode.
     ide_project_ext = ()
     ide_project_is_dir = False
     ide_open_command = ''
@@ -90,7 +86,9 @@ class Platform:
 
 
     def validate_arch(self, arch: str):
-        """Raise when `arch` cannot be built for this platform. Called once, after arg parsing."""
+        """Raise when this platform cannot build for the arch. Called once, after arg parsing.
+        arch: the target arch name from the CLI
+        """
         if self.supported_arches and arch not in self.supported_arches:
             raise RuntimeError(f'Unsupported arch={arch} on {self.name} platform!' + \
                                f' Supported={list(self.supported_arches)}')
@@ -105,7 +103,10 @@ class Platform:
 
     def init_toolchain(self, toolchain_dir=None, toolchain_file=None):
         """Point this platform at an explicit toolchain. A root mamafile calls this from settings().
-        A native platform has nothing to find, so the default does nothing."""
+        A native platform has nothing to find, so the default does nothing.
+        toolchain_dir: the toolchain or SDK root to use, searched before the default paths
+        toolchain_file: an explicit build-system toolchain file
+        """
         pass
 
 
@@ -172,8 +173,9 @@ class Platform:
     ## --- flags ---
 
     def get_cxx_flags(self, add_flag: Callable[[str, str], None]):
-        """Add the compiler flags this platform always needs. `add_flag` keeps an existing value,
-        so a mamafile that already set the flag wins."""
+        """Add the compiler flags this platform always needs.
+        add_flag: (flag, value) sink. It keeps an existing value, so a mamafile that set the flag wins
+        """
         for flag, value in self.cpu_flags.items():
             add_flag(flag, value)
         for define, value in self.compile_defines.items():
@@ -183,7 +185,9 @@ class Platform:
 
 
     def get_ld_flags(self, add_ld_flag: Callable[[str, str], None]):
-        """Add the linker flags this platform always needs."""
+        """Add the linker flags this platform always needs.
+        add_ld_flag: (flag, value) sink, same contract as add_flag in get_cxx_flags
+        """
         pass
 
 
@@ -193,7 +197,9 @@ class Platform:
 
 
     def make_program(self, target=None) -> str:
-        """The build tool cmake drives when the generator picks none. '' lets cmake decide."""
+        """The build tool cmake drives when the generator picks none. '' lets cmake decide.
+        target: the BuildTarget asking, unused by the default
+        """
         return ''
 
 

--- a/mama/platforms/platform.py
+++ b/mama/platforms/platform.py
@@ -8,8 +8,8 @@ if TYPE_CHECKING:
 
 
 # The canonical processor name per mama arch. This names what the TARGET runs on, never the host.
-# A project that branches on it (googletest adds -march=x86-64-v3 the moment it reads x86_64)
-# compiles host instructions into a cross build if the host value leaks in.
+# If the host value leaks in, a project that branches on it compiles host instructions into a
+# cross build. googletest adds -march=x86-64-v3 as soon as it reads x86_64.
 SYSTEM_PROCESSORS = {
     'arm64': 'aarch64', 'arm': 'armv7-a', 'x64': 'x86_64', 'x86': 'i686',
     'mips': 'mips', 'mipsel': 'mipsel', 'mips64': 'mips64', 'mips64el': 'mips64el',
@@ -36,8 +36,8 @@ class Platform:
     """One target platform: what to build FOR, and how to find the tools that build it.
 
     Every platform mama supports is a subclass. Exactly one instance lives at `config.platform`.
-    A subclass overrides only what differs from the defaults below. `Linux` overrides three
-    members. `Android` overrides nine.
+    A subclass overrides only what differs from the defaults below. `Linux` overrides a few
+    members. `Android` overrides the most.
 
     A platform describes facts. It never formats a build-system option. `mama/buildsys/` renders
     `toolchain()` into whatever the active build system needs, so a second build system costs no
@@ -62,8 +62,8 @@ class Platform:
     cxx20_flag = 'c++20'       ## `c++2a` where the toolchain predates the final C++20 name
     ## clang dropped -dumpfullversion, so only ask a gcc-based toolchain for the full x.y.z version
     compiler_dumpfullversion = True
-    ## A system library is named differently per platform: Apple links '-framework Foundation', Linux
-    ## has a real file to find under /usr/lib, and everything else leaves it to the system linker.
+    ## A system library differs per platform. Apple links '-framework Foundation'. Linux has a real
+    ## file to find under /usr/lib. Every other platform leaves it to the system linker.
     syslib_is_framework = False
     syslib_is_searchable = False
     ## The IDE project extensions this platform's own generator emits, newest format first, and the
@@ -153,14 +153,14 @@ class Platform:
 
 
     def banner_name(self) -> str:
-        """What the build banner calls this target. The toolchain alone is ambiguous - 'clang 21.0' is
-        both a host clang and the android NDK's - so the banner names the platform to prove which ran."""
+        """What the build banner calls this target. 'clang 21.0' names both a host clang and the
+        android NDK's, so the banner adds the platform to prove which ran."""
         return ' '.join(p for p in (self.name, self.config.arch) if p)
 
 
     def compiler_version_tag(self) -> str:
         """Compiler id for the artifactory archive name, eg 'gcc14.3'. Named from the RESOLVED
-        compiler, never from config.gcc/clang: those describe the host, so a cross build reported
+        compiler, never from config.gcc/clang. Those describe the host, so a cross build reported
         the host compiler's version for the NDK's clang."""
         cc, _, version = self.config.get_preferred_compiler_paths()
         major, minor = version.split('.')[:2]

--- a/mama/platforms/raspi.py
+++ b/mama/platforms/raspi.py
@@ -7,12 +7,10 @@ from .toolchain import Toolchain
 from mama.utils.system import System, console
 
 
-# Every Raspberry Pi since the Pi 3 is ARMv8, so arm64 is the default and arm is the legacy path. The
-# triple drives the compiler name, the sysroot and the include dir, so a new arch is one entry here.
+# The triple drives the compiler name, the sysroot and the include dir, so a new arch is one entry here.
 _TRIPLES = {'arm64': 'aarch64-linux-gnu', 'arm': 'arm-linux-gnueabihf'}
 _MARCH = {'arm64': 'armv8-a', 'arm': 'armv7-a'}
-# armv7-a on its own declares no FPU, but the gnueabihf triple defaults to -mfloat-abi=hard and
-# then refuses to compile at all. neon-vfpv4 is what the Pi 2 and 3 (Cortex-A7/A53) actually have.
+# The gnueabihf triple defaults to hard float, so armv7-a must name an FPU. neon-vfpv4 is what the Pi 2 and 3 have.
 _FPU = {'arm': 'neon-vfpv4'}
 SUPPORTED_ARCHES = tuple(_TRIPLES)
 
@@ -77,8 +75,7 @@ class Raspi(Platform):
 
     def _layouts(self, root: str) -> list:
         """Where a toolchain root can keep its bin/ dir. The legacy Broadcom `tools` repo nests the
-        32-bit toolchain under arm-bcm2708/<triple>/. A distro cross package (gcc-aarch64-linux-gnu)
-        and a modern standalone toolchain put it straight in bin/."""
+        32-bit toolchain under arm-bcm2708/<triple>/. Every other toolchain puts it straight in bin/."""
         return [root, f'{root}/arm-bcm2708/{self.triple()}']
 
 
@@ -102,12 +99,11 @@ class Raspi(Platform):
 
 
     def init_toolchain(self, toolchain_dir: str = None, toolchain_file=None):
-        """Point every path at `toolchain_dir`, whose bin/ must hold `<triple>-gcc`.
-
-        A standalone toolchain carries its own `<triple>/sysroot`. A distro cross package
-        (gcc-aarch64-linux-gnu) has none, and its gcc already knows where the target headers live.
-        So this method sets the sysroot and the extra include dir ONLY when they exist. A --sysroot
-        that is not there makes every compile fail on missing system headers."""
+        """Point every path at the toolchain root. Set the sysroot and the extra include dir ONLY
+        when they exist: a distro cross package has none, its gcc already knows the target headers,
+        and a --sysroot that is not there makes every compile fail on missing system headers.
+        toolchain_dir: the toolchain root, its bin/ must hold `<triple>-gcc`
+        """
         triple = self.triple()
         self.toolchain_dir = toolchain_dir
         self.compilers = f'{toolchain_dir}/bin/'
@@ -126,9 +122,8 @@ class Raspi(Platform):
         return Toolchain(system_name=self.system_name, system_processor=self.system_processor(),
                          system_version='1', cc=f'{prefix}gcc{ext}', cxx=f'{prefix}g++{ext}',
                          include_paths=tuple(self.get_includes()),
-                         # NEVER, not ONLY: a distro cross package ships no binutils of its own, so the
-                         # build system must take the compiler tools mama named. mama passes the sysroot
-                         # as a compiler flag instead, because a distro package has none at all.
+                         # NEVER, not ONLY: a distro cross package ships no binutils and no sysroot, so
+                         # the build system takes the tools mama named, and the sysroot goes as a flag
                          find_root_program='NEVER')
 
 

--- a/mama/platforms/raspi.py
+++ b/mama/platforms/raspi.py
@@ -76,9 +76,9 @@ class Raspi(Platform):
 
 
     def _layouts(self, root: str) -> list:
-        """Where a toolchain root can keep its bin/ dir. The legacy Broadcom `tools` repo nests the 32-bit
-        toolchain under arm-bcm2708/<triple>/, while a distro cross package (gcc-aarch64-linux-gnu) and the
-        modern standalone toolchains put it straight in bin/."""
+        """Where a toolchain root can keep its bin/ dir. The legacy Broadcom `tools` repo nests the
+        32-bit toolchain under arm-bcm2708/<triple>/. A distro cross package (gcc-aarch64-linux-gnu)
+        and a modern standalone toolchain put it straight in bin/."""
         return [root, f'{root}/arm-bcm2708/{self.triple()}']
 
 
@@ -104,10 +104,10 @@ class Raspi(Platform):
     def init_toolchain(self, toolchain_dir: str = None, toolchain_file=None):
         """Point every path at `toolchain_dir`, whose bin/ must hold `<triple>-gcc`.
 
-        A standalone toolchain carries its own `<triple>/sysroot`; a distro cross package
-        (gcc-aarch64-linux-gnu) has none and its gcc already knows where the target headers live. So both
-        the sysroot and the extra include dir are set ONLY if they exist - passing a --sysroot that is not
-        there makes every compile fail on missing system headers."""
+        A standalone toolchain carries its own `<triple>/sysroot`. A distro cross package
+        (gcc-aarch64-linux-gnu) has none, and its gcc already knows where the target headers live.
+        So this method sets the sysroot and the extra include dir ONLY when they exist. A --sysroot
+        that is not there makes every compile fail on missing system headers."""
         triple = self.triple()
         self.toolchain_dir = toolchain_dir
         self.compilers = f'{toolchain_dir}/bin/'
@@ -127,8 +127,8 @@ class Raspi(Platform):
                          system_version='1', cc=f'{prefix}gcc{ext}', cxx=f'{prefix}g++{ext}',
                          include_paths=tuple(self.get_includes()),
                          # NEVER, not ONLY: a distro cross package ships no binutils of its own, so the
-                         # build system must take the compiler tools mama named. The sysroot goes out as
-                         # a compiler flag instead, because a distro package has none at all.
+                         # build system must take the compiler tools mama named. mama passes the sysroot
+                         # as a compiler flag instead, because a distro package has none at all.
                          find_root_program='NEVER')
 
 

--- a/mama/platforms/registry.py
+++ b/mama/platforms/registry.py
@@ -13,7 +13,7 @@ from ..utils.system import System
 
 
 # Every platform mama supports, in CMake guard order. The generated mama.cmake tests these guards
-# in this order, and android is also UNIX and APPLE also matches Darwin, so the specific platforms
+# in this order. android is also UNIX and APPLE also matches Darwin, so the specific platforms
 # must come before WIN32, APPLE and UNIX. Adding a platform means adding one line here.
 PLATFORMS = (Android, Windows, Ios, Macos, Raspi, Oclea, Xilinx, Imx8mp, Mips, Linux)
 

--- a/mama/platforms/registry.py
+++ b/mama/platforms/registry.py
@@ -12,9 +12,8 @@ from .imx8mp import Imx8mp
 from ..utils.system import System
 
 
-# Every platform mama supports, in CMake guard order. The generated mama.cmake tests these guards
-# in this order. android is also UNIX and APPLE also matches Darwin, so the specific platforms
-# must come before WIN32, APPLE and UNIX. Adding a platform means adding one line here.
+# Every platform mama supports, in CMake guard order: android is also UNIX and APPLE also matches
+# Darwin, so the specific platforms come before WIN32, APPLE and UNIX. A new platform is one line here.
 PLATFORMS = (Android, Windows, Ios, Macos, Raspi, Oclea, Xilinx, Imx8mp, Mips, Linux)
 
 

--- a/mama/platforms/toolchain.py
+++ b/mama/platforms/toolchain.py
@@ -7,8 +7,8 @@ class Toolchain:
     """What a platform knows about its own compilers, in build-system-neutral terms.
 
     A build system renders this. `mama/buildsys/cmake/options.py` turns it into `-D` options.
-    No field uses CMake vocabulary except `extra_opts`, which is the escape hatch for options
-    that only one build system and one platform understand (the Android NDK variables).
+    No field uses CMake vocabulary except `extra_opts`. That field is the escape hatch for
+    options that only one build system and one platform understand, such as the NDK variables.
 
     A platform builds this ONCE, after toolchain discovery, and caches it. See `Platform.toolchain()`.
     """

--- a/mama/platforms/toolchain.py
+++ b/mama/platforms/toolchain.py
@@ -7,9 +7,8 @@ class Toolchain:
     """What a platform knows about its own compilers, in build-system-neutral terms.
 
     A build system renders this. `mama/buildsys/cmake/options.py` turns it into `-D` options.
-    No field uses CMake vocabulary except `extra_opts`. That field is the escape hatch for
-    options that only one build system and one platform understand, such as the NDK variables.
-
+    Only `extra_opts` uses build-system vocabulary: the escape hatch for options that one
+    build system and one platform understand, such as the NDK variables.
     A platform builds this ONCE, after toolchain discovery, and caches it. See `Platform.toolchain()`.
     """
     system_name: str = 'Linux'   ## the OS built FOR: Linux, Android, Darwin or Windows

--- a/mama/platforms/windows.py
+++ b/mama/platforms/windows.py
@@ -70,10 +70,10 @@ def find_visualstudio(verbose=False) -> str:
 
 
 def latest_msvc_toolset(tools_root: str) -> str:
-    """Newest MSVC toolset (highest version) that still has the x64 cl.exe. An upgrade can leave the old
-    version's dir behind without binaries, and os.listdir order is unspecified - so sort by version
-    (numerically, not lexically: 14.51 > 14.9) and skip toolsets whose cl.exe is gone. '' if none:
-    every msvc_* path is bin/Hostx64/x64, so a toolset without it only defers the failure."""
+    """Newest MSVC toolset dir that still has the x64 cl.exe, or '' when none does. An upgrade can
+    leave the old version's dir behind without binaries, and os.listdir order is unspecified. So
+    sort by version, numerically because 14.51 > 14.9, and skip a toolset whose cl.exe is gone.
+    Every msvc_* path is bin/Hostx64/x64, so a toolset without it only defers the failure."""
     try:
         dirs = [d for d in os.listdir(tools_root) if os.path.isdir(os.path.join(tools_root, d))]
     except OSError:
@@ -82,11 +82,11 @@ def latest_msvc_toolset(tools_root: str) -> str:
     for d in dirs:
         if os.path.isfile(os.path.join(tools_root, d, 'bin', 'Hostx64', 'x64', 'cl.exe')):
             return path_join(tools_root, d)
-    return ''  # a dir without cl.exe can't build; '' lets the caller say so up front
+    return ''
 
 
 class Windows(Platform):
-    """MSVC on Windows. Not a cross build: the toolset and the Windows SDK pick the compiler, so
+    """MSVC on Windows. Not a cross build. The toolset and the Windows SDK pick the compiler, so
     mama names no compiler path and resolves the toolset through vswhere instead."""
     name = 'windows'
     cli_aliases = ('msvc',)
@@ -94,7 +94,7 @@ class Windows(Platform):
     build_system = 'visualstudio'
     supported_arches = tuple(_VS_ARCHES)
     build_dirs = {'x64': 'windows', 'x86': 'windows32', 'arm64': 'winarm', 'arm': 'winarm32'}
-    ide_project_ext = ('.slnx', '.sln')  # VS 18 (2026) writes the XML .slnx, an older toolset writes .sln
+    ide_project_ext = ('.slnx', '.sln')  # VS 18 (2026) writes the XML .slnx. An older toolset writes .sln
     ide_open_command = 'start'
     supports_coverage_report = False
 
@@ -121,7 +121,7 @@ class Windows(Platform):
 
 
     def generator_name(self) -> str:
-        """The Visual Studio generation, eg 'Visual Studio 17 2022'. Both cmake and mama name it this."""
+        """The cmake generator name, eg 'Visual Studio 17 2022', matched from the install path."""
         vspath = self.visualstudio_path()
         return next((g for tag, g in _VS_GENERATORS.items() if tag in vspath), _VS_GENERATOR_FALLBACK)
 
@@ -161,4 +161,4 @@ class Windows(Platform):
 
 
     def debugger(self) -> str:
-        return ''  # the test exe runs directly, there is no batch-mode debugger to wrap it
+        return ''  # no batch-mode debugger exists here, so the test exe runs directly

--- a/mama/platforms/windows.py
+++ b/mama/platforms/windows.py
@@ -8,8 +8,7 @@ from mama.utils.system import System, console
 from mama.utils.sub_process import execute_piped
 
 
-# Where Visual Studio installs itself, newest first. vswhere.exe answers this properly, so these are
-# only the fallback for a machine where the installer is missing.
+# Visual Studio install roots, newest first. Only the fallback for a machine with no vswhere.exe.
 VS_VARIANTS = ('Enterprise', 'Professional', 'Community')
 VS_ROOTS = [f'C:\\Program Files\\Microsoft Visual Studio\\{v}' for v in ('18', '2022')] + \
             [f'C:\\Program Files (x86)\\Microsoft Visual Studio\\{v}' for v in ('2019', '2017')]
@@ -52,8 +51,7 @@ def vswhere_property(name: str) -> str:
 def find_visualstudio(verbose=False) -> str:
     """The Visual Studio install root. Raises when there is none: every MSVC path derives from it."""
     def find():
-        # inside the memo, so mama reports the detection once. A print per caller wrote the same line
-        # 8 times into one verbose build log.
+        # inside the memo, so the detection prints once, not once per caller
         vspath = vswhere_property('installationPath')
         if not vspath or not os.path.exists(vspath):
             variants = [f'{root}\\{v}' for root in VS_ROOTS for v in VS_VARIANTS]
@@ -71,9 +69,10 @@ def find_visualstudio(verbose=False) -> str:
 
 def latest_msvc_toolset(tools_root: str) -> str:
     """Newest MSVC toolset dir that still has the x64 cl.exe, or '' when none does. An upgrade can
-    leave the old version's dir behind without binaries, and os.listdir order is unspecified. So
-    sort by version, numerically because 14.51 > 14.9, and skip a toolset whose cl.exe is gone.
-    Every msvc_* path is bin/Hostx64/x64, so a toolset without it only defers the failure."""
+    leave a version dir behind without binaries, so sort by version, numerically because 14.51 > 14.9,
+    and skip a toolset whose cl.exe is gone. Every msvc_* path assumes bin/Hostx64/x64.
+    tools_root: the `VC\\Tools\\MSVC` dir that holds the versioned toolsets
+    """
     try:
         dirs = [d for d in os.listdir(tools_root) if os.path.isdir(os.path.join(tools_root, d))]
     except OSError:
@@ -99,8 +98,7 @@ class Windows(Platform):
     supports_coverage_report = False
 
     def _build_toolchain(self) -> Toolchain:
-        # An x86 target needs the 32-bit host toolset. Everything else about the compiler comes from
-        # the toolset and the Windows SDK, so mama names no compiler path here.
+        # An x86 target needs the 32-bit host toolset. The toolset and the SDK pick the compiler, so mama names none.
         return Toolchain(system_name=self.system_name, host_toolset='x86' if self.arch() == 'x86' else '')
 
 

--- a/mama/types/artifactory_pkg.py
+++ b/mama/types/artifactory_pkg.py
@@ -1,9 +1,7 @@
 from .dep_source import DepSource
 
 class ArtifactoryPkg(DepSource):
-    """
-    For a BuildDependency whose source is an artifactory package
-    """
+    """For a BuildDependency whose source is an artifactory package."""
     def __init__(self, name:str, version:str, fullname:str):
         super(ArtifactoryPkg, self).__init__(name)
         self.is_pkg = True

--- a/mama/types/artifactory_pkg.py
+++ b/mama/types/artifactory_pkg.py
@@ -2,7 +2,7 @@ from .dep_source import DepSource
 
 class ArtifactoryPkg(DepSource):
     """
-    For BuildDependency whose source is from an Artifactory Package
+    For a BuildDependency whose source is an artifactory package
     """
     def __init__(self, name:str, version:str, fullname:str):
         super(ArtifactoryPkg, self).__init__(name)

--- a/mama/types/asset.py
+++ b/mama/types/asset.py
@@ -2,11 +2,10 @@ import os
 
 class Asset:
     def __init__(self, relpath, fullpath, category):
-        """
-        Creates an asset. If category is set, it replaces the relative directory in the deploy path.
-            relpath  -- Relative path to the source file
-            fullpath -- Single full path to the source file
-            category -- Deployment category, used as the deploy path prefix
+        """Create an asset.
+        relpath: relative path to the source file
+        fullpath: full path to the source file
+        category: deploy path prefix that replaces the relative directory when set
         """
         reldir = os.path.dirname(relpath)
         self.name     = os.path.basename(fullpath)

--- a/mama/types/asset.py
+++ b/mama/types/asset.py
@@ -3,10 +3,10 @@ import os
 class Asset:
     def __init__(self, relpath, fullpath, category):
         """
-        Creates an asset. If category is set, then relpath is ignored during deploy
-            relpath  -- Relative path to source
-            fullpath -- Single full path
-            category -- Deployment category
+        Creates an asset. If category is set, it replaces the relative directory in the deploy path.
+            relpath  -- Relative path to the source file
+            fullpath -- Single full path to the source file
+            category -- Deployment category, used as the deploy path prefix
         """
         reldir = os.path.dirname(relpath)
         self.name     = os.path.basename(fullpath)
@@ -15,7 +15,6 @@ class Asset:
 
         if category: self.outpath = f'{category}/{self.outpath}'
         else:        self.outpath = f'{reldir}/{self.outpath}'
-        #console(f'asset {self.outpath}')
 
     def __str__(self):  return self.outpath
     def __repr__(self): return self.outpath

--- a/mama/types/git.py
+++ b/mama/types/git.py
@@ -53,14 +53,14 @@ _ERROR_TAIL = 40  # git lines kept for the failure report. A fetch's output is o
 
 
 def _filter_git_progress(dep, line: str, state: dict, label='') -> bool:
-    """True if `line` is git transfer progress (the caller drops it) - collapsing the per-percent flood
+    """True when `line` is git transfer progress (the caller drops it). Collapses the per-percent flood
     the PTY makes git emit into one throttled redraw. EVERY git runner routes output through this single
-    chokepoint. `state` carries the throttle across calls; `label` prefixes (e.g. CLONE)."""
+    chokepoint. `state` carries the throttle across calls. `label` prefixes the line (e.g. CLONE)."""
     st = git_progress_status(line)
     if st is None: return False
     if dep.config.print:
         now = time.monotonic()
-        if 'at' not in state: state['at'] = now  # seed on first sight; don't emit until the throttle elapses
+        if 'at' not in state: state['at'] = now  # seed on the first line. No emit until the throttle elapses.
         if st != state.get('last') and (st[1] >= 100 or now - state['at'] >= _FILTERED_GIT_PROGRESS_REPORT_INTERVAL):
             state['last'] = st; state['at'] = now
             tag = f'{label} ' if label else ''
@@ -107,7 +107,7 @@ def _canonical_remote(url: str) -> str:
 
 class Git(DepSource):
     """
-    For BuildDependency whose source is from a Git repository
+    For a BuildDependency whose source is a git repository
     """
     def __init__(self, name:str, url:str, branch:str, tag:str, mamafile:str, shallow:bool, args:list):
         super(Git, self).__init__(name)
@@ -120,7 +120,7 @@ class Git(DepSource):
         self.shallow = shallow
         self.args = args
 
-        self.from_source = False  # if True, this must be built from source, not from artifactory
+        self.from_source = False  # True forces a source build instead of an artifactory package
         self.commit_hash = None  # the git commit hash of this DepSource
         self.url_overridden = False  # True once apply_url_override rewrote self.url
 
@@ -133,7 +133,7 @@ class Git(DepSource):
 
     def apply_url_override(self, config: BuildConfig):
         """Rewrite self.url between ssh<->https per config.git_url_override (the
-        `https-override` / `ssh-override` build args). Idempotent; no-op for local
+        `https-override` / `ssh-override` build args). Idempotent. No-op for local
         paths or urls already in the target protocol."""
         if not config.git_url_override: return
         new_url = convert_git_url(self.url, config.git_url_override)
@@ -183,7 +183,7 @@ class Git(DepSource):
 
 
     def run_git(self, dep: BuildDependency, git_command, throw=True):
-        # Shim has no .git; `cd src_dir && git ...` would walk up and hit the wrong repo.
+        # A shim has no .git, so git run in src_dir would walk up and hit the wrong repo.
         if dep.is_artifactory_shim():
             msg = f'Target {dep.name} is an artifactory shim; cannot run `git {git_command}`'
             if dep.config.verbose: error(f'  {dep.name: <16} {msg}')
@@ -193,7 +193,7 @@ class Git(DepSource):
         if dep.config.verbose:
             warning(f'  {dep.name: <16} {cmd}')
         ssh_multiplex.ensure_master_for_url(self.url)
-        # Capture and prefix each line so parallel updates don't tear and the
+        # Capture and prefix each line so parallel updates do not tear and the
         # user can see which target said what (e.g. 'remote: Enumerating ...').
         prog: dict = {}
         tail = deque(maxlen=_ERROR_TAIL)  # the last real lines, which the failure report shows
@@ -222,20 +222,20 @@ class Git(DepSource):
 
 
     def _has_local_modifications(self, dep: BuildDependency) -> bool:
-        """Check if the working tree has uncommitted modifications to tracked files"""
+        """True when the working tree has uncommitted modifications to tracked files"""
         return self.run_git(dep, "diff --quiet HEAD", throw=False) != 0
 
 
     def _ensure_no_local_modifications(self, dep: BuildDependency):
         """Raise (with an actionable message + `git status`) when the working tree has uncommitted
-        changes an update's reset --hard would overwrite. Called at the TOP of the update path so a
-        dirty dep fails loudly (marked `x`), even when upstream is unchanged - otherwise the pull below
-        fails, gets swallowed by its fetch fallback, and the dep silently reports success un-updated."""
+        changes an update's reset --hard would overwrite. The update path calls this at its TOP, so a
+        dirty dep fails loudly (marked `x`) even when upstream is unchanged. Otherwise the later pull
+        fails, its fetch fallback swallows the error, and the dep silently reports success un-updated."""
         if not self._has_local_modifications(dep): return
         name = dep.name
         error(f"  Target {name} has local modifications that would be overwritten by update.\n"
               f"  To discard local changes and re-fetch, run: `mama wipe {name}`")
-        self.run_git(dep, "status --porcelain") # show the user what files are modified
+        self.run_git(dep, "status --porcelain") # show the modified files
         raise RuntimeError(f"Target {name} has local modifications. Use 'mama wipe {name}' to discard changes.")
 
 
@@ -260,7 +260,7 @@ class Git(DepSource):
 
     @staticmethod
     def get_current_repository_commit(dep: BuildDependency):
-        """ Assuming {src_dir}/.git exists, this will get the repository commit short hash """
+        """The short commit hash of the repository at src_dir. The caller makes sure {src_dir}/.git exists."""
         result = execute_piped(['git', 'show', '--format=%h', '-s'], cwd=dep.src_dir)
         if dep.config.verbose:
             console(f'  {dep.name: <16} git show --format=%h -s:   {result}')
@@ -272,16 +272,16 @@ class Git(DepSource):
 
 
     def fetch_self_version_from_remote(self, dep: BuildDependency):
-        """Fetches just the dep's mamafile to read `self.version` without pulling the
-        full repo. Used by the shim probe for version-pinned deps (e.g. boost 1.60)
-        where the archive name doesn't track the commit hash. The clone goes through
-        SubProcess.run (live progress UI); the one-shot `git show` uses subprocess.run
+        """Fetches only the dep's mamafile to read `self.version` without pulling the
+        full repo. The shim probe uses this for version-pinned deps (e.g. boost 1.60)
+        where the archive name does not track the commit hash. The clone goes through
+        SubProcess.run (live progress UI). The one-shot `git show` uses subprocess.run
         with stderr=DEVNULL + timeout to drop the lazy-fetch's `remote: ...` chatter
         and to bound a stuck fetch. Returns the version string or None on any failure."""
         if dep.mamafile:
             # Parent-repo mamafile override: the remote repo's mamafile is not the one mama
-            # runs, and `git show HEAD:<local path>` can never resolve. The local file was
-            # already checked for a pin before this fallback (mamafile_version.pinned_version).
+            # runs, and `git show HEAD:<local path>` can never resolve. Before this fallback,
+            # mamafile_version.pinned_version already checked the local file for a pin.
             return None
         if not dep.config.is_network_available():
             return None
@@ -290,9 +290,9 @@ class Git(DepSource):
         branch_arg = f' --branch {branch}' if branch and not Git.is_hex_string(branch) else ''
         try:
             # ignore_cleanup_errors: on Windows git sets read-only on .git/objects/*,
-            # which trips shutil.rmtree. normalized_path: project convention is
-            # forward slashes; raw tempdir paths on Windows use backslashes that
-            # would be eaten by shlex.split inside SubProcess.
+            # which trips shutil.rmtree. normalized_path: the project convention is
+            # forward slashes. Raw tempdir paths on Windows use backslashes, which
+            # shlex.split inside SubProcess eats.
             with tempfile.TemporaryDirectory(prefix='mama_probe_', ignore_cleanup_errors=True) as tmp:
                 tmp = normalized_path(tmp)
                 clone_cmd = f'git clone --depth=1 --filter=blob:none --no-checkout{branch_arg} {self.url} {tmp}'
@@ -305,7 +305,7 @@ class Git(DepSource):
                 # subprocess.run, not SubProcess.run: see docstring above.
                 # stderr=DEVNULL drops the lazy-fetch's `remote: ...` noise.
                 try:
-                    # 10s is plenty: the clone is already done, this is a <1KB blob fetch via the same connection.
+                    # 10s is enough: the clone already finished, and this fetches a <1KB blob over the same connection.
                     cp = subprocess.run(['git', '-C', tmp, 'show', f'HEAD:{mamafile_name}'],
                                         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=10)
                 except subprocess.TimeoutExpired:
@@ -335,7 +335,7 @@ class Git(DepSource):
         if not dep.dep_source.is_git:
             return None
 
-        # update is not specified? then we can try to skip the check
+        # no update requested: the stored commit hash is enough
         if use_cache and not dep.config.update and os.path.exists(self.git_status_file(dep)):
             status = self.read_stored_status(dep)
             result = status[3].split(' ')[0]
@@ -343,20 +343,20 @@ class Git(DepSource):
                 console(f'    {self.name}  using stored commit hash: {result}')
             return result
 
-        # is the tag actually a commit hash?
+        # a hex tag is already a commit pin
         if Git.is_hex_string(self.tag):
             if dep.config.verbose:
                 console(f'    {self.name}  using tag as the commit hash: {self.tag}')
             return self.tag
 
-        # is this a git repository? we can get the current commit from that
+        # an existing repository answers with its current commit
         if os.path.exists(f'{dep.src_dir}/.git'):
             result = Git.get_current_repository_commit(dep)
             if not result:
                 error(f'    {self.name}  invalid git repository at {dep.src_dir}')
             return result
 
-        # can we fetch the latest commit from remote instead?
+        # last resort: ask the remote for the latest commit
         if fetch_remote:
             if not dep.config.is_network_available():
                 return None
@@ -384,11 +384,11 @@ class Git(DepSource):
         """`.git` present but this dir is not a usable repo OF ITS OWN. -q keeps git silent on failure.
 
         --show-toplevel is what makes it safe. A corrupt `.git` does not stop git's discovery walk, it
-        resumes UPWARD - and a local workspace lives inside the project's own repo, so `rev-parse HEAD`
-        then answers with the PARENT. The dep read as healthy and the pull path ran `reset --hard`
-        against the user's project checkout. Anything we cannot prove is this dir's own repo counts as
-        broken, which is the safe bias: a wrong 'broken' only reaches _refuse_destructive_clone, which
-        keeps real source and builds it as-is."""
+        resumes UPWARD. A local workspace lives inside the project's own repo, so `rev-parse HEAD` then
+        answers with the PARENT, and the pull path would run `reset --hard` against the user's project
+        checkout. Anything not proven to be this dir's own repo counts as broken, which is the safe
+        bias: a wrong 'broken' only reaches _refuse_destructive_clone, which keeps real source and
+        builds it as-is."""
         out = execute_piped(['git', 'rev-parse', '--show-toplevel', '--verify', '-q', 'HEAD'],
                             cwd=dep.src_dir, throw=False)
         lines = out.splitlines() if out else []
@@ -397,8 +397,8 @@ class Git(DepSource):
 
 
     def _refuse_destructive_clone(self, dep: BuildDependency) -> bool:
-        """True when src_dir has real source but no usable .git (rsync'd sandbox copy, local dev work):
-        cloning over it destroys uncommitted changes, so build as-is. Only `mama wipe` may discard it."""
+        """True when src_dir has real source but no usable .git (rsync'd sandbox copy, local dev work).
+        A clone over it destroys uncommitted changes, so build as-is. Only `mama wipe` may discard it."""
         if not has_source_content(dep.src_dir): return False
         if dep.is_current_target() and dep.config.reclone: return False
         if dep.config.print:
@@ -408,13 +408,13 @@ class Git(DepSource):
 
 
     def _is_detached_head(self, dep: BuildDependency) -> bool:
-        """Check if the repository is in detached HEAD state"""
+        """True when the repository is in a detached HEAD state"""
         result = execute_piped(['git', 'symbolic-ref', '-q', 'HEAD'], cwd=dep.src_dir, throw=False)
         return not result
 
 
     def _is_rebase_in_progress(self, dep: BuildDependency) -> bool:
-        """Check if the repository currently has an active rebase"""
+        """True when the repository has an active rebase"""
         return os.path.exists(f'{dep.src_dir}/.git/rebase-merge') or \
                os.path.exists(f'{dep.src_dir}/.git/rebase-apply')
 
@@ -422,13 +422,13 @@ class Git(DepSource):
     def fetch_origin(self, dep: BuildDependency):
         branch = self.branch_or_tag()
         if Git.is_hex_string(branch):
-            return # no need to fetch if we're pinned to a specific commit hash
+            return # a commit-hash pin needs no fetch
         if not dep.config.is_network_available():
             return
         if self.tag:
             self.run_git(dep, f"fetch origin tag {branch} -q")
         else:
-            # only safe to pull when staying on the same branch and not in detached HEAD
+            # a pull is only safe on the same branch and outside a detached HEAD
             can_pull = not (self.tag_changed or self.branch_changed or self._is_detached_head(dep))
             origin_br = f'origin {branch}' if branch else 'origin'
             result = -1
@@ -478,20 +478,18 @@ class Git(DepSource):
         if not status:
             self.missing_status = True
             if not self.url: return False
-            #console(f'check_status {self.url}: NO STATUS AT {dep.build_dir}/git_status')
             self.url_changed = True
             self.tag_changed = True
             self.branch_changed = True
             self.commit_changed = True
             return True
-        # update basic flags before fetching origin, so we can detect tag/branch pin changes
+        # set the flags before fetch_origin, which reads tag_changed and branch_changed for its pull decision
         self.url_changed = not same_git_remote(self.url, status[0])
         self.tag_changed = self.tag != status[1]
         self.branch_changed = self.branch != status[2]
-        # fetch origin and then check the commit hash to detect upstream changes
+        # then compare the commit hash to detect upstream changes
         self.fetch_origin(dep)
         self.commit_changed = self.get_commit_hash(dep, use_cache=False) != status[3]
-        #console(f'check_status {self.url} {self.branch_or_tag()}: urlc={self.url_changed} tagc={self.tag_changed} brnc={self.branch_changed} cmtc={self.commit_changed}')
         return self.url_changed or self.tag_changed or self.branch_changed or self.commit_changed
 
 
@@ -512,7 +510,7 @@ class Git(DepSource):
                 self.run_git(dep, f"fetch --depth 1 origin {branch}")
                 self.run_git(dep, f"checkout {branch}")
             elif self.branch:
-                # hacky fix
+                # fetch the branch ref explicitly, so checkout -B always has origin/<branch>
                 self.run_git(dep, f"fetch origin +refs/heads/{branch}:refs/remotes/origin/{branch}", throw=False)
                 self.run_git(dep, f"checkout -B {branch} origin/{branch}")
             else: # tag
@@ -524,12 +522,12 @@ class Git(DepSource):
     def reclone_wipe(self, dep: BuildDependency, source_only: bool = False):
         """Drop this dep's tree so it can be cloned fresh.
 
-        `source_only` removes ONLY src_dir, and is what every AUTOMATIC recovery must use. dep_dir is shared
-        by every platform: its `<dep_dir>/<platform>/` siblings hold OTHER platforms' artifactory packages,
-        shim markers and build output, plus the cached package zip. A git tree that's broken for THIS platform
-        is no reason to destroy those - and with a nested `mama <host> build` (build_host_binary) running
-        concurrently, that sibling dir may be the include tree another build is compiling against right now.
-        The whole dep_dir goes only on an explicit `mama wipe`, where discarding everything is the intent."""
+        `source_only` removes ONLY src_dir, and every AUTOMATIC recovery must use it. Every platform shares
+        dep_dir: its `<dep_dir>/<platform>/` siblings hold OTHER platforms' artifactory packages, shim
+        markers and build output, plus the cached package zip. A git tree broken for THIS platform is no
+        reason to destroy those. With a nested `mama <host> build` (build_host_binary) running concurrently,
+        a sibling dir may be the include tree another build compiles against right now. The whole dep_dir
+        goes only on an explicit `mama wipe`, where discarding everything is the intent."""
         target = dep.src_dir if source_only else dep.dep_dir
         if dep.config.print:
             console(f'  - Target {dep.name: <16} RECLONE WIPE{" (source)" if source_only else ""}')
@@ -539,8 +537,8 @@ class Git(DepSource):
     def _run_git_with_filtered_progress(self, dep: BuildDependency, cmd: str, label: str):
         """Run a git command with progress filtered into one redrawn status line.
         Returns (exit_code, captured_output, elapsed_str). Does not raise.
-        Used by full clone and by the sparse mamafile probe so both share the
-        same nice UI instead of spewing git's raw remote: output."""
+        The full clone and the sparse mamafile probe both use it, so they share
+        one progress UI instead of printing git's raw remote: output."""
         output = []  # list + join, not output += line (O(n^2) over a big checkout's file list)
         start = time.monotonic()
         prog: dict = {}
@@ -549,10 +547,9 @@ class Git(DepSource):
             if 'Cloning into ' in line:
                 return
             elif 'Are you sure you want to continue connecting' in line:
-                # TODO: maybe auto-add the key before running clone?
-                # if [ ! -n "$(grep "^bitbucket.org " ~/.ssh/known_hosts)" ]; then ssh-keyscan bitbucket.org >> ~/.ssh/known_hosts 2>/dev/null; fi
+                # TODO: maybe auto-add the host key with ssh-keyscan before the clone?
                 console(line)
-                p.write('yes\n') # get us unstuck
+                p.write('yes\n') # answer the host-key prompt so the clone continues
             elif line:
                 output.append(line)
                 if dep.config.verbose:
@@ -564,7 +561,7 @@ class Git(DepSource):
         with ssh_multiplex.fetch_slot():
             ssh_multiplex.pace_new_connection()  # no-op unless a host already pushed back this run
             # idle_timeout: kill a clone stuck on a passphrase prompt so a parallel wave never
-            # freezes; a real download streams progress and is never wrongly aborted.
+            # freezes. A real download streams progress, so the timeout never aborts it.
             try:
                 result = SubProcess.run(cmd, io_func=print_output, idle_timeout=dep.config.git_timeout)
             except subprocess.TimeoutExpired:
@@ -594,8 +591,8 @@ class Git(DepSource):
 
 
     def _backoff_before_reclone(self, dep: BuildDependency, clone_to_dir: str, attempt: int, elapsed: str):
-        """Wait out a throttle, then clear the partial tree git left behind - a second `git clone` into a
-        non-empty directory fails on the directory and hides the error that actually needs fixing."""
+        """Sleep through the throttle window, then remove the partial tree git left behind. A second
+        `git clone` into a non-empty directory fails on the directory and hides the real error."""
         ssh_multiplex.note_connection_throttled()  # the host pushed back: stagger every later connection
         delay = _CLONE_RETRY_BASE * (2 ** (attempt - 1)) * random.uniform(0.5, 1.5)
         if dep.config.print:
@@ -606,7 +603,7 @@ class Git(DepSource):
 
 
     def clone_or_pull(self, dep: BuildDependency, wiped=False):
-        # by default we create a shallow clone, unless unshallow is specified in config or this dep
+        # shallow clone by default, unless the config or this dep asks for unshallow
         unshallow = dep.config.unshallow or (not self.shallow)
         if is_dir_empty(dep.src_dir):
             if not dep.config.is_network_available():
@@ -630,7 +627,6 @@ class Git(DepSource):
             dep.load_action = 'pulling'  # actual git pull/fetch (display label)
             if dep.config.print:
                 console(f"  - Pulling {dep.name: <16}  SCM change detected", color=Color.BLUE)
-            # check for local modifications before potentially destructive operations
             self._ensure_no_local_modifications(dep)
             if unshallow:
                 self.unshallow(dep)
@@ -643,14 +639,13 @@ class Git(DepSource):
                     self.run_git(dep, f"reset --hard origin/{self.branch} -q")
                 else:
                     self.run_git(dep, "fetch -q", throw=False)
-                    self.run_git(dep, "reset --hard @{upstream} -q") # https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-branchnameupstreamegmasterupstreamu
+                    self.run_git(dep, "reset --hard @{upstream} -q") # @{upstream}: see git docs on gitrevisions
             dep.config.update_stats.record_pull()
 
 
     def unshallow(self, dep: BuildDependency):
-        # Detecting shallowness can be quite tricky, since the repository can be in multiple different states
-        # Detecting the easy cases first:
-        #   git rev-parse --is-shallow-repository --> .git/shallow exists
+        # Shallowness detection is unreliable, because the repository can be in several states.
+        # .git/shallow is the easy case (what `git rev-parse --is-shallow-repository` checks).
         is_shallow = os.path.exists(f'{dep.src_dir}/.git/shallow')
         if not is_shallow:
             _, output = execute_piped_echo(dep.src_dir, 'git config remote.origin.fetch', echo=False)
@@ -664,24 +659,23 @@ class Git(DepSource):
                 warning(f'  - Unshallowing {dep.name}')
             self.run_git(dep, 'config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"')
             self.run_git(dep, 'remote update')
-            # this last step is allowed to fail, just in case it was
-            # semi-shallow (history was complete, but remote refs were shallow)
+            # this last step may fail for a semi-shallow repo (complete history, shallow remote refs)
             self.run_git(dep, 'fetch --unshallow', throw=False)
 
 
     def dependency_checkout(self, dep: BuildDependency):
         """
         Do a git repository checkout. Can be an expensive operation.
-        If an existing artifactory package exists, then this step is skipped
+        An existing artifactory package skips this step.
         """
-        # No valid working tree: nothing on disk, a limbo dir (dropped shim / half-finished clone)
-        # with files but no .git, or a .git that's present but corrupt (HEAD unresolvable). None can
-        # be pulled - wipe leftovers, then clone fresh. Unless real source sits there (sandbox rsync,
-        # local dev): that must never be clobbered, so build it as-is.
+        # No valid working tree: nothing on disk, a limbo dir (dropped shim, half-finished clone)
+        # with files but no .git, or a .git that is present but corrupt (HEAD unresolvable). None of
+        # these can pull. Wipe the leftovers, then clone fresh. Unless real source sits there
+        # (sandbox rsync, local dev): never destroy that, build it as-is.
         if not dep.is_real_clone() or self._is_repo_broken(dep):
             if self._refuse_destructive_clone(dep): return False
             # source_only: a broken tree here says nothing about the sibling platforms sharing this dep_dir.
-            # An explicit `mama wipe` still means everything - that's the one case the user asked for it.
+            # An explicit `mama wipe` still means everything, because the user asked for it.
             if dep.source_dir_exists():
                 self.reclone_wipe(dep, source_only=not (dep.is_current_target() and dep.config.reclone))
             self.clone_or_pull(dep)
@@ -693,8 +687,7 @@ class Git(DepSource):
         changed = False
 
         if config.update and is_target:
-            # Fail loudly on a dirty tree BEFORE the pull below - which would otherwise fail, get
-            # swallowed by its fetch fallback, and leave the dep un-updated but reporting success.
+            # fail loudly on a dirty tree BEFORE the pull below - see _ensure_no_local_modifications
             self._ensure_no_local_modifications(dep)
             changed = self.check_status(dep)
 
@@ -705,13 +698,11 @@ class Git(DepSource):
             # a url change re-clones the source, but the sibling platform dirs are not ours to delete
             self.reclone_wipe(dep, source_only=not explicit_wipe)
             wiped = True
-        elif dep.config.unshallow and is_target: # unshallow was specified, we should at least pull
-            pass # fallthrough to clone_or_pull
+        elif dep.config.unshallow and is_target:
+            pass # unshallow requested: fall through to clone_or_pull
         else:
-            # don't pull if no changes to git status
-            # or if we're current target of a non-update build
-            # mama update target=ReCpp  -- this should git pull
-            # mama build target=ReCpp   -- should NOT pull
+            # no pull when the git status shows no change, or for the current target of a non-update
+            # build: `mama update target=ReCpp` pulls, `mama build target=ReCpp` does not
             non_update_target = is_target and not config.update
             if non_update_target or not changed:
                 if config.verbose:

--- a/mama/types/git.py
+++ b/mama/types/git.py
@@ -32,10 +32,8 @@ _GIT_NOISE = ('Reset branch ', 'Your branch is up to date with ', 'Already up to
               'Your configuration specifies to merge with the ref ', 'from the remote, but no such ref was fetched',
               'There is no tracking information for the current branch')
 
-# An ssh client built without GSSAPI warns about the `GSSAPIAuthentication` line Debian and Ubuntu ship
-# in /etc/ssh/ssh_config, once per fetch. Auth still works and mama never sets that option, so the line
-# says nothing about the build. Which ssh build sits in PATH differs per machine image, which is why the
-# warning comes and goes between CI runners.
+# An ssh client built without GSSAPI warns once per fetch about the `GSSAPIAuthentication` line many
+# distros ship in /etc/ssh/ssh_config. Auth still works, so the line says nothing about the build.
 _SSH_CONFIG_WARNING = re.compile(r'^\S*(?:ssh_config|/config) line \d+: ')
 
 def _is_git_status_noise(line: str) -> bool:
@@ -53,9 +51,8 @@ _ERROR_TAIL = 40  # git lines kept for the failure report. A fetch's output is o
 
 
 def _filter_git_progress(dep, line: str, state: dict, label='') -> bool:
-    """True when `line` is git transfer progress (the caller drops it). Collapses the per-percent flood
-    the PTY makes git emit into one throttled redraw. EVERY git runner routes output through this single
-    chokepoint. `state` carries the throttle across calls. `label` prefixes the line (e.g. CLONE)."""
+    """True when `line` is git transfer progress, which the caller drops. Collapses the per-percent
+    flood into one throttled redraw. EVERY git runner routes output through this single chokepoint."""
     st = git_progress_status(line)
     if st is None: return False
     if dep.config.print:
@@ -106,9 +103,7 @@ def _canonical_remote(url: str) -> str:
 
 
 class Git(DepSource):
-    """
-    For a BuildDependency whose source is a git repository
-    """
+    """For a BuildDependency whose source is a git repository."""
     def __init__(self, name:str, url:str, branch:str, tag:str, mamafile:str, shallow:bool, args:list):
         super(Git, self).__init__(name)
         if not url: raise RuntimeError("Git url must not be empty!")
@@ -193,8 +188,7 @@ class Git(DepSource):
         if dep.config.verbose:
             warning(f'  {dep.name: <16} {cmd}')
         ssh_multiplex.ensure_master_for_url(self.url)
-        # Capture and prefix each line so parallel updates do not tear and the
-        # user can see which target said what (e.g. 'remote: Enumerating ...').
+        # capture and prefix each line, so parallel updates do not tear and each line names its target
         prog: dict = {}
         tail = deque(maxlen=_ERROR_TAIL)  # the last real lines, which the failure report shows
         def prefixed(p:SubProcess, line:str):
@@ -227,10 +221,10 @@ class Git(DepSource):
 
 
     def _ensure_no_local_modifications(self, dep: BuildDependency):
-        """Raise (with an actionable message + `git status`) when the working tree has uncommitted
-        changes an update's reset --hard would overwrite. The update path calls this at its TOP, so a
-        dirty dep fails loudly (marked `x`) even when upstream is unchanged. Otherwise the later pull
-        fails, its fetch fallback swallows the error, and the dep silently reports success un-updated."""
+        """Raise when the working tree has uncommitted changes that an update's reset --hard would
+        overwrite. The update path calls this at its TOP, so a dirty dep fails loudly even when
+        upstream is unchanged. Otherwise the later pull fails, its fetch fallback swallows the
+        error, and the dep silently reports success un-updated."""
         if not self._has_local_modifications(dep): return
         name = dep.name
         error(f"  Target {name} has local modifications that would be overwritten by update.\n"
@@ -241,8 +235,7 @@ class Git(DepSource):
 
     def working_tree_fingerprint(self, dep: BuildDependency) -> str:
         """'' for a clean tree, else a content-aware hash of uncommitted source. See
-        util.git_dir_fingerprint. Guarded on is_real_clone so a shim (no working tree on
-        disk) is treated as clean rather than probing an absent directory."""
+        util.git_dir_fingerprint. A shim has no working tree on disk, so it counts as clean."""
         return git_dir_fingerprint(dep.src_dir) if dep.is_real_clone() else ''
 
 
@@ -272,16 +265,13 @@ class Git(DepSource):
 
 
     def fetch_self_version_from_remote(self, dep: BuildDependency):
-        """Fetches only the dep's mamafile to read `self.version` without pulling the
-        full repo. The shim probe uses this for version-pinned deps (e.g. boost 1.60)
-        where the archive name does not track the commit hash. The clone goes through
-        SubProcess.run (live progress UI). The one-shot `git show` uses subprocess.run
-        with stderr=DEVNULL + timeout to drop the lazy-fetch's `remote: ...` chatter
-        and to bound a stuck fetch. Returns the version string or None on any failure."""
+        """Fetch only the dep's mamafile, to read `self.version` without the full repo. The shim
+        probe uses this for version-pinned deps whose archive name does not track the commit hash.
+        The one-shot `git show` uses subprocess.run with stderr=DEVNULL and a timeout, to drop the
+        lazy-fetch's `remote: ...` chatter and to bound a stuck fetch. Returns the version or None."""
         if dep.mamafile:
-            # Parent-repo mamafile override: the remote repo's mamafile is not the one mama
-            # runs, and `git show HEAD:<local path>` can never resolve. Before this fallback,
-            # mamafile_version.pinned_version already checked the local file for a pin.
+            # A parent-repo mamafile override never resolves through `git show HEAD:<path>` on the
+            # remote. mamafile_version.pinned_version already checked the local file for a pin.
             return None
         if not dep.config.is_network_available():
             return None
@@ -289,10 +279,8 @@ class Git(DepSource):
         branch = self.branch or self.tag or ''
         branch_arg = f' --branch {branch}' if branch and not Git.is_hex_string(branch) else ''
         try:
-            # ignore_cleanup_errors: on Windows git sets read-only on .git/objects/*,
-            # which trips shutil.rmtree. normalized_path: the project convention is
-            # forward slashes. Raw tempdir paths on Windows use backslashes, which
-            # shlex.split inside SubProcess eats.
+            # ignore_cleanup_errors: on Windows git sets read-only on .git/objects/*, which trips
+            # shutil.rmtree. normalized_path: shlex.split inside SubProcess eats raw backslash paths.
             with tempfile.TemporaryDirectory(prefix='mama_probe_', ignore_cleanup_errors=True) as tmp:
                 tmp = normalized_path(tmp)
                 clone_cmd = f'git clone --depth=1 --filter=blob:none --no-checkout{branch_arg} {self.url} {tmp}'
@@ -302,8 +290,7 @@ class Git(DepSource):
                         progress(f'  - Target {dep.name: <16} PROBE FAILED ({result}) after {elapsed}',
                                  color=Color.RED, final=True)
                     return None
-                # subprocess.run, not SubProcess.run: see docstring above.
-                # stderr=DEVNULL drops the lazy-fetch's `remote: ...` noise.
+                # subprocess.run, not SubProcess.run: see the docstring above
                 try:
                     # 10s is enough: the clone already finished, and this fetches a <1KB blob over the same connection.
                     cp = subprocess.run(['git', '-C', tmp, 'show', f'HEAD:{mamafile_name}'],
@@ -329,9 +316,7 @@ class Git(DepSource):
             return None
 
     def init_commit_hash(self, dep: BuildDependency, use_cache: bool, fetch_remote: bool):
-        """
-        Gets the latest commit hash, based on git source tag and branch options.
-        """
+        """The latest commit hash, based on the git tag and branch options."""
         if not dep.dep_source.is_git:
             return None
 
@@ -381,14 +366,10 @@ class Git(DepSource):
 
 
     def _is_repo_broken(self, dep: BuildDependency) -> bool:
-        """`.git` present but this dir is not a usable repo OF ITS OWN. -q keeps git silent on failure.
-
-        --show-toplevel is what makes it safe. A corrupt `.git` does not stop git's discovery walk, it
-        resumes UPWARD. A local workspace lives inside the project's own repo, so `rev-parse HEAD` then
-        answers with the PARENT, and the pull path would run `reset --hard` against the user's project
-        checkout. Anything not proven to be this dir's own repo counts as broken, which is the safe
-        bias: a wrong 'broken' only reaches _refuse_destructive_clone, which keeps real source and
-        builds it as-is."""
+        """`.git` present but this dir is not a usable repo OF ITS OWN. A corrupt `.git` resumes
+        git's discovery walk UPWARD, so `rev-parse HEAD` can answer with a PARENT repo, and the pull
+        path would then `reset --hard` the user's own checkout. --show-toplevel proves the repo is
+        this dir's own. A wrong 'broken' only reaches _refuse_destructive_clone, which keeps real source."""
         out = execute_piped(['git', 'rev-parse', '--show-toplevel', '--verify', '-q', 'HEAD'],
                             cwd=dep.src_dir, throw=False)
         lines = out.splitlines() if out else []
@@ -466,7 +447,7 @@ class Git(DepSource):
 
 
     def reset_status(self, dep: BuildDependency):
-        """ Clears the status file """
+        """Clear the status file."""
         self.missing_status = True
         status_file = self.git_status_file(dep)
         if os.path.exists(status_file):
@@ -521,13 +502,10 @@ class Git(DepSource):
 
     def reclone_wipe(self, dep: BuildDependency, source_only: bool = False):
         """Drop this dep's tree so it can be cloned fresh.
-
-        `source_only` removes ONLY src_dir, and every AUTOMATIC recovery must use it. Every platform shares
-        dep_dir: its `<dep_dir>/<platform>/` siblings hold OTHER platforms' artifactory packages, shim
-        markers and build output, plus the cached package zip. A git tree broken for THIS platform is no
-        reason to destroy those. With a nested `mama <host> build` (build_host_binary) running concurrently,
-        a sibling dir may be the include tree another build compiles against right now. The whole dep_dir
-        goes only on an explicit `mama wipe`, where discarding everything is the intent."""
+        source_only: remove ONLY src_dir. Every AUTOMATIC recovery must use it: the `<dep_dir>/<platform>/`
+        siblings hold OTHER platforms' packages, shim markers and build output. A concurrent nested
+        build may compile against them right now. The whole dep_dir goes only on an explicit `mama wipe`.
+        """
         target = dep.src_dir if source_only else dep.dep_dir
         if dep.config.print:
             console(f'  - Target {dep.name: <16} RECLONE WIPE{" (source)" if source_only else ""}')
@@ -535,10 +513,9 @@ class Git(DepSource):
 
 
     def _run_git_with_filtered_progress(self, dep: BuildDependency, cmd: str, label: str):
-        """Run a git command with progress filtered into one redrawn status line.
-        Returns (exit_code, captured_output, elapsed_str). Does not raise.
-        The full clone and the sparse mamafile probe both use it, so they share
-        one progress UI instead of printing git's raw remote: output."""
+        """Run a git command with progress filtered into one redrawn status line. Returns
+        (exit_code, captured_output, elapsed_str). Does not raise. The full clone and the
+        mamafile probe share this one progress UI."""
         output = []  # list + join, not output += line (O(n^2) over a big checkout's file list)
         start = time.monotonic()
         prog: dict = {}
@@ -664,14 +641,10 @@ class Git(DepSource):
 
 
     def dependency_checkout(self, dep: BuildDependency):
-        """
-        Do a git repository checkout. Can be an expensive operation.
-        An existing artifactory package skips this step.
-        """
-        # No valid working tree: nothing on disk, a limbo dir (dropped shim, half-finished clone)
-        # with files but no .git, or a .git that is present but corrupt (HEAD unresolvable). None of
-        # these can pull. Wipe the leftovers, then clone fresh. Unless real source sits there
-        # (sandbox rsync, local dev): never destroy that, build it as-is.
+        """Do a git repository checkout, which can be expensive. An existing artifactory package skips this step."""
+        # No valid working tree: nothing on disk, files without .git, or a corrupt .git. None of these
+        # can pull, so wipe the leftovers and clone fresh. Real source (sandbox rsync, local dev work)
+        # is never destroyed: build it as-is.
         if not dep.is_real_clone() or self._is_repo_broken(dep):
             if self._refuse_destructive_clone(dep): return False
             # source_only: a broken tree here says nothing about the sibling platforms sharing this dep_dir.

--- a/mama/types/git_errors.py
+++ b/mama/types/git_errors.py
@@ -21,8 +21,7 @@ _WIPE_HINT = 'Run `mama wipe <target>` to clone the target again.'
 _UNKNOWN_HINT = 'Run mama with `verbose` to see the full git output.'
 
 # (needles, transient, reason, hint). The scan returns the FIRST match, so each specific cause comes
-# before the general one. A rate limit answers 403, which alone reads as access denied. A 404 over
-# https also prints 'unable to access'.
+# before the general one: a rate limit answers 403, and a 404 over https also prints 'unable to access'.
 _CAUSES = (
     (('too many requests', 'rate limit', 'error: 429', 'try again later', 'temporarily unavailable'), True,
      'the server throttled mama (rate limit)', _WAIT_HINT),
@@ -53,8 +52,7 @@ _CAUSES = (
      'mama cannot reach the git server', _RETRY_HINT),
 )
 
-# Substrings that mark a line as the one that names the failure. The rest of a clone's output is
-# progress and transfer text.
+# Substrings that mark the line naming the failure. The rest of the output is progress and transfer text.
 _ERROR_NEEDLES = ('fatal:', 'error:', 'denied', 'ssh:', 'warning:', '[mama]')
 _MAX_GIT_LINES = 6  # enough for the git error and the two lines after it, short enough to read
 _TAIL_LINES = 3     # fallback when no line matches: each git version words an error differently

--- a/mama/types/git_errors.py
+++ b/mama/types/git_errors.py
@@ -1,8 +1,5 @@
 """Name the cause of a failed git command and render it as a report the user can act on.
-
-One table drives both the retry decision and the report, so a new pattern is one line in one place.
-Without this, a git failure reaches the user as a Python traceback. Mama's own call stack then buries
-the line that matters, for example `error: RPC failed; curl 35 Recv failure`."""
+One table drives both the retry decision and the report, so a new pattern is one line in one place."""
 
 from typing import NamedTuple
 
@@ -23,9 +20,9 @@ _KEY_HINT = 'Check the ssh key of this machine, or the access token of the repos
 _WIPE_HINT = 'Run `mama wipe <target>` to clone the target again.'
 _UNKNOWN_HINT = 'Run mama with `verbose` to see the full git output.'
 
-# (needles, transient, reason, hint). The scan returns the FIRST match, so the order matters twice.
-# A rate limit answers 403, which alone reads as access denied. A 404 over https also prints
-# 'unable to access'. Each specific cause comes before the general one.
+# (needles, transient, reason, hint). The scan returns the FIRST match, so each specific cause comes
+# before the general one. A rate limit answers 403, which alone reads as access denied. A 404 over
+# https also prints 'unable to access'.
 _CAUSES = (
     (('too many requests', 'rate limit', 'error: 429', 'try again later', 'temporarily unavailable'), True,
      'the server throttled mama (rate limit)', _WAIT_HINT),

--- a/mama/types/local_source.py
+++ b/mama/types/local_source.py
@@ -4,7 +4,7 @@ from ..util import git_dir_fingerprint, path_join, save_file_if_contents_changed
 
 class LocalSource(DepSource):
     """
-    For BuildDependency whose source is from a Local Source
+    For a BuildDependency whose source is a local directory
     """
     def __init__(self, name:str, rel_path:str, mamafile:str, always_build:bool, args:list):
         super(LocalSource, self).__init__(name)
@@ -17,8 +17,8 @@ class LocalSource(DepSource):
     def __str__(self):  return f'DepSource LocalSource {self.name} {self.rel_path} {self.mamafile} always_build={self.always_build}'
     def __repr__(self): return self.__str__()
 
-    # A local dep has no git_status of its own; the enclosing repo's working-tree state is what
-    # gates its cmake step. Snapshot lives beside the build, next to git's git_status.
+    # A local dep has no git_status of its own. The working-tree state of the enclosing repo gates
+    # its cmake step. The snapshot lives in the build dir, next to git's git_status.
     def src_status_file(self, dep) -> str:
         return path_join(dep.build_dir, 'src_status')
 

--- a/mama/types/local_source.py
+++ b/mama/types/local_source.py
@@ -3,9 +3,7 @@ from .dep_source import DepSource
 from ..util import git_dir_fingerprint, path_join, save_file_if_contents_changed, read_text_from
 
 class LocalSource(DepSource):
-    """
-    For a BuildDependency whose source is a local directory
-    """
+    """For a BuildDependency whose source is a local directory."""
     def __init__(self, name:str, rel_path:str, mamafile:str, always_build:bool, args:list):
         super(LocalSource, self).__init__(name)
         self.is_src = True
@@ -23,8 +21,8 @@ class LocalSource(DepSource):
         return path_join(dep.build_dir, 'src_status')
 
     def working_tree_fingerprint(self, dep) -> str:
-        """Fingerprint of uncommitted edits inside this local dep's subfolder, as tracked by an
-        enclosing git repo. '' when the subfolder is clean or not under git. See git_dir_fingerprint."""
+        """Fingerprint of uncommitted edits in this dep's subfolder, as tracked by an enclosing git
+        repo. '' when the subfolder is clean or not under git. See git_dir_fingerprint."""
         return git_dir_fingerprint(dep.src_dir)
 
     def source_tree_changed(self, dep) -> bool:

--- a/mama/util.py
+++ b/mama/util.py
@@ -77,12 +77,10 @@ def save_file_if_contents_changed(filename: str, new_contents: str) -> bool:
 
 
 def path_join(first: str, *parts) -> str:
-    """Join with forward/ slashes and keep the path exactly where it points.
-
-    The relative sibling of normalized_join(). abspath() turns a relative path into a machine-specific
-    absolute one. On Windows it prepends the current drive, so `/tmp/x` becomes `C:/tmp/x`. Use this
-    for a path mama only prints, records, or hands to another tool. Use normalized_join() for a path
-    mama opens on this machine."""
+    """Join with forward/ slashes and keep the path exactly where it points. The relative sibling of
+    normalized_join(): abspath() turns a relative path into a machine-specific absolute one, and on
+    Windows it prepends the current drive. Use this for a path mama only prints, records, or hands to
+    another tool. Use normalized_join() for a path mama opens on this machine."""
     result = first.rstrip('/\\')
     for part in parts:
         part = part.lstrip('/\\')
@@ -179,9 +177,8 @@ def remove_tree(dir: str):
     shutil.rmtree(dir)
 
 
-# Subdirs that prove a checkout is already here, even with no file at the top level. `.git` is the
-# strongest of them: a working tree whose root holds only directories used to read as empty. Mama then
-# cloned over a good clone, and git failed with 'already exists and is not an empty directory'.
+# Subdirs that prove a checkout is already here, even with no top-level file. A working tree whose root
+# holds only directories used to read as empty, and mama then cloned over a good clone and failed.
 _OCCUPIED_SUBDIRS = {'.git', 'include', 'src', 'lib', 'bin'}
 
 
@@ -234,15 +231,13 @@ def read_lines_from(file: str) -> List[str]:
 
 
 def git_dir_fingerprint(src_dir: str) -> str:
-    """Cheap content-aware hash of uncommitted source under `src_dir`: tracked `git diff HEAD`
-    scoped to this dir plus untracked file stats. '' for a clean tree, a dir not under git, or
-    a missing dir. Lets `mama build` catch in-place source edits - of a git dep clone, or of a
-    local dep tracked by an enclosing repo - without a full status check or reconfigure.
+    """Cheap content-aware hash of uncommitted source under `src_dir`: tracked `git diff HEAD` scoped
+    to this dir plus untracked file stats. '' for a clean tree, a dir not under git, or a missing dir.
+    Lets `mama build` catch in-place source edits without a full status check or reconfigure.
 
-    Uses subprocess.run with stderr=DEVNULL, not SubProcess.run / execute_piped: a local
-    source dir may not be under git at all, and the `fatal: not a git repository` noise must
-    not reach the user. Scoping with `-- .` keeps a subfolder of a larger repo from
-    fingerprinting the parent's unrelated changes. Two git calls, near-free on a clean tree."""
+    Uses subprocess.run with stderr=DEVNULL, not SubProcess.run: a local source dir may not be under
+    git at all, and the `fatal: not a git repository` noise must not reach the user. Scoping with `-- .`
+    keeps a subfolder of a larger repo from fingerprinting the parent's unrelated changes."""
     if not src_dir or not os.path.exists(src_dir):
         return ''
     def git(args) -> bytes:
@@ -325,11 +320,11 @@ class ProgressBar:
 
 
 def download_file(remote_url:str, local_dir:str, force=False, message=None, name:str=None):
-    """Downloads remote_url into local_dir.
-    - force=False: use any existing local file without contacting the server.
-    - force=True:  open the connection and compare Content-Length. Skip the body transfer when the
-      sizes match, so an artifactory fetch does not re-download an archive already on disk.
-    - name: optional target name that prefixes the log lines under parallel updates."""
+    """Downloads remote_url into local_dir. Returns the local file path, or None on failure.
+    - force: [False] use any existing local file without contacting the server. When True, open the
+      connection and compare Content-Length, and skip the body transfer when the sizes match.
+    - message: [None] custom log line for the download start
+    - name: [None] target name that prefixes the log lines under parallel updates"""
     local_file = normalized_join(local_dir, os.path.basename(remote_url))
     indent = f'  - {name: <16} ' if name else '    '
     if not force and os.path.exists(local_file):
@@ -350,9 +345,7 @@ def download_file(remote_url:str, local_dir:str, force=False, message=None, name
         size = urlfile.info()['Content-Length']
         size = int(size.strip()) if size else None
 
-        # Size-match cache: skip the body transfer entirely when the local
-        # file matches the remote Content-Length. Costs one HTTP round-trip,
-        # already paid by opening the connection, and saves the whole body.
+        # size-match cache: one HTTP round-trip, already paid by opening the connection, saves the whole body
         if size is not None and os.path.exists(local_file) \
                 and os.path.getsize(local_file) == size:
             console(f'{indent}Artifactory CACHE (size-match) '
@@ -379,13 +372,10 @@ def download_file(remote_url:str, local_dir:str, force=False, message=None, name
 
 
 def unzip(local_zip: str, extract_dir: str, pwd: str = None):
-    """
-    Unzips an archive into extract_dir, throws on failure.
-    Extracts a file only when its current size or modified time mismatches.
-    Always sets the modified time from the zipfile info.
-    Preserves symlinks and sets the correct file permission attributes.
-    Returns the number of files actually extracted.
-    """
+    """Unzips an archive into extract_dir, throws on failure. Returns the number of files extracted.
+    Extracts a file only when its size or modified time mismatches, preserves symlinks and permissions,
+    and always sets the modified time from the zipfile info.
+    - pwd: [None] archive password"""
     def get_zipinfo_datetime(zipmember: zipfile.ZipInfo) -> datetime:
         zt = zipmember.date_time # tuple: year, month, day, hour, min, sec
         # ZIP uses localtime
@@ -449,8 +439,7 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
                     if not is_symlink:
                         perm = stat.S_IMODE(zipmember.external_attr >> 16)
                         os.chmod(dst_path, perm)
-                    # Always set the modification date from the zipmember timestamp.
-                    # This avoids needless file changes and full rebuilds.
+                    # set the modified time from the zip timestamp, so nothing reads as changed and rebuilds
                     time = get_zipinfo_datetime(zipmember)
                     mtime = time.timestamp()
                     if System.windows:
@@ -464,10 +453,8 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
 
 
 def try_unzip(local_file:str, extract_dir:str) -> bool:
-    """
-    Attempts to unzip an archive. Returns a tuple (success: bool, num_extracted: int).
-    (True, 0) means every destination file already matched the zip contents.
-    """
+    """Attempts to unzip an archive. Returns (success: bool, num_extracted: int).
+    (True, 0) means every destination file already matched the zip contents."""
     try:
         files_extracted = unzip(local_file, extract_dir)
         return (True, files_extracted)
@@ -517,10 +504,8 @@ def _passes_filter(src_file: str, filter) -> bool:
 
 
 def copy_file(src: str, dst: str, filter=None) -> bool:
-    """
-    Copies a single file when it passes the filter and has changed. Returns True if copied.
-    The filter is a string suffix, a list of suffixes, or a function of the file path.
-    """
+    """Copies a single file when it passes the filter and has changed. Returns True if copied.
+    - filter: [None] a string suffix, a list of suffixes, or a function of the file path"""
     if _passes_filter(src, filter):
         if os.path.isdir(dst):
             dst = path_join(dst, os.path.basename(src))
@@ -532,15 +517,11 @@ def copy_file(src: str, dst: str, filter=None) -> bool:
 
 
 def copy_dir(src_dir: str, out_dir: str, filter=None, remap_root_dirname=False) -> bool:
-    """
-    Copies an entire dir. Copies each file only when it passes the filter and has changed.
+    """Copies an entire dir. Copies each file only when it passes the filter and has changed.
     Returns True if any file was copied.
-    The filter is a string suffix, a list of suffixes, or a function of the file path.
-    If remap_root_dirname is True, src_dir contents map directly into out_dir, which
-    renames the source directory to out_dir's basename.
-    Example: copy_dir('proj/src', 'deploy/include/mylib', remap_root_dirname=True)
-             copies src/* -> include/mylib/* instead of src/* -> include/mylib/src/*
-    """
+    - filter: [None] a string suffix, a list of suffixes, or a function of the file path
+    - remap_root_dirname: [False] map src_dir contents directly into out_dir, so
+      copy_dir('proj/src', 'deploy/include/mylib', remap_root_dirname=True) copies src/* -> include/mylib/*"""
     if not os.path.exists(src_dir):
         raise RuntimeError(f'copy_dir: {src_dir} does not exist!')
     if not os.path.exists(out_dir):
@@ -566,10 +547,8 @@ def copy_dir(src_dir: str, out_dir: str, filter=None, remap_root_dirname=False) 
 
 
 def copy_if_needed(src: str, dst: str, filter=None) -> bool:
-    """
-    Copies src -> dst dir or file when needed. Returns True if anything was copied.
-    The filter is a string suffix, a list of suffixes, or a function of the file path.
-    """
+    """Copies src -> dst dir or file when needed. Returns True if anything was copied.
+    - filter: [None] a string suffix, a list of suffixes, or a function of the file path"""
     if os.path.isdir(src):
         return copy_dir(src, dst, filter)
     else:
@@ -577,11 +556,9 @@ def copy_if_needed(src: str, dst: str, filter=None) -> bool:
 
 
 def is_network_error(e: Exception) -> bool:
-    """
-    Returns True only if the exception clearly indicates network unavailability
-    (DNS failure, connection refused/reset, timeout). Returns False for auth
-    errors (SSH key rejected, HTTP 401/403), HTTP 404, and anything ambiguous.
-    """
+    """True only if the exception clearly indicates network unavailability: DNS failure, connection
+    refused or reset, timeout. False for auth errors (SSH key rejected, HTTP 401/403), HTTP 404,
+    and anything ambiguous."""
     import subprocess, socket
     from urllib.error import HTTPError, URLError
 

--- a/mama/util.py
+++ b/mama/util.py
@@ -20,7 +20,7 @@ def is_file_modified(src: str, dst: str):
 
 
 def find_executable_from_system(name: str, follow_symlinks=False) -> str:
-    """ Returns the absolute path to an executable if found, otherwise returns empty string """
+    """Returns the absolute path to an executable, or an empty string when not found."""
     if not name: return ''
     output = shutil.which(name)
     if not output: return ''
@@ -80,7 +80,7 @@ def path_join(first: str, *parts) -> str:
     """Join with forward/ slashes and keep the path exactly where it points.
 
     The relative sibling of normalized_join(). abspath() turns a relative path into a machine-specific
-    absolute one, and on Windows it prepends the current drive, so `/tmp/x` becomes `C:/tmp/x`. Use this
+    absolute one. On Windows it prepends the current drive, so `/tmp/x` becomes `C:/tmp/x`. Use this
     for a path mama only prints, records, or hands to another tool. Use normalized_join() for a path
     mama opens on this machine."""
     result = first.rstrip('/\\')
@@ -92,7 +92,7 @@ def path_join(first: str, *parts) -> str:
 
 
 def forward_slashes(pathstring: str) -> str:
-    """ Replace all back\\ slashes with forward/ slashes"""
+    """Replaces all back\\ slashes with forward/ slashes."""
     return pathstring.replace('\\', '/')
 
 
@@ -111,18 +111,18 @@ def short_path(path) -> str:
 
 
 def back_slashes(pathstring: str) -> str:
-    """ Replace all forward/ slashes with back\\ slashes"""
+    """Replaces all forward/ slashes with back\\ slashes."""
     return pathstring.replace('/', '\\')
 
 
 def normalized_path(pathstring: str) -> str:
-    """ Normalizes a path to ABSOLUTE path and all forward/ slashes """
+    """Normalizes a path to an ABSOLUTE path with all forward/ slashes."""
     pathstring = os.path.abspath(pathstring)
     return pathstring.replace('\\', '/').rstrip()
 
 
 def normalized_join(path1: str, *pathsN) -> str:
-    """ Joins N paths and the calls normalized_path() """
+    """Joins N paths and then calls normalized_path()."""
     return normalized_path(os.path.join(path1, *pathsN))
 
 
@@ -139,8 +139,7 @@ def glob_with_extensions(rootdir: str, extensions: List[str], exclude_dirs: List
 
 
 def strstr_multi(s: str, substrings: List[str]) -> bool:
-    #console(f'file: {s} matches: {substrings}')
-    if not substrings: # if no substrings, then match everything
+    if not substrings: # no substrings matches everything
         return True
     for substr in substrings:
         if substr in s:
@@ -181,8 +180,8 @@ def remove_tree(dir: str):
 
 
 # Subdirs that prove a checkout is already here, even with no file at the top level. `.git` is the
-# strongest of them: a working tree whose root holds only directories used to read as empty, so mama
-# cloned over a perfectly good clone and git failed with 'already exists and is not an empty directory'.
+# strongest of them: a working tree whose root holds only directories used to read as empty. Mama then
+# cloned over a good clone, and git failed with 'already exists and is not an empty directory'.
 _OCCUPIED_SUBDIRS = {'.git', 'include', 'src', 'lib', 'bin'}
 
 
@@ -199,7 +198,7 @@ _NON_SOURCE_ENTRIES = {'mama.cmake', '.git'}
 
 
 def has_source_content(dir: str) -> bool:
-    """True if `dir` holds anything mama didn't put there - source a wipe would destroy. Counts subdirs
+    """True if `dir` holds anything mama did not put there - source a wipe would destroy. Counts subdirs
     (unlike is_dir_empty) and biases to 'source': worst case keeps a stale dir, never loses local work."""
     if not os.path.exists(dir): return False
     return any(entry not in _NON_SOURCE_ENTRIES for entry in os.listdir(dir))
@@ -240,11 +239,10 @@ def git_dir_fingerprint(src_dir: str) -> str:
     a missing dir. Lets `mama build` catch in-place source edits - of a git dep clone, or of a
     local dep tracked by an enclosing repo - without a full status check or reconfigure.
 
-    Uses subprocess.run with stderr=DEVNULL (not SubProcess.run / execute_piped): a local
-    source dir may not be under git at all, and we must swallow git's `fatal: not a git
-    repository` rather than surface it on every build. Scoping with `-- .` keeps a subfolder of
-    a larger repo from fingerprinting the parent's unrelated changes. Two git calls; near-free
-    on a clean tree."""
+    Uses subprocess.run with stderr=DEVNULL, not SubProcess.run / execute_piped: a local
+    source dir may not be under git at all, and the `fatal: not a git repository` noise must
+    not reach the user. Scoping with `-- .` keeps a subfolder of a larger repo from
+    fingerprinting the parent's unrelated changes. Two git calls, near-free on a clean tree."""
     if not src_dir or not os.path.exists(src_dir):
         return ''
     def git(args) -> bytes:
@@ -268,9 +266,7 @@ def git_dir_fingerprint(src_dir: str) -> str:
 
 
 def get_file_size_str(size):
-    """
-    Returns file size as a human readable string, eg 96.5KB, or 100.1MB
-    """
+    """Returns the file size as a human readable string, eg 96.5KB or 100.1MB."""
     if size < 128: return f'{size}B' # only show bytes for really small < 0.1 KB sizes
     if size < (1024*1024): return f'{size/1024:.1f}KB'
     if size < (1024*1024*1024): return f'{size/(1024*1024):.1f}MB'
@@ -278,7 +274,7 @@ def get_file_size_str(size):
 
 
 def get_time_str(seconds: float):
-    if seconds < 0.1: return f'{int(seconds*1000)}ms'  # ms only below 0.1s, else 0.0s; 0.2s beats 200ms
+    if seconds < 0.1: return f'{int(seconds*1000)}ms'  # ms only below 0.1s, because 0.2s reads better than 200ms
     if seconds < 60: return f'{seconds:.1f}s'
     if seconds < 60*60: return f'{int(seconds/60)}m {int(seconds%60)}s'
     if seconds < 24*60*60: return f'{int(seconds/(60*60))}h {int(seconds/60)%60}m {int(seconds)%60}s'
@@ -312,7 +308,7 @@ class ProgressBar:
         progress(f'{self.indent}{bar}{self._tail()}', final=final)
 
     def step(self, amount: int, label: str = ''):
-        """Advance by `amount` bytes; `label` names the item in flight, shown on the next redraw."""
+        """Advances by `amount` bytes. `label` names the item in flight, shown on the next redraw."""
         self.done += amount
         self.label = label
         if self.interval >= 100: return
@@ -324,17 +320,16 @@ class ProgressBar:
     def finish(self):
         """Commit the bar on its own line. Always drawn, even when redraws were throttled off, and
         reports the real percent so a truncated transfer is visible rather than claiming 100%."""
-        self.label = ''  # at 100% there is no item in flight; keep the committed line clean
+        self.label = ''  # at 100% there is no item in flight, so keep the committed line clean
         self._draw(self._percent(), final=True)
 
 
 def download_file(remote_url:str, local_dir:str, force=False, message=None, name:str=None):
     """Downloads remote_url into local_dir.
     - force=False: use any existing local file without contacting the server.
-    - force=True:  open the connection and compare Content-Length; skip the
-      body transfer when sizes match (used for artifactory fetches so we don't
-      re-download archives already on disk).
-    - name: optional target name for prefixing log lines under parallel updates."""
+    - force=True:  open the connection and compare Content-Length. Skip the body transfer when the
+      sizes match, so an artifactory fetch does not re-download an archive already on disk.
+    - name: optional target name that prefixes the log lines under parallel updates."""
     local_file = normalized_join(local_dir, os.path.basename(remote_url))
     indent = f'  - {name: <16} ' if name else '    '
     if not force and os.path.exists(local_file):
@@ -356,8 +351,8 @@ def download_file(remote_url:str, local_dir:str, force=False, message=None, name
         size = int(size.strip()) if size else None
 
         # Size-match cache: skip the body transfer entirely when the local
-        # file matches the remote Content-Length. Costs one HTTP round-trip
-        # (already paid by opening the connection); saves the whole body.
+        # file matches the remote Content-Length. Costs one HTTP round-trip,
+        # already paid by opening the connection, and saves the whole body.
         if size is not None and os.path.exists(local_file) \
                 and os.path.getsize(local_file) == size:
             console(f'{indent}Artifactory CACHE (size-match) '
@@ -373,7 +368,7 @@ def download_file(remote_url:str, local_dir:str, force=False, message=None, name
         transferred = 0
         with open(local_file, 'wb') as output:
             while transferred < size:
-                data = urlfile.read(32*1024) # large chunks plz
+                data = urlfile.read(32*1024)
                 if not data: break
                 output.write(data)
                 transferred += len(data)
@@ -385,11 +380,11 @@ def download_file(remote_url:str, local_dir:str, force=False, message=None, name
 
 def unzip(local_zip: str, extract_dir: str, pwd: str = None):
     """
-    Attempts to unzip an archive, throws on failure.
-    Only extracts the files if their current size or modified time mismatches.
-    Always sets modified time from the zipfile info.
-    Preserves symlinks. And sets the correct file permission attributes.
-    Returns # of files actually extracted.
+    Unzips an archive into extract_dir, throws on failure.
+    Extracts a file only when its current size or modified time mismatches.
+    Always sets the modified time from the zipfile info.
+    Preserves symlinks and sets the correct file permission attributes.
+    Returns the number of files actually extracted.
     """
     def get_zipinfo_datetime(zipmember: zipfile.ZipInfo) -> datetime:
         zt = zipmember.date_time # tuple: year, month, day, hour, min, sec
@@ -413,7 +408,7 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
     # creates a symlink only if necessary
     def make_symlink(zipmember: zipfile.ZipInfo, symlink_location, is_directory):
         target = zip.read(zipmember, pwd=pwd).decode('utf-8')
-        # link does not exist, recreate it
+        # link does not exist, create it
         if not os.path.islink(symlink_location):
             if os.path.exists(symlink_location):
                 os.remove(symlink_location)
@@ -434,7 +429,7 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
             mode = zipmember.external_attr >> 16
             is_symlink = stat.S_ISLNK(mode)
             did_extract = False
-            if zipmember.is_dir():  # make dirs if needed
+            if zipmember.is_dir():
                 if is_symlink:
                     did_extract = make_symlink(zipmember, dst_path, is_directory=True)
                 elif not os.path.isdir(dst_path):
@@ -451,14 +446,12 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
                         shutil.copyfileobj(src, dst)
                         did_extract = True
                 if did_extract:
-                    # set the correct permissions for files and folders
                     if not is_symlink:
                         perm = stat.S_IMODE(zipmember.external_attr >> 16)
                         os.chmod(dst_path, perm)
-                    # always set the modification date from the zipmember timestamp,
-                    # this way we can avoid unnecessarily modifying files and causing full rebuilds
+                    # Always set the modification date from the zipmember timestamp.
+                    # This avoids needless file changes and full rebuilds.
                     time = get_zipinfo_datetime(zipmember)
-                    #print(f'    | {dst_path} {time}')
                     mtime = time.timestamp()
                     if System.windows:
                         os.utime(dst_path, times=(mtime, mtime))
@@ -472,9 +465,8 @@ def unzip(local_zip: str, extract_dir: str, pwd: str = None):
 
 def try_unzip(local_file:str, extract_dir:str) -> bool:
     """
-    Attempts to unzip an archive, returns a tuple (success: bool, num_extracted: int)
-    If (success: True, num_extracted: 0) is returned, it means none of the destination files
-    were different from the zip contents, and zero extractions were performed
+    Attempts to unzip an archive. Returns a tuple (success: bool, num_extracted: int).
+    (True, 0) means every destination file already matched the zip contents.
     """
     try:
         files_extracted = unzip(local_file, extract_dir)
@@ -508,15 +500,12 @@ def _should_copy(src: str, dst: str):
     try:
         dst_stat = os.stat(dst)
     except (OSError, ValueError):
-        return True # dst doesn't exist, definitely need to copy it
+        return True # dst does not exist, so copy
 
     if src_stat.st_size != dst_stat.st_size:
-        #console(f'_should_copy true src.size != dst.size\n┌──{src}\n└─>{dst}')
         return True
     if src_stat.st_mtime != dst_stat.st_mtime:
-        #console(f'_should_copy true src.mtime != dst.mtime\n┌<──{src}\n└──> {dst}')
         return True
-    #console(f'skip {dst}')
     return False
 
 
@@ -529,15 +518,13 @@ def _passes_filter(src_file: str, filter) -> bool:
 
 def copy_file(src: str, dst: str, filter=None) -> bool:
     """
-        Copies a single file if it passes the filter and
-        if it has changed, returns TRUE if copied.
-        The filter is a string suffix, a list of suffixes, or a function of the file path.
+    Copies a single file when it passes the filter and has changed. Returns True if copied.
+    The filter is a string suffix, a list of suffixes, or a function of the file path.
     """
     if _passes_filter(src, filter):
         if os.path.isdir(dst):
             dst = path_join(dst, os.path.basename(src))
         if _should_copy(src, dst):
-            #console(f'copy {src}\n --> {dst}')
             shutil.copyfile(src, dst, follow_symlinks=True)
             shutil.copystat(src, dst, follow_symlinks=True)
             return True
@@ -546,14 +533,13 @@ def copy_file(src: str, dst: str, filter=None) -> bool:
 
 def copy_dir(src_dir: str, out_dir: str, filter=None, remap_root_dirname=False) -> bool:
     """
-        Copies an entire dir if it passes the filter and
-        if the individual files have changed.
-        Returns TRUE if any files were copied.
-        The filter is a string suffix, a list of suffixes, or a function of the file path.
-        If remap_root_dirname is True, then src_dir contents are mapped directly
-        into out_dir, effectively renaming the source directory to out_dir's basename.
-        Example: copy_dir('proj/src', 'deploy/include/mylib', remap_root_dirname=True)
-                 copies src/* -> include/mylib/* instead of src/* -> include/mylib/src/*
+    Copies an entire dir. Copies each file only when it passes the filter and has changed.
+    Returns True if any file was copied.
+    The filter is a string suffix, a list of suffixes, or a function of the file path.
+    If remap_root_dirname is True, src_dir contents map directly into out_dir, which
+    renames the source directory to out_dir's basename.
+    Example: copy_dir('proj/src', 'deploy/include/mylib', remap_root_dirname=True)
+             copies src/* -> include/mylib/* instead of src/* -> include/mylib/src/*
     """
     if not os.path.exists(src_dir):
         raise RuntimeError(f'copy_dir: {src_dir} does not exist!')
@@ -581,10 +567,9 @@ def copy_dir(src_dir: str, out_dir: str, filter=None, remap_root_dirname=False) 
 
 def copy_if_needed(src: str, dst: str, filter=None) -> bool:
     """
-        Copies src -> dst  dir/file  if needed and returns TRUE if anything was copied.
-        The filter is a string suffix, a list of suffixes, or a function of the file path.
+    Copies src -> dst dir or file when needed. Returns True if anything was copied.
+    The filter is a string suffix, a list of suffixes, or a function of the file path.
     """
-    #console(f'COPY {src} --> {dst}')
     if os.path.isdir(src):
         return copy_dir(src, dst, filter)
     else:
@@ -644,7 +629,7 @@ def is_network_error(e: Exception) -> bool:
 
 
 # git transfer progress ('Receiving objects: 42% (...)') classification - shared so every place that
-# captures git output collapses the per-percent flood identically (one source of truth).
+# captures git output collapses the per-percent flood identically.
 _GIT_PROGRESS = (('remote: Counting objects:', 'counting objects   '), ('remote: Compressing objects:', 'compressing objects'),
                  ('Receiving objects:', 'receiving objects  '), ('Resolving deltas:', 'resolving deltas   '),
                  ('Updating files:', 'updating files     '))
@@ -665,14 +650,14 @@ _PERCENT_RE = re.compile(r'\b\d{1,3}%')  # a NN% completion token: git 'Receivin
 
 def is_progress_line(line: str) -> bool:
     """True for any transfer/download progress update - a line carrying a NN% completion token.
-    Consecutive such lines collapse to just the latest so a progress bar (git, artifactory download,
-    a custom build's own downloader) can't flood a captured buffer with hundreds of per-percent updates."""
+    Consecutive such lines collapse to just the latest, so a progress bar (git, artifactory download,
+    a custom build's own downloader) cannot flood a captured buffer with hundreds of per-percent updates."""
     return _PERCENT_RE.search(line) is not None
 
 
 def parse_version(version: str) -> tuple:
     """'0.13.01' -> (0, 13, 1). Segments parse as ints so zero-padding is irrelevant and 0.13 ranks
-    ABOVE 0.9 (a plain string compare gets that backwards). Non-numeric junk in a segment is dropped."""
+    ABOVE 0.9 (a plain string compare gets that backwards). The parse drops non-numeric junk in a segment."""
     parts = []
     for segment in str(version).split('.'):
         digits = ''.join(c for c in segment if c.isdigit())

--- a/mama/utils/abort.py
+++ b/mama/utils/abort.py
@@ -1,10 +1,5 @@
-"""Cooperative shutdown for a build that must stop: a first failure, or Ctrl+C.
-
-Two stages. `request()` only sets a flag, so nothing NEW starts - no job launch, no phase transition,
-no subprocess spawn. Then mama asks every running child to stop and waits out the grace period. Mama
-kills only a child that ignores the request. A hard kill of git, cmake or ninja mid-write leaves a
-broken cmake cache, a half-written object file or a stale .git/index.lock. The next build then fails
-on that leftover state, not on the real error."""
+"""Cooperative shutdown for a build that must stop: a first failure, or Ctrl+C. `request()` only sets a flag,
+so nothing new starts. Mama then asks each running child to stop and kills only one that ignores the grace period."""
 
 import threading
 

--- a/mama/utils/abort.py
+++ b/mama/utils/abort.py
@@ -18,8 +18,8 @@ _reason = ''
 
 
 def request(reason: str):
-    """Stage 1: stop every job that has not started yet. Idempotent. The FIRST reason stays, because
-    that is the cause the user must read. A later failure is only a consequence of it."""
+    """Stage 1: stop every job that has not started yet. Idempotent.
+    reason: the cause the user must read. The FIRST reason stays, a later failure is only a consequence."""
     global _reason
     with _lock:
         if _requested.is_set(): return

--- a/mama/utils/build_display.py
+++ b/mama/utils/build_display.py
@@ -1,13 +1,5 @@
-"""Unified live display for parallel configure/build jobs.
-
-TTY: a live region of one line per ACTIVELY-running task, capped to terminal height, redrawn in
-place (superconsole style). A dep flows through phases (load -> configure -> build) on ONE task that
-stays put across them; when its whole workflow finishes it commits a single summary line above the
-region with a per-phase timing breakdown - `git 3.7s  cfg 0.4s  bld 0.4s` (git/loc/art load, cfg
-configure, bld build), every step shown + tagged (even an instant configure) for a consistent column.
-Non-TTY: that same one merged summary line per dep, + a full output dump when verbose.
-Every task keeps its raw colour-preserving output for failure replay. Injected seams (out / isatty /
-term_size / clock) -> unit-testable with no real terminal/threads/subprocesses."""
+"""Live display for parallel configure/build jobs: one redrawn-in-place line per running task, and one committed
+summary line per dep with a per-phase timing breakdown. Injected seams (out / isatty / term_size / clock) ease tests."""
 
 from __future__ import annotations
 import re, time, threading
@@ -19,26 +11,24 @@ from ..util import get_time_str, is_progress_line
 _CURSOR_UP = '\x1b[1A'
 _ERASE_EOL = '\x1b[K'  # erase to end of line (colorama enables it on Windows)
 _ERASE_EOL_LF = _ERASE_EOL + '\n'  # clear-to-EOL then newline: one written task/permanent line
-_ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')  # SGR colour codes, for width-correct previews
-_ESC_RE = re.compile(r'\x1b\[[0-9;?]*[A-Za-z]|\x1b.')  # ANY escape sequence, colour ones included
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')  # SGR color codes, for width-correct previews
+_ESC_RE = re.compile(r'\x1b\[[0-9;?]*[A-Za-z]|\x1b.')  # any escape sequence, color codes included
 _CTRL_RE = re.compile(r'[\x00-\x1a\x1c-\x1f\x7f]')  # every C0 control except ESC, which _ESC_RE handles
 # A diagnostic line: MSVC 'warning C4996:' / 'error C2065:' / 'error LNK2019:', GCC/Clang 'warning:' /
-# 'error:', and CMake's 'CMake Error at <file>' (no colon, so the generic form below never caught it -
-# which is exactly how a failing target's real error went missing from the summary).
-# \b guards keep -Werror, std::error_code and '0 errors' from matching.
+# 'error:', and CMake's 'CMake Error at <file>', which has no colon and so needs its own alternative.
+# The \b guards keep -Werror, std::error_code and '0 errors' from matching.
 _DIAG_RE = re.compile(r'\bcmake\s+(?P<cm>error|warning)\b|\b(?P<sev>error|warning)\b\s*(?:[A-Za-z]+[0-9]+)?\s*:',
                       re.IGNORECASE)
 
 
 _CMAKE_HEAD = re.compile(r'^cmake\s+(error|warning)\b', re.IGNORECASE)
-_MAX_BODY = 8  # continuation lines kept per cmake block, so one chatty warning can't bury the rest
+_MAX_BODY = 8  # continuation lines kept per cmake block, so one chatty warning cannot bury the rest
 
-# GCC and Clang wrap a diagnostic in context. The lines BEFORE it name the call site - which template
-# instantiated this, or which of the user's functions this system header got inlined into - and that is
-# where the bug usually is. The numbered source snippet AFTER it shows the expression that broke.
-# Without both, a diagnostic reads as one line pointing deep inside a header nobody edited.
+# GCC and Clang wrap a diagnostic in context. The lines BEFORE it name the call site, which is where
+# the bug usually is. The numbered source snippet AFTER it shows the expression that broke. Without
+# both, a diagnostic reads as one line that points deep inside a header nobody edited.
 # The `In function` header carries no file prefix when it opens an inlining chain, so the prefix is
-# optional here; `inlined from` and `from` are its indented continuation lines.
+# optional here. `inlined from` and `from` are its indented continuation lines.
 _DIAG_ROLE = (r'In (instantiation of|substitution of|(static |member |lambda )*function|constructor|destructor)\b'
               r'|At global scope:')
 _DIAG_CONTEXT = re.compile(r'^(In file included from |\s+(inlined )?from \S'
@@ -47,7 +37,7 @@ _DIAG_CONTEXT = re.compile(r'^(In file included from |\s+(inlined )?from \S'
                            r'|.*:\s*note:\s+in instantiation of\b)')
 _DIAG_SNIPPET = re.compile(r'^\s*(\d+\s*\||\||[\^~])')  # `  566 | expr` and `      |     ~~~^~~~`
 _DIAG_NOTE = re.compile(r'.*:\s*note:\s')
-_MAX_CONTEXT = 5  # an instantiation chain runs dozens deep; the innermost frames are the useful ones
+_MAX_CONTEXT = 5  # an instantiation chain runs dozens deep, and the innermost frames are the useful ones
 _MAX_SNIPPET = 3  # the numbered source line plus its caret line, and one spare for a multi-line caret
 _MAX_NOTES = 2    # clang reports the instantiation site in the notes AFTER the error, not above it
 
@@ -65,8 +55,8 @@ def _diag_context(lines, i):
 
 
 def _diag_snippet(lines, i):
-    """The source snippet the compiler prints under a diagnostic. Returns (snippet, next_i). Leading
-    whitespace is kept, so the caret still points at the right column."""
+    """The source snippet the compiler prints under a diagnostic. Returns (snippet, next_i). Keeps
+    leading whitespace, so the caret still points at the right column."""
     out = []
     while i < len(lines) and len(out) < _MAX_SNIPPET:
         text = _ANSI_RE.sub('', lines[i]).rstrip()
@@ -79,7 +69,7 @@ def _diag_snippet(lines, i):
 def _diag_trailer(lines, i):
     """Everything the compiler prints under a diagnostic: the source snippet, then the `note:` lines with
     their own snippets. Clang reports the instantiation site in those notes rather than above the error,
-    so without them a Clang template failure keeps the same one-line-inside-a-header problem."""
+    so without them a Clang template failure again reads as one line inside a header."""
     out, i = _diag_snippet(lines, i)
     for _ in range(_MAX_NOTES):
         if i >= len(lines): break
@@ -92,10 +82,9 @@ def _diag_trailer(lines, i):
 
 
 def _cmake_body(lines, i):
-    """A cmake diagnostic is a header plus an INDENTED body that ends on a blank pair - scanning by line
-    alone reports a bare 'CMake Warning:' with the actual message thrown away. Always walks to the END of
-    the block - stopping at the cap left the scanner inside it, re-reporting body lines as diagnostics of
-    their own - but keeps only the first _MAX_BODY lines. Returns (body, next_i)."""
+    """A cmake diagnostic is a header plus an INDENTED body that ends on a blank pair. Always walks to
+    the END of the block, so the scanner never re-reports body lines as diagnostics of their own, but
+    keeps only the first _MAX_BODY lines. Returns (body, next_i)."""
     body, j, blanks, dropped = [], i + 1, 0, 0
     while j < len(lines):
         raw = _ANSI_RE.sub('', lines[j]).rstrip()
@@ -113,10 +102,10 @@ def _cmake_body(lines, i):
 
 
 def scan_diagnostics(lines, limit=8):
-    """Pull compiler warning/error diagnostics out of a task's raw output for the post-build summary
+    """Extract compiler warning/error diagnostics from a task's raw output for the post-build summary
     (parallel builds only replay output on failure, so a successful build's diagnostics are lost).
     De-duplicated, errors before warnings, capped to `limit`. Returns (diags, n_err, n_warn) with
-    diags = [(severity, ansi-stripped text)]; a cmake block keeps its body as embedded newlines."""
+    diags = [(severity, ansi-stripped text)]. A cmake block keeps its body as embedded newlines."""
     seen = set(); errs = []; warns = []
     i = 0
     while i < len(lines):
@@ -148,15 +137,15 @@ _PHASE_TAG = {'check': 'git', 'clone': 'git', 'pulling': 'git', 'local': 'loc', 
 
 def _fmt_dur(d: float) -> str:
     """One phase's duration for the timing column, right-aligned to a fixed width so the cfg/bld
-    columns line up across rows. Sub-0.1s shows 2 decimals (`0.03s`) not the noisy `34ms`; 0.1s+
-    uses the shared get_time_str (`0.5s`, `2m 44s`)."""
+    columns line up across rows. Sub-0.1s shows 2 decimals (`0.03s`), not the noisy `34ms`. 0.1s and
+    up uses the shared get_time_str (`0.5s`, `2m 44s`)."""
     s = f'{d:.2f}s' if d < 0.1 else get_time_str(d)
     if s == '0.00s': s = '0.0s'   # an instant phase: 0.0s reads better than an over-precise 0.00s
     return s.rjust(6)
 
 
 class Task:
-    """One dep across its whole workflow. `kind`/`detail`/`start` track the CURRENT phase; `phases`
+    """One dep across its whole workflow. `kind`/`detail`/`start` track the CURRENT phase. `phases`
     accumulates (duration, kind, detail) for each completed phase that did real work, so the final
     summary can show the breakdown. `lines` accumulates across phases for failure replay."""
     def __init__(self, id, kind: str, name: str, start: float, detail: str = ''):
@@ -168,7 +157,7 @@ class Task:
         self.end = None
         self.state = 'run'          # 'run' | 'ok' | 'fail'
         self.cpu = 0.0              # live subprocess-tree CPU% (Linux-style: 8 busy cores ~ 800%)
-        self.lines: list[str] = []  # full raw output, colours intact (for replay)
+        self.lines: list[str] = []  # full raw output, colors intact (for replay)
         self.phase_start = 0        # index in `lines` where the CURRENT phase's output begins
         self.current = ''           # last non-empty line, shown live
         self.phases: list = []      # completed (duration, kind, detail), interesting phases only
@@ -181,8 +170,8 @@ class Task:
 
     def feed(self, line: str):
         # Collapse a run of progress updates (git 'Receiving objects: 0%..100%', a download bar's
-        # per-percent frames) to just its latest line, so a captured clone/download doesn't flood the
-        # buffer (and thus the log + failure replay) with hundreds of updates.
+        # per-percent frames) to just its latest line, so a captured clone or download does not flood
+        # the buffer (and thus the log + failure replay) with hundreds of updates.
         if self.lines and is_progress_line(line) and is_progress_line(self.lines[-1]):
             self.lines[-1] = line
         else:
@@ -205,7 +194,7 @@ class BuildDisplay:
         self._clock = clock          # () -> float
         self._verbose = verbose
         self._color = color
-        self._platform = f'[{platform}] ' if platform else ''  # tells apart parallel builds of different platforms
+        self._platform = f'[{platform}] ' if platform else ''  # separates parallel builds of different platforms
         self._min_interval = min_interval
         self._margin = margin
         self._reveal = reveal_delay  # hide tasks that start+finish faster than this (instant no-ops)
@@ -216,8 +205,8 @@ class BuildDisplay:
         self._drawn = 0                  # active region lines drawn last frame
         self._last_render = 0.0
         self._lock = threading.RLock()        # guards task/region state (held only briefly)
-        self._render_lock = threading.Lock()  # serializes terminal writes; non-forced renders skip if busy
-        self._cpu_sampler = cpu_sampler  # (set[int]) -> float total tree CPU%; None -> auto (psutil)
+        self._render_lock = threading.Lock()  # serializes terminal writes, non-forced renders skip if busy
+        self._cpu_sampler = cpu_sampler  # (set[int]) -> float total tree CPU%. None -> auto (psutil)
         self._cpu_auto = cpu_sampler is None
         self._pids: dict[object, set] = {}  # tid -> live child pids, for CPU sampling
         self._sampler = None             # daemon thread, lazily started on first attach_pid
@@ -263,12 +252,12 @@ class BuildDisplay:
             t = self._tasks.get(id)
             if t is None: return
             t.feed(line)
-        if self._isatty: self.render()  # state lock released first: a slow draw can't stall the subprocess reader
+        if self._isatty: self.render()  # state lock released first: a slow draw cannot stall the subprocess reader
 
     def finish_task(self, id, ok: bool, final: bool = True):
-        # End the current phase. A non-final success stays DORMANT (no summary yet); the dep's last
+        # End the current phase. A non-final success stays DORMANT (no summary yet). The dep's last
         # phase (final=True) or any failure commits ONE merged summary for the whole dep. Every phase
-        # is recorded so the table shows all steps (incl. an instant 0ms configure); only a dep whose
+        # is recorded so the table shows all steps (incl. an instant 0ms configure). Only a dep whose
         # every phase was instant (a pure cached no-op) is hidden.
         with self._lock:
             t = self._tasks.get(id)
@@ -277,7 +266,7 @@ class BuildDisplay:
             t.state = 'ok' if ok else 'fail'
             if id in self._active: self._active.remove(id)
             t.phases.append((t.elapsed(t.end), t.kind, t.detail))
-            done = final or not ok                        # workflow over -> emit; else dormant, resume later
+            done = final or not ok                        # workflow over -> emit, else dormant until resume
             show = done and (not ok or any(d >= self._reveal for d, _, _ in t.phases))  # hide a wholly-instant dep
             if done: self._log_task(t)  # full per-target output -> log, even for deps hidden from the live region
             if not self._isatty:
@@ -295,7 +284,7 @@ class BuildDisplay:
         """Emit a line that survives above the live region (status messages)."""
         if self._log is not None: self._log.write(text + '\n')
         with self._lock:
-            if not self._isatty or self._closed:  # no live region (or it's gone): write it straight out
+            if not self._isatty or self._closed:  # no live region (or it is gone): write it straight out
                 self._writeln(text); return
             self._pending.append(text)
         self.render(force=True)
@@ -309,7 +298,7 @@ class BuildDisplay:
         self._log.write('\n'.join(t.lines) + '\n')
 
     def replay(self, id):
-        """Dump the FAILING phase's captured output permanently (colours intact). Not the whole dep
+        """Dump the FAILING phase's captured output permanently (colors intact). Not the whole dep
         buffer: replaying load/configure output after the build died reads as stale mid-build noise
         long after the fact. The full history is still in mamabuild.log."""
         with self._lock:
@@ -326,9 +315,9 @@ class BuildDisplay:
     # -- rendering ---------------------------------------------------------
 
     def render(self, force=False):
-        """Draw the live frame. A forced render waits for the terminal; a normal one SKIPS if another
-        thread is already drawing (it'll be covered by that draw / the next tick), so feeders never
-        block. State is snapshotted under the short state lock; the terminal write happens off it."""
+        """Draw the live frame. A forced render waits for the terminal. A normal one SKIPS if another
+        thread is already drawing (that draw or the next tick covers it), so feeders never block.
+        The state snapshot happens under the short state lock, and the terminal write happens off it."""
         if not self._isatty or self._closed:
             return
         if force: self._render_lock.acquire()
@@ -369,7 +358,7 @@ class BuildDisplay:
     # -- internals ---------------------------------------------------------
 
     def _clear_region(self):
-        # Cursor sits below the region (after trailing newlines); walk up,
+        # The cursor sits below the region (after trailing newlines). Walk up,
         # erasing each line, to land at the region's top-left.
         if self._drawn:
             self._out.write((_CURSOR_UP + '\r' + _ERASE_EOL) * self._drawn)
@@ -380,7 +369,7 @@ class BuildDisplay:
         cap = max(1, rows - self._margin)
         ids = [i for i in self._active if self._tasks[i].elapsed(now) >= self._reveal]  # past reveal delay
         lines = [self._task_line(self._tasks[i], now, cols) for i in ids]
-        if self._pending_hint:  # the single next blocked task + why, so a stall is visible at a glance
+        if self._pending_hint:  # the single next blocked task + why, so a stall is visible
             lines.append(self._pending_line(self._pending_hint[0], self._pending_hint[1], cols))
         if len(lines) > cap:
             lines[cap - 1:] = [self._truncate(f'  ... (+{len(lines) - (cap - 1)} more)', cols)]
@@ -408,9 +397,9 @@ class BuildDisplay:
 
     def _task_line(self, t: Task, now: float, cols: int) -> str:
         icon = self._colored(_ICON[t.state], _ICON_COLOR[t.state])
-        preview = _ANSI_RE.sub('', t.current)  # strip colours so width math is correct
+        preview = _ANSI_RE.sub('', t.current)  # strip colors so width math is correct
         head = f'{icon} {self._kind_field(t.kind, t.detail, t.cpu):<24}{t.name:<22} {self._time_field(t, now)}  '
-        return self._truncate((head + preview).rstrip(), cols)  # rstrip: no trailing pad when there's no preview yet
+        return self._truncate((head + preview).rstrip(), cols)  # rstrip: no trailing pad when there is no preview yet
 
     def _summary_line(self, t: Task) -> str:
         icon = self._colored(_ICON[t.state], _ICON_COLOR[t.state])
@@ -421,7 +410,7 @@ class BuildDisplay:
 
     def attach_pid(self, tid, pid: int):
         """Register a running child pid so the sampler can attribute its process-tree CPU to `tid`.
-        Only build tasks are sampled - a CPU% on a configure/clone/update step is noise and wasted work."""
+        The sampler covers only build tasks: a CPU% on a configure/clone/update step is noise."""
         with self._lock:
             t = self._tasks.get(tid)
             if t is None or t.kind != 'build': return
@@ -449,7 +438,7 @@ class BuildDisplay:
             self._sampler.start()
 
     def _next_wait(self, sample_cost: float) -> float:
-        # back off when a sample is expensive (busy host, huge process table) so CPU sampling can never
+        # wait longer when a sample is expensive (busy host, huge process table) so CPU sampling can never
         # exceed ~10% of wall-time - a hard cap against starving the build threads (cost*9 -> 1-in-10).
         return max(self._sample_interval, sample_cost * 9)
 
@@ -466,21 +455,21 @@ class BuildDisplay:
         with self._lock:
             snapshot = {tid: set(pids) for tid, pids in self._pids.items() if pids}
         if not snapshot: return
-        cpus = self._cpu_sampler(snapshot)  # ONE process scan for ALL build trees -> {tid: cpu%}; off-lock
+        cpus = self._cpu_sampler(snapshot)  # ONE process scan for ALL build trees -> {tid: cpu%}, off-lock
         with self._lock:
             for tid, cpu in cpus.items():
-                if tid not in self._pids: continue  # detached mid-scan: don't resurrect a dead task's CPU
+                if tid not in self._pids: continue  # detached mid-scan: do not resurrect a dead task's CPU
                 t = self._tasks.get(tid)
                 if t is not None: t.cpu = cpu
 
     def _truncate(self, text: str, cols: int) -> str:
-        # Cap to cols-1 to avoid wrapping that would break the cursor math. If it
-        # fits, keep colours; if not, truncate the plain text (drops the icon colour).
+        # Cap to cols-1 to avoid wrapping that would break the cursor math. If it fits, keep colors.
+        # If not, truncate the plain text, which drops the icon color.
         # Neutralize every control character first. ONE stray \n shifts the cursor and strands every
         # finished task line on screen. A child's OWN live display (a nested `mama` bootstrap, ninja,
         # aqtinstall) smuggles \x1b[1A and \x1b[2K in the same way. A tab breaks the same math: it counts as one
         # character and renders up to eight columns, so the line wraps. GNU make tags every line with one.
-        # Colour is width-free, and survives.
+        # Color is width-free, and survives.
         text = _CTRL_RE.sub(' ', text)
         if '\x1b' in text: text = _ESC_RE.sub(lambda m: m[0] if m[0].endswith('m') else '', text)
         limit = max(1, cols - 1)

--- a/mama/utils/build_display.py
+++ b/mama/utils/build_display.py
@@ -14,8 +14,7 @@ _ERASE_EOL_LF = _ERASE_EOL + '\n'  # clear-to-EOL then newline: one written task
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*m')  # SGR color codes, for width-correct previews
 _ESC_RE = re.compile(r'\x1b\[[0-9;?]*[A-Za-z]|\x1b.')  # any escape sequence, color codes included
 _CTRL_RE = re.compile(r'[\x00-\x1a\x1c-\x1f\x7f]')  # every C0 control except ESC, which _ESC_RE handles
-# A diagnostic line: MSVC 'warning C4996:' / 'error C2065:' / 'error LNK2019:', GCC/Clang 'warning:' /
-# 'error:', and CMake's 'CMake Error at <file>', which has no colon and so needs its own alternative.
+# Matches MSVC 'error C2065:', GCC/Clang 'warning:' / 'error:', and CMake's colon-less 'CMake Error at <file>'.
 # The \b guards keep -Werror, std::error_code and '0 errors' from matching.
 _DIAG_RE = re.compile(r'\bcmake\s+(?P<cm>error|warning)\b|\b(?P<sev>error|warning)\b\s*(?:[A-Za-z]+[0-9]+)?\s*:',
                       re.IGNORECASE)
@@ -24,11 +23,9 @@ _DIAG_RE = re.compile(r'\bcmake\s+(?P<cm>error|warning)\b|\b(?P<sev>error|warnin
 _CMAKE_HEAD = re.compile(r'^cmake\s+(error|warning)\b', re.IGNORECASE)
 _MAX_BODY = 8  # continuation lines kept per cmake block, so one chatty warning cannot bury the rest
 
-# GCC and Clang wrap a diagnostic in context. The lines BEFORE it name the call site, which is where
-# the bug usually is. The numbered source snippet AFTER it shows the expression that broke. Without
-# both, a diagnostic reads as one line that points deep inside a header nobody edited.
-# The `In function` header carries no file prefix when it opens an inlining chain, so the prefix is
-# optional here. `inlined from` and `from` are its indented continuation lines.
+# Keep the context BEFORE a diagnostic (the call site) and the numbered snippet AFTER it (the broken
+# expression), or a diagnostic reads as one line that points deep inside a header nobody edited.
+# An `In function` header that opens an inlining chain carries no file prefix, so the prefix is optional here.
 _DIAG_ROLE = (r'In (instantiation of|substitution of|(static |member |lambda )*function|constructor|destructor)\b'
               r'|At global scope:')
 _DIAG_CONTEXT = re.compile(r'^(In file included from |\s+(inlined )?from \S'
@@ -55,8 +52,7 @@ def _diag_context(lines, i):
 
 
 def _diag_snippet(lines, i):
-    """The source snippet the compiler prints under a diagnostic. Returns (snippet, next_i). Keeps
-    leading whitespace, so the caret still points at the right column."""
+    """The source snippet under a diagnostic, whitespace kept so the caret column stays right. Returns (snippet, next_i)."""
     out = []
     while i < len(lines) and len(out) < _MAX_SNIPPET:
         text = _ANSI_RE.sub('', lines[i]).rstrip()
@@ -67,9 +63,8 @@ def _diag_snippet(lines, i):
 
 
 def _diag_trailer(lines, i):
-    """Everything the compiler prints under a diagnostic: the source snippet, then the `note:` lines with
-    their own snippets. Clang reports the instantiation site in those notes rather than above the error,
-    so without them a Clang template failure again reads as one line inside a header."""
+    """The source snippet under a diagnostic, then the `note:` lines with their own snippets. Returns (out, next_i).
+    Clang reports the instantiation site in those notes, not above the error, so they must survive."""
     out, i = _diag_snippet(lines, i)
     for _ in range(_MAX_NOTES):
         if i >= len(lines): break
@@ -82,9 +77,8 @@ def _diag_trailer(lines, i):
 
 
 def _cmake_body(lines, i):
-    """A cmake diagnostic is a header plus an INDENTED body that ends on a blank pair. Always walks to
-    the END of the block, so the scanner never re-reports body lines as diagnostics of their own, but
-    keeps only the first _MAX_BODY lines. Returns (body, next_i)."""
+    """A cmake diagnostic is a header plus an INDENTED body that ends on a blank pair. Returns (body, next_i).
+    Walks to the END of the block, so the scanner never re-reports body lines, but keeps only _MAX_BODY lines."""
     body, j, blanks, dropped = [], i + 1, 0, 0
     while j < len(lines):
         raw = _ANSI_RE.sub('', lines[j]).rstrip()
@@ -102,10 +96,11 @@ def _cmake_body(lines, i):
 
 
 def scan_diagnostics(lines, limit=8):
-    """Extract compiler warning/error diagnostics from a task's raw output for the post-build summary
-    (parallel builds only replay output on failure, so a successful build's diagnostics are lost).
-    De-duplicated, errors before warnings, capped to `limit`. Returns (diags, n_err, n_warn) with
-    diags = [(severity, ansi-stripped text)]. A cmake block keeps its body as embedded newlines."""
+    """Extract compiler diagnostics for the post-build summary (a parallel build replays output only on failure).
+    Returns (diags, n_err, n_warn) with diags = [(severity, ansi-stripped text)], de-duplicated, errors
+    before warnings. A cmake block keeps its body as embedded newlines.
+    lines: the task's raw captured output lines
+    limit: max diagnostics returned"""
     seen = set(); errs = []; warns = []
     i = 0
     while i < len(lines):
@@ -129,25 +124,23 @@ def scan_diagnostics(lines, limit=8):
 
 _ICON = {'run': '*', 'ok': '+', 'fail': 'x'}
 _ICON_COLOR = {'run': Color.BLUE, 'ok': Color.GREEN, 'fail': Color.RED}
-# Short lowercase tag per phase for the timing breakdown (lowercase stands out between the times):
-# git for any git load (check/clone/pull), loc local source, art artifactory, cfg configure, bld build.
+# Short tag per phase for the timing breakdown (lowercase stands out between the times):
+# git any git load, loc local source, art artifactory, cfg configure, bld build.
 _PHASE_TAG = {'check': 'git', 'clone': 'git', 'pulling': 'git', 'local': 'loc', 'artifactory': 'art',
               'configure': 'cfg', 'build': 'bld'}
 
 
 def _fmt_dur(d: float) -> str:
-    """One phase's duration for the timing column, right-aligned to a fixed width so the cfg/bld
-    columns line up across rows. Sub-0.1s shows 2 decimals (`0.03s`), not the noisy `34ms`. 0.1s and
-    up uses the shared get_time_str (`0.5s`, `2m 44s`)."""
+    """One phase's duration, right-aligned to a fixed width so the timing columns line up across rows.
+    Sub-0.1s shows 2 decimals (`0.03s`), 0.1s and up uses the shared get_time_str (`0.5s`, `2m 44s`)."""
     s = f'{d:.2f}s' if d < 0.1 else get_time_str(d)
     if s == '0.00s': s = '0.0s'   # an instant phase: 0.0s reads better than an over-precise 0.00s
     return s.rjust(6)
 
 
 class Task:
-    """One dep across its whole workflow. `kind`/`detail`/`start` track the CURRENT phase. `phases`
-    accumulates (duration, kind, detail) for each completed phase that did real work, so the final
-    summary can show the breakdown. `lines` accumulates across phases for failure replay."""
+    """One dep across its whole workflow. `kind`/`detail`/`start` track the CURRENT phase. `phases` holds
+    each completed phase that did real work, and `lines` accumulates across phases for failure replay."""
     def __init__(self, id, kind: str, name: str, start: float, detail: str = ''):
         self.id = id
         self.kind = kind            # current phase: 'check' | 'configure' | 'build' | ...
@@ -169,9 +162,8 @@ class Task:
         self.phase_start = len(self.lines)  # replay shows THIS phase, not the whole dep's history
 
     def feed(self, line: str):
-        # Collapse a run of progress updates (git 'Receiving objects: 0%..100%', a download bar's
-        # per-percent frames) to just its latest line, so a captured clone or download does not flood
-        # the buffer (and thus the log + failure replay) with hundreds of updates.
+        # Collapse a run of progress updates to just the latest line, so a captured clone or download
+        # does not flood the buffer (and thus the log + failure replay) with hundreds of updates.
         if self.lines and is_progress_line(line) and is_progress_line(self.lines[-1]):
             self.lines[-1] = line
         else:
@@ -221,9 +213,8 @@ class BuildDisplay:
     # -- task lifecycle ----------------------------------------------------
 
     def start_task(self, id, kind: str, name: str, detail: str = '') -> Task:
-        # Create on the first phase, else RESUME the existing dep task on a new phase (so check ->
-        # configure -> build stay one line). Either way INVISIBLE until it outlives reveal_delay, so
-        # an instant no-op (~0.0s cached dep) never clutters output.
+        # Create on the first phase, else RESUME the existing dep task, so check -> configure -> build stay
+        # one line. Either way INVISIBLE until it outlives reveal_delay, so an instant no-op never clutters.
         with self._lock:
             t = self._tasks.get(id)
             if t is None: t = self._tasks[id] = Task(id, kind, name, self._clock(), detail)
@@ -240,8 +231,7 @@ class BuildDisplay:
 
     def set_pending(self, hint):
         """Show the single next blocked task `(name, reason)` below the live region, or clear it (None).
-        Renders on change so the line updates even when nothing else draws - the stalled-scheduler case
-        the user most wants to see."""
+        Renders on change, so a stalled scheduler stays visible even when nothing else draws."""
         with self._lock:
             if hint == self._pending_hint: return
             self._pending_hint = hint
@@ -255,10 +245,9 @@ class BuildDisplay:
         if self._isatty: self.render()  # state lock released first: a slow draw cannot stall the subprocess reader
 
     def finish_task(self, id, ok: bool, final: bool = True):
-        # End the current phase. A non-final success stays DORMANT (no summary yet). The dep's last
-        # phase (final=True) or any failure commits ONE merged summary for the whole dep. Every phase
-        # is recorded so the table shows all steps (incl. an instant 0ms configure). Only a dep whose
-        # every phase was instant (a pure cached no-op) is hidden.
+        # End the current phase. A non-final success stays DORMANT, the dep's last phase or any failure
+        # commits ONE merged summary. Every phase is recorded so the table shows all steps, but a dep
+        # whose every phase was instant (a pure cached no-op) is hidden.
         with self._lock:
             t = self._tasks.get(id)
             if t is None: return
@@ -290,17 +279,15 @@ class BuildDisplay:
         self.render(force=True)
 
     def _log_task(self, t: Task):
-        """Write a target's whole captured buffer to the build log as ONE contiguous block (all phases,
-        verbatim) so the log has the full configure/build output the live region only previews, never
-        intermixed across parallel targets."""
+        """Write a target's whole captured buffer to the build log as ONE contiguous block, never intermixed
+        across parallel targets. The log then has the full output the live region only previews."""
         if self._log is None or not t.lines: return
         self._log.write(f'\n{"=" * 100}\n{self._summary_line(t)}\n{"-" * 100}\n')
         self._log.write('\n'.join(t.lines) + '\n')
 
     def replay(self, id):
-        """Dump the FAILING phase's captured output permanently (colors intact). Not the whole dep
-        buffer: replaying load/configure output after the build died reads as stale mid-build noise
-        long after the fact. The full history is still in mamabuild.log."""
+        """Dump the FAILING phase's captured output permanently (colors intact). Not the whole dep buffer:
+        an earlier phase replays as stale noise. The full history is still in mamabuild.log."""
         with self._lock:
             t = self._tasks.get(id)
             if t is None: return
@@ -315,9 +302,9 @@ class BuildDisplay:
     # -- rendering ---------------------------------------------------------
 
     def render(self, force=False):
-        """Draw the live frame. A forced render waits for the terminal. A normal one SKIPS if another
-        thread is already drawing (that draw or the next tick covers it), so feeders never block.
-        The state snapshot happens under the short state lock, and the terminal write happens off it."""
+        """Draw the live frame. A forced render waits for the terminal, a normal one SKIPS if another thread
+        already draws, so feeders never block. The state snapshot goes under the short state lock, the
+        terminal write off it."""
         if not self._isatty or self._closed:
             return
         if force: self._render_lock.acquire()
@@ -343,8 +330,7 @@ class BuildDisplay:
         """Finalize: stop the CPU sampler, flush any pending permanent lines, drop the live region."""
         self._stop.set()
         if self._sampler is not None: self._sampler.join(timeout=1.0)  # join off-lock: sampler takes it
-        # take the render lock too: a slow sampler scan can outlive the join, and its render would
-        # otherwise redraw the region UNDER the final output with _drawn already reset to 0
+        # take the render lock too: a sampler render that outlives the join would redraw the region UNDER the final output
         with self._render_lock, self._lock:
             self._closed = True
             if self._isatty:
@@ -358,8 +344,7 @@ class BuildDisplay:
     # -- internals ---------------------------------------------------------
 
     def _clear_region(self):
-        # The cursor sits below the region (after trailing newlines). Walk up,
-        # erasing each line, to land at the region's top-left.
+        # the cursor sits below the region: walk up, erasing each line, to land at the region's top-left
         if self._drawn:
             self._out.write((_CURSOR_UP + '\r' + _ERASE_EOL) * self._drawn)
             self._drawn = 0
@@ -390,8 +375,7 @@ class BuildDisplay:
         return _PHASE_TAG.get(kind, (kind[:3] or '?').lower())
 
     def _time_field(self, t: Task, now: float) -> str:
-        # Always tag every phase (even a lone build -> 'bld 4.0s'), so the timing column stays
-        # consistent whether or not configure/load did visible work.
+        # tag every phase, even a lone build -> 'bld 4.0s', so the timing column stays consistent
         phases = t.phases + ([(t.elapsed(now), t.kind, t.detail)] if t.state == 'run' else [])
         return self._platform + '  '.join(f'{self._tag(k)} {_fmt_dur(d)}' for d, k, _ in phases)
 
@@ -438,8 +422,7 @@ class BuildDisplay:
             self._sampler.start()
 
     def _next_wait(self, sample_cost: float) -> float:
-        # wait longer when a sample is expensive (busy host, huge process table) so CPU sampling can never
-        # exceed ~10% of wall-time - a hard cap against starving the build threads (cost*9 -> 1-in-10).
+        # wait longer when a sample is expensive, so sampling never exceeds ~10% of wall-time (cost*9 -> 1-in-10)
         return max(self._sample_interval, sample_cost * 9)
 
     def _sample_loop(self):
@@ -463,13 +446,9 @@ class BuildDisplay:
                 if t is not None: t.cpu = cpu
 
     def _truncate(self, text: str, cols: int) -> str:
-        # Cap to cols-1 to avoid wrapping that would break the cursor math. If it fits, keep colors.
-        # If not, truncate the plain text, which drops the icon color.
-        # Neutralize every control character first. ONE stray \n shifts the cursor and strands every
-        # finished task line on screen. A child's OWN live display (a nested `mama` bootstrap, ninja,
-        # aqtinstall) smuggles \x1b[1A and \x1b[2K in the same way. A tab breaks the same math: it counts as one
-        # character and renders up to eight columns, so the line wraps. GNU make tags every line with one.
-        # Color is width-free, and survives.
+        # Cap to cols-1: a wrapped line breaks the cursor math. A fitting line keeps its colors, an over-long
+        # one truncates as plain text. Neutralize control characters and non-color escapes first: one stray
+        # \n, cursor-move escape or multi-column tab shifts the cursor and strands finished task lines.
         text = _CTRL_RE.sub(' ', text)
         if '\x1b' in text: text = _ESC_RE.sub(lambda m: m[0] if m[0].endswith('m') else '', text)
         limit = max(1, cols - 1)

--- a/mama/utils/dir_lock.py
+++ b/mama/utils/dir_lock.py
@@ -27,12 +27,13 @@ else:
 
 @contextlib.contextmanager
 def interprocess_dir_lock(lock_dir: str, timeout: float, poll: float = 0.1):
-    """Hold an exclusive cross-process lock on `lock_dir` for the `with` block. Yields True on acquire, or
-    False when the acquire timed out after `timeout` seconds. A timed-out caller still runs, unlocked.
-    Always releases on exit. Different `lock_dir`s never contend, so loads of different deps stay parallel."""
-    # The sidecar lives beside lock_dir, never inside it: a reclone wipe removes the whole lock_dir, and a lock
-    # file deleted while held unlinks its inode, so the next opener makes a fresh inode and exclusion silently
-    # breaks. The parent location survives a wipe of the directory it guards.
+    """Hold an exclusive cross-process lock on `lock_dir` for the `with` block. Yields True on acquire, else
+    False on timeout, and a timed-out caller still runs, unlocked. Always releases on exit.
+    lock_dir: the directory to guard. Different lock_dirs never contend, so loads of different deps stay parallel
+    timeout: seconds to wait for the lock
+    poll: seconds between lock attempts"""
+    # The sidecar lives beside lock_dir, never inside it: a lock file wiped while held unlinks its inode,
+    # so the next opener makes a fresh inode and exclusion silently breaks.
     lock_dir = os.path.normpath(lock_dir)
     parent = os.path.dirname(lock_dir) or '.'
     os.makedirs(parent, exist_ok=True)

--- a/mama/utils/dir_lock.py
+++ b/mama/utils/dir_lock.py
@@ -1,7 +1,5 @@
-"""Cross-process advisory lock on a directory, via an flock/msvcrt lock on a sidecar `.mama.lock` file. The
-kernel releases the lock when the fd closes or the process dies, so - unlike an O_CREAT|O_EXCL lockfile - a
-crash can NEVER leave it stuck. Non-blocking with a bounded poll timeout: a live-but-hung holder delays a
-waiter at most `timeout` seconds, after which it proceeds unlocked (risking the original race, never a hang)."""
+"""Cross-process advisory lock on a directory, held as an flock/msvcrt lock on a sidecar `.mama.lock` file.
+The kernel releases the lock when the fd closes or the process dies, so a crash can never leave it stuck."""
 import contextlib, os, time
 from .system import System, warning
 
@@ -29,12 +27,12 @@ else:
 
 @contextlib.contextmanager
 def interprocess_dir_lock(lock_dir: str, timeout: float, poll: float = 0.1):
-    """Hold an exclusive cross-process lock for `lock_dir` for the duration of the `with` block. Yields True if
-    the lock was acquired, False if the acquire timed out (the caller still runs - best-effort). Always releases
-    on exit. Different `lock_dir`s never contend, so parallel loads of DIFFERENT deps run fully concurrently."""
-    # The sidecar lives BESIDE lock_dir, never inside it: a reclone-wipe rmtree's the whole lock_dir, and a lock
-    # file deleted while held unlinks its inode - the next opener would make a fresh inode and exclusion silently
-    # breaks. Keeping it in the parent means it survives a wipe of the very dir it guards.
+    """Hold an exclusive cross-process lock on `lock_dir` for the `with` block. Yields True on acquire, or
+    False when the acquire timed out after `timeout` seconds. A timed-out caller still runs, unlocked.
+    Always releases on exit. Different `lock_dir`s never contend, so loads of different deps stay parallel."""
+    # The sidecar lives beside lock_dir, never inside it: a reclone wipe removes the whole lock_dir, and a lock
+    # file deleted while held unlinks its inode, so the next opener makes a fresh inode and exclusion silently
+    # breaks. The parent location survives a wipe of the directory it guards.
     lock_dir = os.path.normpath(lock_dir)
     parent = os.path.dirname(lock_dir) or '.'
     os.makedirs(parent, exist_ok=True)

--- a/mama/utils/gdb.py
+++ b/mama/utils/gdb.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:
 
 
 def filter_gdb_arg(args: str, default_gdb=False) -> Tuple[str, bool]:
+    """Strip a leading 'gdb' or 'nogdb' token. Returns (remaining_args, use_gdb).
+    args: the command arguments to filter
+    default_gdb: the use_gdb result when args does not choose"""
     if 'nogdb' == args: return '', False
     if 'nogdb ' in args: return args.replace('nogdb ', ''), False
     if 'gdb' == args: return '', True
@@ -25,6 +28,11 @@ def _is_running_leak_sanitizer(target: BuildTarget):
 
 
 def run_gdb(target: BuildTarget, command: str, src_dir=True):
+    """Run an executable under the platform debugger, with a backtrace on crash. A leak or address
+    sanitizer build runs without the debugger, which would disable LEAK detection.
+    target: the BuildTarget whose platform and directories apply
+    command: the executable and its arguments
+    src_dir: if True, the command runs relative to the source dir, else the build dir"""
     platform = target.config.platform
     if not platform.is_host_runnable:
         console(f'Cannot run tests for a {platform.name} build: this machine cannot execute them.')

--- a/mama/utils/gdb.py
+++ b/mama/utils/gdb.py
@@ -28,7 +28,7 @@ def run_gdb(target: BuildTarget, command: str, src_dir=True):
     platform = target.config.platform
     if not platform.is_host_runnable:
         console(f'Cannot run tests for a {platform.name} build: this machine cannot execute them.')
-        return # nothing to run
+        return
 
     root_dir = target.source_dir() if src_dir else target.build_dir()
     if target.msvc and not src_dir:
@@ -44,7 +44,7 @@ def run_gdb(target: BuildTarget, command: str, src_dir=True):
         # b: batch, q: quiet, -o r: run, -k bt: on crash backtrace, -k q: on crash quit
         debugger = f'lldb -b -o r -k bt -k q  -- {exe} {args}'
     elif tool == 'gdb':
-        # r: run;  bt: give backtrace;  q: quit when done;
+        # r: run, bt: print backtrace, q: quit when done
         debugger = f'gdb -batch -return-child-result -ex=r -ex=bt -ex=q --args {exe} {args}'
     else:
         debugger = f'{exe} {args}'

--- a/mama/utils/gnu_project.py
+++ b/mama/utils/gnu_project.py
@@ -14,16 +14,12 @@ if TYPE_CHECKING:
 class BuildProduct:
     """ One build product of a project, and where to deploy it """
     def __init__(self, built_path:str, deploy_path:str=None, strip=None, is_dir=False):
-        """
-            - built_path: where the built file exists.
-                          Supported project variables {{installed}}, {{source}}, {{build}}
-            - deploy_path: where to deploy the file, or None when no deploy is needed
-            - strip: whether to strip the binary on deploy
-            - is_dir: whether built_path is a directory
-        """
+        """built_path: where the built file exists, supports the variables {{installed}}, {{source}}, {{build}}
+        deploy_path: where to deploy the file, or None when no deploy is needed
+        strip: whether to strip the binary on deploy, default strips files but not directories
+        is_dir: whether built_path is a directory"""
         self.built_path = built_path
         self.deploy_path = deploy_path
-        # default when strip is not given: strip files, do not strip directories
         self.strip = strip if strip != None else not is_dir
         self.is_dir = is_dir
 
@@ -45,17 +41,14 @@ class GnuProject:
                  build_products=[],
                  autogen=False,
                  configure='configure'):
-        """
-        - target: mama.BuildTarget that builds this GnuProject and collects the build products
-        - name: name of the project, e.g. 'gmp'
-        - version: version of the project, e.g. '6.2.1'
-        - url: url to download the project, e.g. 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
-        - git: git repository to clone the project from
-        - build_products: the final products, e.g. [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
-                          Supported project variables {{installed}}, {{source}}, {{build}}
-        - autogen: whether to run ./autogen.sh before ./configure
-        - configure: the configure command, 'configure' by default, but can be 'make config' etc
-        """
+        """target: the mama.BuildTarget that builds this GnuProject and collects the build products
+        name: the project name, e.g. 'gmp'
+        version: the project version, e.g. '6.2.1'
+        url: url to download the project, e.g. 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
+        git: git repository to clone the project from
+        build_products: BuildProduct or list, paths support the variables {{installed}}, {{source}}, {{build}}
+        autogen: whether to run ./autogen.sh before ./configure
+        configure: the configure command, 'configure' by default, but can be 'make config' etc"""
         self.target = target
         self.name = name
         self.version = version
@@ -163,9 +156,7 @@ class GnuProject:
 
 
     def checkout_code(self):
-        """
-        Gets the source code: downloads and extracts the archive, or clones the git repository.
-        """
+        """ Gets the source code: downloads and extracts the archive, or clones the git repository """
         source = self.source_dir()
         configure_file = self.get_configure_file()
         autogen_file = f'{self.source_dir()}/autogen.sh' if self.autogen else ''
@@ -234,12 +225,10 @@ class GnuProject:
 
 
     def configure(self, options='', autogen_opts='', prefix=''):
-        """
-        Only configures the project, which generates the Makefile
-            - options: extra options for the configure script
-            - autogen_opts: extra options for ./autogen.sh when autogen is enabled
-            - prefix: install prefix argument, defaults to '--prefix {install_dir()}'
-        """
+        """Only configures the project, which generates the Makefile.
+        options: extra options for the configure script
+        autogen_opts: extra options for ./autogen.sh when autogen is enabled
+        prefix: install prefix argument, defaults to '--prefix {install_dir()}'"""
         console(f'>>> Configuring {self.name}', color=Color.GREEN)
         self.configure_env()
 
@@ -276,11 +265,9 @@ class GnuProject:
 
 
     def make(self, opts='', multithreaded=False):
-        """
-        Only makes the project
-            - opts: extra options for make
-            - multithreaded: if True, adds the -j option to build with multiple threads
-        """
+        """Only makes the project.
+        opts: extra options for make
+        multithreaded: if True, adds the -j option to build with multiple threads"""
         make_opts = self._get_make_opts(opts, multithreaded)
         console(f'>>> Make {self.name} {make_opts}', color=Color.GREEN)
         self.configure_env()
@@ -289,7 +276,8 @@ class GnuProject:
 
 
     def install(self, no_prefix=False):
-        """ Only installs the project. no_prefix=True omits the PREFIX= make argument """
+        """Only installs the project. Returns the install dir.
+        no_prefix: if True, omits the PREFIX= make argument"""
         console(f'>>> Installing {self.name}', color=Color.GREEN)
         self.configure_env()
         prefix = '' if no_prefix else f'PREFIX={self.install_dir()}'
@@ -301,14 +289,12 @@ class GnuProject:
 
     def build(self, options='', make_opts='', prefix='',
               multithreaded=False, install=True):
-        """
-        Downloads, extracts, configures, makes and installs the project
-            - options: extra options for the configure script
-            - make_opts: extra options for make
-            - prefix: install prefix argument, see configure()
-            - multithreaded: if True, adds the -j option to build with multiple threads
-            - install: if True, also runs the install step
-        """
+        """Downloads, extracts, configures, makes and installs the project.
+        options: extra options for the configure script
+        make_opts: extra options for make
+        prefix: install prefix argument, see configure()
+        multithreaded: if True, adds the -j option to build with multiple threads
+        install: if True, also runs the install step"""
         project_dir = self.source_dir()
         autoconf_makefile = f'{project_dir}/Makefile' if self.configure_command == 'configure' else None
         try:
@@ -353,7 +339,10 @@ class GnuProject:
 
 
     def deploy(self, src_path:str, dest_path=None, strip=False):
-        """ Deploys src_path to dest_path, and optionally strips the binary """
+        """Deploys src_path to dest_path.
+        src_path: the file to deploy, supports the variables {{installed}}, {{source}}, {{build}}
+        dest_path: the deploy target, defaults to src_path
+        strip: if True, strips the binary on deploy"""
         if not src_path:
             raise RuntimeError('src_path must be specified')
 
@@ -373,7 +362,10 @@ class GnuProject:
 
 
     def deploy_dir(self, src_dir, dest_dir, strip=False):
-        """ Deploys every file under src_dir into dest_dir, and optionally strips them """
+        """Deploys every file under src_dir into dest_dir.
+        src_dir: the directory to deploy, supports the variables {{installed}}, {{source}}, {{build}}
+        dest_dir: the deploy target directory
+        strip: if True, strips each deployable binary"""
         src_dir = self.get_parsed_path(src_dir)
         if not os.path.exists(src_dir):
             raise Exception(f'Failed to deploy from {src_dir}, directory does not exist')

--- a/mama/utils/gnu_project.py
+++ b/mama/utils/gnu_project.py
@@ -12,33 +12,32 @@ if TYPE_CHECKING:
 ######################################################################################
 
 class BuildProduct:
-    """ Represents the build product of a project that should be deployed """
+    """ One build product of a project, and where to deploy it """
     def __init__(self, built_path:str, deploy_path:str=None, strip=None, is_dir=False):
         """
             - built_path: where the built file exists.
                           Supported project variables {{installed}}, {{source}}, {{build}}
-            - deploy_path where the file should be deployed, can be None if no deploy needed
-            - strip: whether to strip the binary when deploying
-            - is_dir: whether the built_path is a directory
+            - deploy_path: where to deploy the file, or None when no deploy is needed
+            - strip: whether to strip the binary on deploy
+            - is_dir: whether built_path is a directory
         """
         self.built_path = built_path
         self.deploy_path = deploy_path
-        # if strip option is specified, then use it,
-        # otherwise default to strip=True for files and strip=False for dirs
+        # default when strip is not given: strip files, do not strip directories
         self.strip = strip if strip != None else not is_dir
         self.is_dir = is_dir
 
 ######################################################################################
 
 class GnuProject:
-    """ 
-    Helper utility class for compiling GNU projects.
-    This will enable downloading, unzipping and building GNU projects.
+    """
+    Helper for GNU projects: download or clone, configure, make and install.
 
     Example usage:
     ```
     gmp = GnuProject(target, 'gmp', '6.2.1', 'https://gmplib.org/download/gmp/{{project}}.tar.xz', 'lib/libgmp.a')
     gmp.build()
+    ```
     """
     def __init__(self, target:BuildTarget, name:str, version:str,
                  url:str='',
@@ -47,15 +46,15 @@ class GnuProject:
                  autogen=False,
                  configure='configure'):
         """
-        - target: mama.BuildTarget building this GnuProject and collecting the build products
-        - name: name of the project, eg 'gmp'
-        - version: version of the project, eg '6.2.1'
-        - url: url to download the project, eg 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
-        - git: git to clone the project from
-        - build_products: the final products to build, eg [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
+        - target: mama.BuildTarget that builds this GnuProject and collects the build products
+        - name: name of the project, e.g. 'gmp'
+        - version: version of the project, e.g. '6.2.1'
+        - url: url to download the project, e.g. 'https://gmplib.org/download/gmp/{{project}}.tar.xz'
+        - git: git repository to clone the project from
+        - build_products: the final products, e.g. [BuildProduct('{{installed}}/lib/libgmp.a', 'mypath/libgmp.a')].
                           Supported project variables {{installed}}, {{source}}, {{build}}
-        - autogen: whether to use ./autogen.sh before running ./configure
-        - configure: the configuration command, by default 'configure' but can be 'make config' etc
+        - autogen: whether to run ./autogen.sh before ./configure
+        - configure: the configure command, 'configure' by default, but can be 'make config' etc
         """
         self.target = target
         self.name = name
@@ -75,22 +74,21 @@ class GnuProject:
         # the --host triple for a cross build, '' for a native one
         self.host = self.target.config.platform.gnu_host_triple()
 
-        # the configure command, by default it's 'configure'
-        # however using something other than 'configure' will completely override it
+        # any value other than 'configure' fully replaces the generated ./configure command line
         self.configure_command = configure
         # extra environment variables to set when running the project
         self.extra_env = {}
 
 
     def source_dir(self, subpath=''):
-        """ Where the project is extracted to, eg project/mips/gdb-13.2 """
+        """ Where the project extracts to, e.g. project/mips/gdb-13.2 """
         if subpath:
             return self.target.build_dir(self.name_with_version + '/' + subpath)
         return self.target.build_dir(self.name_with_version)
 
 
     def install_dir(self, subpath=''):
-        """ Where the project is installed to, eg project/mips/gdb-built """
+        """ Where the project installs to, e.g. project/mips/gdb-built """
         if subpath:
             return self.target.build_dir(self.name + self.install_dir_suffix + '/' + subpath)
         return self.target.build_dir(self.name + self.install_dir_suffix)
@@ -101,7 +99,7 @@ class GnuProject:
 
 
     def get_parsed_path(self, path:str):
-        """ Parses the path with the project variables: {{installed}}, {{source}}, {{build}} """
+        """ Expands the project variables {{installed}}, {{source}} and {{build}} in the path """
         if '{{installed}}' in path:
             path = path.replace('{{installed}}', self.install_dir())
         if '{{source}}' in path:
@@ -112,7 +110,7 @@ class GnuProject:
 
 
     def should_build(self):
-        """ Returns True if any deployed files or any built files are missing """
+        """ Returns True when a built product is missing, unless every deploy target already exists """
         if self.has_deployables() and not self.should_deploy():
             return False
         for p in self.build_products:
@@ -122,7 +120,7 @@ class GnuProject:
 
 
     def should_deploy(self):
-        """ Returns True if any of the deployed files are missing """
+        """ Returns True when any deploy target is missing """
         for f in self.build_products:
             if f.deploy_path and not os.path.exists(f.deploy_path):
                 return True
@@ -130,7 +128,7 @@ class GnuProject:
 
 
     def has_deployables(self):
-        """ Returns True if any of the build products have a deploy path """
+        """ Returns True when any build product has a deploy path """
         for f in self.build_products:
             if f.deploy_path:
                 return True
@@ -138,7 +136,7 @@ class GnuProject:
 
 
     def deploy_all_products(self, force=False):
-        """ Deploys all built products if needed """
+        """ Deploys every build product when a deploy target is missing, or always when force=True """
         if force or self.should_deploy():
             for p in self.build_products:
                 if p.deploy_path:
@@ -151,23 +149,22 @@ class GnuProject:
 
 
     def get_makefile(self):
-        """ Gets the Makefile, which is a build step dependency """
+        """ Gets the Makefile path, a build step dependency """
         return f'{self.source_dir()}/Makefile'
 
 
     def get_configure_file(self):
-        """ Gets the file which performs configuration, and is thus a configuration step dependency """
+        """ Gets the file that performs configuration, a configuration step dependency """
         args = shlex.split(self.configure_command)
         config_cmd = args[0].strip()
-        if config_cmd == 'make':  # if config_cmd is 'make', then look for a Makefile
+        if config_cmd == 'make':  # a 'make config' style command depends on the Makefile instead
             return self.get_makefile()
         return f'{self.source_dir()}/{config_cmd}'
 
 
     def checkout_code(self):
         """
-        Checks out the code archive, either by downloading and extracting the zip archive, 
-        or cloning the project from git repository.
+        Gets the source code: downloads and extracts the archive, or clones the git repository.
         """
         source = self.source_dir()
         configure_file = self.get_configure_file()
@@ -201,7 +198,6 @@ class GnuProject:
             else:
                 console(f'>>> ERROR: Unknown archive type: {local_file}', color=Color.RED)
 
-        # final check if the configure file exists
         if autogen_file:
             if not os.path.exists(autogen_file):
                 raise Exception(f'Checkout failed, no autogen file at: {autogen_file}')
@@ -214,7 +210,7 @@ class GnuProject:
         if self.target.yocto_linux:
             self.target.yocto_linux.get_gnu_build_env(self.extra_env)
         else:
-            # GNU projects need to be configured with the CC, CXX and AR environment variables set
+            # a GNU configure reads the cross toolchain from CC, CXX, AR and the other tool variables
             cc_prefix = self.target.get_cc_prefix()
             if cc_prefix:
                 os.environ['CC'] = cc_prefix + 'gcc'
@@ -228,9 +224,9 @@ class GnuProject:
 
 
     def run(self, command):
-        """ Runs a command in the project directory, eg 'make specialsetup' """
+        """ Runs a command in the project source directory, e.g. 'make specialsetup' """
         env = None
-        if self.extra_env: # copy env and add extra env vars
+        if self.extra_env:
             env = os.environ.copy()
             for k, v in self.extra_env.items():
                 env[k] = v
@@ -239,8 +235,10 @@ class GnuProject:
 
     def configure(self, options='', autogen_opts='', prefix=''):
         """
-        Only configures the project for building by generating the Makefile
-            - options: additional options to pass to the configure script
+        Only configures the project, which generates the Makefile
+            - options: extra options for the configure script
+            - autogen_opts: extra options for ./autogen.sh when autogen is enabled
+            - prefix: install prefix argument, defaults to '--prefix {install_dir()}'
         """
         console(f'>>> Configuring {self.name}', color=Color.GREEN)
         self.configure_env()
@@ -249,7 +247,7 @@ class GnuProject:
             self.run(f'./autogen.sh {autogen_opts}')
 
         if self.configure_command != 'configure':
-            # user overrides with custom configurator, such as `make config` etc
+            # the user gave a custom configure command, such as 'make config'
             configure = self.configure_command
         else:
             args = ''
@@ -260,7 +258,7 @@ class GnuProject:
             if not self.autogen:
                 guess_machine = f'{self.source_dir()}/config.guess'
                 if os.path.exists(guess_machine):
-                    os.chmod(guess_machine, 0o755) # make sure it's executable
+                    os.chmod(guess_machine, 0o755) # make sure it is executable
                     args += f' --build={proc.execute_piped(guess_machine)}'
             configure = f'./configure {args} {prefix}'
 
@@ -281,7 +279,7 @@ class GnuProject:
         """
         Only makes the project
             - opts: extra options for make
-            - multithreaded: if true, will use the -j option to build with multiple threads
+            - multithreaded: if True, adds the -j option to build with multiple threads
         """
         make_opts = self._get_make_opts(opts, multithreaded)
         console(f'>>> Make {self.name} {make_opts}', color=Color.GREEN)
@@ -291,7 +289,7 @@ class GnuProject:
 
 
     def install(self, no_prefix=False):
-        """ Only installs the project """
+        """ Only installs the project. no_prefix=True omits the PREFIX= make argument """
         console(f'>>> Installing {self.name}', color=Color.GREEN)
         self.configure_env()
         prefix = '' if no_prefix else f'PREFIX={self.install_dir()}'
@@ -304,9 +302,12 @@ class GnuProject:
     def build(self, options='', make_opts='', prefix='',
               multithreaded=False, install=True):
         """
-        Downloads, Unzips, Configures, Makes and Installs the project 
-            - options: additional options to pass to the configure script
-            - multithreaded: if true, will use the -j option to build with multiple threads
+        Downloads, extracts, configures, makes and installs the project
+            - options: extra options for the configure script
+            - make_opts: extra options for make
+            - prefix: install prefix argument, see configure()
+            - multithreaded: if True, adds the -j option to build with multiple threads
+            - install: if True, also runs the install step
         """
         project_dir = self.source_dir()
         autoconf_makefile = f'{project_dir}/Makefile' if self.configure_command == 'configure' else None
@@ -324,9 +325,6 @@ class GnuProject:
                 self.install()
         except:
             console(f'>>> ERROR: Failed to build {self.name}', color=Color.RED)
-            # with autoconf projects, delete the makefile so that it will be regenerated
-            #if autoconf_makefile and os.path.exists(autoconf_makefile):
-            #    os.remove(autoconf_makefile)
             raise
 
 
@@ -338,10 +336,9 @@ class GnuProject:
 
 
     def copy_file_or_link(self, src_file, dst_file):
-        """ Copies a file or symlink preserving their attributes and relative symlinks """
+        """ Copies a file, or replicates a symlink with its original link target """
         if os.path.islink(src_file):
             link = os.readlink(src_file)
-            #warning(f'link: {dst_file} -> {link}')
             os.remove(dst_file)
             os.symlink(link, dst_file)
         else:
@@ -356,10 +353,7 @@ class GnuProject:
 
 
     def deploy(self, src_path:str, dest_path=None, strip=False):
-        """ 
-        Deploys the src_path to dest_path, 
-        optionally stripping the binary in the process.
-        """
+        """ Deploys src_path to dest_path, and optionally strips the binary """
         if not src_path:
             raise RuntimeError('src_path must be specified')
 
@@ -379,7 +373,7 @@ class GnuProject:
 
 
     def deploy_dir(self, src_dir, dest_dir, strip=False):
-        """ Deploys all built products from src_dir to dest_dir and optionally strips them """
+        """ Deploys every file under src_dir into dest_dir, and optionally strips them """
         src_dir = self.get_parsed_path(src_dir)
         if not os.path.exists(src_dir):
             raise Exception(f'Failed to deploy from {src_dir}, directory does not exist')

--- a/mama/utils/log_writer.py
+++ b/mama/utils/log_writer.py
@@ -7,10 +7,8 @@ _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')  # SGR colors + cursor moves, st
 
 class AsyncLogWriter:
     def __init__(self, stream, flush_interval=1.0):
-        """`stream`: an open, writable text stream this writer owns. open_build_log wraps the
-        packages/mamabuild.log case, and tests pass a capture stream. `flush_interval`: writes go to
-        the buffered stream as they arrive, but the loop flushes only on an idle lull, so bursts
-        amortize and the log still stays tail-able mid-build."""
+        """stream: an open, writable text stream this writer owns and closes
+        flush_interval: seconds of idle lull before a flush, so bursts amortize and the log stays tail-able"""
         self._stream = stream
         self._flush_interval = flush_interval
         self._q: queue.Queue = queue.Queue()
@@ -45,8 +43,7 @@ class AsyncLogWriter:
 
 
 def open_build_log(path: str):
-    """Open `path` (truncating) as an AsyncLogWriter, or None when it cannot be created: the log must
-    never break a build."""
+    """Open `path` (truncating) as an AsyncLogWriter, or None when it cannot be created: the log must never break a build."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         return AsyncLogWriter(open(path, 'w', encoding='utf-8'))

--- a/mama/utils/log_writer.py
+++ b/mama/utils/log_writer.py
@@ -1,17 +1,16 @@
-"""Async build log: a daemon thread drains a queue to packages/mamabuild.log so write() never blocks
-a build thread. ANSI is stripped for a clean, greppable file. Best-effort - a bad path or IO error
-never breaks a build."""
+"""Async build log: a daemon thread drains a queue to packages/mamabuild.log, so write() never blocks a
+build thread. The writer strips ANSI codes, and a bad path or IO error never breaks a build."""
 import os, re, threading, queue
 
-_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')  # SGR colours + cursor moves, stripped for the log file
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')  # SGR colors + cursor moves, stripped for the log file
 
 
 class AsyncLogWriter:
     def __init__(self, stream, flush_interval=1.0):
-        """`stream`: an open, writable text stream this writer owns (open_build_log wraps the
-        packages/mamabuild.log case; tests pass a capture stream). `flush_interval`: writes go to the
-        buffered stream as they arrive (cheap) but are fsync-flushed only on an idle lull, so bursts are
-        amortized yet confirmed output still lands on disk promptly (tail-able mid-build)."""
+        """`stream`: an open, writable text stream this writer owns. open_build_log wraps the
+        packages/mamabuild.log case, and tests pass a capture stream. `flush_interval`: writes go to
+        the buffered stream as they arrive, but the loop flushes only on an idle lull, so bursts
+        amortize and the log still stays tail-able mid-build."""
         self._stream = stream
         self._flush_interval = flush_interval
         self._q: queue.Queue = queue.Queue()
@@ -46,7 +45,7 @@ class AsyncLogWriter:
 
 
 def open_build_log(path: str):
-    """Open `path` (truncating) as an AsyncLogWriter, or None if it can't be created - the log must
+    """Open `path` (truncating) as an AsyncLogWriter, or None when it cannot be created: the log must
     never break a build."""
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/mama/utils/mama_ssh.py
+++ b/mama/utils/mama_ssh.py
@@ -7,11 +7,8 @@ from __future__ import annotations
 import os
 import sys
 
-# Allow a run as a standalone script, not only as a package module.
-# Important: do NOT put `<...>/mama` on sys.path. `mama/types/` would then
-# shadow Python's stdlib `types` module the moment anything (e.g. contextlib)
-# does `from types import ...`. Add the package's PARENT instead, so that
-# `mama.utils.ssh_multiplex` resolves as a normal qualified import.
+# Standalone-script mode: add the package's PARENT to sys.path, never `<...>/mama` itself,
+# because `mama/types/` would then shadow the stdlib `types` module on any `from types import ...`.
 if __package__ in (None, ''):
     try:
         from mama.utils import ssh_multiplex
@@ -27,8 +24,7 @@ else:
 def main(argv: list[str]) -> int:
     args = argv[1:]
     extra: list[str] = []
-    # The last arg is the remote command (`git-upload-pack '...'`). Everything
-    # before it is options + destination, which is exactly what ssh -G expects.
+    # the last arg is the remote command, everything before it is options + destination, which is what ssh -G expects
     if len(args) >= 2:
         try:
             probe = ssh_multiplex.probe_ssh_config(args[:-1])

--- a/mama/utils/mama_ssh.py
+++ b/mama/utils/mama_ssh.py
@@ -1,27 +1,14 @@
 #!/usr/bin/env python3
-"""
-GIT_SSH_COMMAND wrapper for mama.
-
-Git invokes us as if we were ssh:
-    mama_ssh.py [ssh-args] [user@]host command-on-remote
-
-We hand the same args (minus the trailing remote command) to `ssh -G`,
-which gives us the user's effective config for that destination. Then we
-decide which extra `-o` flags to add (multiplexing, keepalives) WITHOUT
-overriding anything the user already configured, and exec ssh with the
-augmented args.
-
-If anything goes wrong we still exec ssh with the original args. Never
-break a build because of multiplexing setup.
-"""
+"""GIT_SSH_COMMAND wrapper for mama: probe `ssh -G`, add the multiplex/keepalive options the user has not
+set, then exec ssh. On any error it execs ssh with the original args: multiplex setup must never break a build."""
 
 from __future__ import annotations
 
 import os
 import sys
 
-# Allow running as a standalone script, not just as a package module.
-# Important: do NOT put `<...>/mama` on sys.path - `mama/types/` would then
+# Allow a run as a standalone script, not only as a package module.
+# Important: do NOT put `<...>/mama` on sys.path. `mama/types/` would then
 # shadow Python's stdlib `types` module the moment anything (e.g. contextlib)
 # does `from types import ...`. Add the package's PARENT instead, so that
 # `mama.utils.ssh_multiplex` resolves as a normal qualified import.
@@ -40,7 +27,7 @@ else:
 def main(argv: list[str]) -> int:
     args = argv[1:]
     extra: list[str] = []
-    # Last arg is the remote command (`git-upload-pack '...'`); everything
+    # The last arg is the remote command (`git-upload-pack '...'`). Everything
     # before it is options + destination, which is exactly what ssh -G expects.
     if len(args) >= 2:
         try:

--- a/mama/utils/proc_cpu.py
+++ b/mama/utils/proc_cpu.py
@@ -14,10 +14,9 @@ def make_sampler():
 
 
 def accumulate_cpu(state: dict, now: float, trees: dict) -> dict:
-    """trees: {tid: {pid: (cpu_seconds, create_ts)}} -> {tid: cpu%}. Per pid, CPU% is the cpu-time
-    delta since the last sample over wall-clock (a first sight averages over the lifetime so far), so
-    a build tree that saturates N cores reads ~N*100%. `state` (pid -> (cpu_seconds, ts)) carries the
-    delta across samples, and drops a pid no longer in any tree."""
+    """trees: {tid: {pid: (cpu_seconds, create_ts)}} -> {tid: cpu%}. Per pid, CPU% is the cpu-time delta
+    since the last sample over wall-clock (a new pid averages over its lifetime so far), so a tree that
+    saturates N cores reads ~N*100%. `state` carries the delta across samples and drops dead pids."""
     result, seen = {}, set()
     for tid, procs in trees.items():
         total = 0.0
@@ -57,10 +56,9 @@ class PsutilTreeCpu:
 
 
 class WinTreeCpu:
-    """Process-tree CPU% straight from kernel32 (no psutil): ONE CreateToolhelp32Snapshot builds the
-    ppid tree of all processes, then GetProcessTimes reads CPU for each build-tree pid. psutil's
-    children(recursive=True) snapshots the whole process table once PER build root, plus heavy
-    per-process handle work, which made Windows sampling slow."""
+    """Process-tree CPU% straight from kernel32 (no psutil): ONE CreateToolhelp32Snapshot builds the ppid
+    tree, then GetProcessTimes reads CPU per build-tree pid. psutil snapshots the whole process table
+    once PER build root, plus heavy per-process handle work, which made Windows sampling slow."""
     _SNAPPROCESS = 0x00000002
     _QUERY = 0x1000  # PROCESS_QUERY_LIMITED_INFORMATION
 

--- a/mama/utils/proc_cpu.py
+++ b/mama/utils/proc_cpu.py
@@ -1,10 +1,5 @@
-"""Per-build subprocess-tree CPU% sampling, isolated for unit-testing + benchmarking.
-
-A sampler is `callable(snapshot) -> {tid: cpu%}`, where snapshot is `{tid: set(root_pids)}`. It sums
-the cpu-time delta since the last sample over wall-clock for each build's OWN process tree (cmake ->
-ninja/make/msbuild -> compilers), so a tree saturating N cores reads ~N*100%. It reads CPU only for
-those trees, never every system process. Windows uses kernel32 directly (one CreateToolhelp32Snapshot
-+ GetProcessTimes); other platforms use psutil. make_sampler() picks the right one (None if neither)."""
+"""Per-build subprocess-tree CPU% sampling. A sampler is `callable(snapshot) -> {tid: cpu%}` with
+snapshot = `{tid: set(root_pids)}`. make_sampler() picks kernel32 on Windows, psutil elsewhere, else None."""
 import time
 from .system import System
 
@@ -12,7 +7,7 @@ from .system import System
 def make_sampler():
     if System.windows:
         try: return WinTreeCpu()        # low-level kernel32: far cheaper than psutil on Windows
-        except Exception: pass           # ctypes oddity -> fall back to psutil
+        except Exception: pass           # ctypes oddity -> use psutil instead
     try: import psutil
     except ImportError: return None
     return PsutilTreeCpu(psutil)
@@ -20,9 +15,9 @@ def make_sampler():
 
 def accumulate_cpu(state: dict, now: float, trees: dict) -> dict:
     """trees: {tid: {pid: (cpu_seconds, create_ts)}} -> {tid: cpu%}. Per pid, CPU% is the cpu-time
-    delta since the last sample over wall-clock (first sight averages over the lifetime so far), so a
-    build tree saturating N cores reads ~N*100%. `state` (pid -> (cpu_seconds, ts)) carries the delta
-    across samples and is pruned of pids no longer in any tree."""
+    delta since the last sample over wall-clock (a first sight averages over the lifetime so far), so
+    a build tree that saturates N cores reads ~N*100%. `state` (pid -> (cpu_seconds, ts)) carries the
+    delta across samples, and drops a pid no longer in any tree."""
     result, seen = {}, set()
     for tid, procs in trees.items():
         total = 0.0
@@ -38,8 +33,8 @@ def accumulate_cpu(state: dict, now: float, trees: dict) -> dict:
 
 
 class PsutilTreeCpu:
-    """Process-tree CPU% via psutil (non-Windows): cpu_times read ONLY for each build's own tree, never
-    every system process. oneshot() batches the per-proc cpu_times + create_time into one read."""
+    """Process-tree CPU% through psutil (non-Windows): reads cpu_times ONLY for each build's own tree,
+    never every system process. oneshot() batches the per-proc cpu_times + create_time into one read."""
     def __init__(self, psutil):
         self._ps = psutil
         self._state: dict = {}  # pid -> (cpu_seconds, wallclock_ts)
@@ -65,7 +60,7 @@ class WinTreeCpu:
     """Process-tree CPU% straight from kernel32 (no psutil): ONE CreateToolhelp32Snapshot builds the
     ppid tree of all processes, then GetProcessTimes reads CPU for each build-tree pid. psutil's
     children(recursive=True) snapshots the whole process table once PER build root, plus heavy
-    per-process handle work - that is what made Windows sampling slow."""
+    per-process handle work, which made Windows sampling slow."""
     _SNAPPROCESS = 0x00000002
     _QUERY = 0x1000  # PROCESS_QUERY_LIMITED_INFORMATION
 

--- a/mama/utils/run.py
+++ b/mama/utils/run.py
@@ -14,7 +14,6 @@ def get_cwd_exe_args(target: BuildTarget, command: str, cwd='', root_dir='') -> 
     shell_args = shlex.split(command)
     program = shell_args[0]
     args = ' '.join(shell_args[1:]) if shell_args else ''
-    #print(f'get_cwd_exe_args: program={program} args={args} cwd={cwd} root_dir={root_dir}')
 
     # Add or strip the executable suffix. Gated on the HOST as well as the target: a mamafile runs
     # HOST tools during a cross build, so a Windows host must not have `protoc.exe` stripped just
@@ -24,51 +23,46 @@ def get_cwd_exe_args(target: BuildTarget, command: str, cwd='', root_dir='') -> 
     elif not System.windows and not suffix and program.endswith('.exe'): program = program[:-4]
 
     if root_dir:
-        # if root_dir is set, then command will be run relative to it
+        # the command runs relative to root_dir:
         # program: bin/app.exe
         # cwd: /path/to/root_dir/bin
         # exe: /path/to/root_dir/bin/app.exe
         cwd = normalized_join(root_dir, os.path.dirname(program))
         if program.startswith('/'):
-            exe = program # already absolute
+            exe = program
         elif program.startswith('./'):
-            exe = normalized_join(root_dir, program[2:]) # turn relative to absolute
+            exe = normalized_join(root_dir, program[2:])
         else:
-            exe = shutil.which(program) # is it a common executable?
+            exe = shutil.which(program) # a program on PATH wins over a root_dir-relative one
             if not exe:
-                exe = normalized_join(root_dir, program) # turn relative to absolute
-        #print(f'ROOT cwd={cwd} exe={exe} args={args}')
+                exe = normalized_join(root_dir, program)
     elif cwd:
-        # if CWD is set, then command will be run in this dir
+        # the command runs in cwd:
         # program: bin/app.exe
         # cwd: /path/to/project
         # exe: /path/to/project/bin/app.exe
         if program.startswith('/'):
-            exe = program # already absolute
+            exe = program
         elif program.startswith('./'):
-            exe = normalized_join(cwd, program[2:]) # turn relative to absolute
+            exe = normalized_join(cwd, program[2:])
         else:
-            exe = shutil.which(program) # is it a common executable?
+            exe = shutil.which(program) # a program on PATH wins over a cwd-relative one
             if not exe:
-                exe = normalized_join(cwd, program) # turn relative to absolute
-        #print(f'CWD cwd={cwd} exe={exe} args={args}')
+                exe = normalized_join(cwd, program)
     else:
-        # otherwise the command will be run at the same dir as the executable
+        # the command runs in the directory of the executable:
         # program: bin/app.exe
         # cwd: /path/to/bin
         # exe: /path/to/bin/app.exe
         cwd = os.path.dirname(os.path.abspath(program))
-        # is it a common executable?
-        exe = shutil.which(program)
+        exe = shutil.which(program) # a program on PATH wins over a local one
         if not exe:
             exe = f'{cwd}/{os.path.basename(program)}'
-        #print(f'DEFAULT cwd={cwd} exe={exe} args={args}')
 
     cwd = normalized_path(cwd)
     exe = normalized_path(exe)
     if ' ' in exe:
         exe = '"' + exe + '"'
-    #print(f'CWD={cwd} EXE={exe} ARGS={args}')
     return cwd, exe, args
 
 

--- a/mama/utils/run.py
+++ b/mama/utils/run.py
@@ -10,23 +10,23 @@ if TYPE_CHECKING:
 
 
 def get_cwd_exe_args(target: BuildTarget, command: str, cwd='', root_dir='') -> Tuple[str, str, str]:
-    """ Extracts the `cwd`, `exe` and `args` from a command string """
+    """Extracts (cwd, exe, args) from a command string, with the platform executable suffix applied.
+    target: supplies the platform exe suffix
+    command: the command string, shlex-split
+    cwd: run the command in this directory
+    root_dir: run the command relative to this directory"""
     shell_args = shlex.split(command)
     program = shell_args[0]
     args = ' '.join(shell_args[1:]) if shell_args else ''
 
-    # Add or strip the executable suffix. Gated on the HOST as well as the target: a mamafile runs
-    # HOST tools during a cross build, so a Windows host must not have `protoc.exe` stripped just
-    # because the TARGET platform (android, raspi, mips) has no suffix of its own.
+    # The suffix is gated on the HOST as well as the target: a mamafile runs HOST tools during a cross
+    # build, so a Windows host must not have `protoc.exe` stripped for a suffix-less TARGET platform.
     suffix = target.config.platform.exe_suffix()
     if System.windows and suffix and not program.endswith(suffix): program += suffix
     elif not System.windows and not suffix and program.endswith('.exe'): program = program[:-4]
 
     if root_dir:
-        # the command runs relative to root_dir:
-        # program: bin/app.exe
-        # cwd: /path/to/root_dir/bin
-        # exe: /path/to/root_dir/bin/app.exe
+        # relative to root_dir: bin/app.exe -> cwd root_dir/bin, exe root_dir/bin/app.exe
         cwd = normalized_join(root_dir, os.path.dirname(program))
         if program.startswith('/'):
             exe = program
@@ -37,10 +37,7 @@ def get_cwd_exe_args(target: BuildTarget, command: str, cwd='', root_dir='') -> 
             if not exe:
                 exe = normalized_join(root_dir, program)
     elif cwd:
-        # the command runs in cwd:
-        # program: bin/app.exe
-        # cwd: /path/to/project
-        # exe: /path/to/project/bin/app.exe
+        # in cwd: bin/app.exe -> cwd unchanged, exe cwd/bin/app.exe
         if program.startswith('/'):
             exe = program
         elif program.startswith('./'):
@@ -50,10 +47,7 @@ def get_cwd_exe_args(target: BuildTarget, command: str, cwd='', root_dir='') -> 
             if not exe:
                 exe = normalized_join(cwd, program)
     else:
-        # the command runs in the directory of the executable:
-        # program: bin/app.exe
-        # cwd: /path/to/bin
-        # exe: /path/to/bin/app.exe
+        # in the directory of the executable: bin/app.exe -> cwd /abs/bin, exe /abs/bin/app.exe
         cwd = os.path.dirname(os.path.abspath(program))
         exe = shutil.which(program) # a program on PATH wins over a local one
         if not exe:

--- a/mama/utils/ssh_multiplex.py
+++ b/mama/utils/ssh_multiplex.py
@@ -18,26 +18,21 @@ from urllib.parse import urlparse
 from .system import System
 
 
-# One master carries every parallel fetch as a separate SSH session, and sshd's default MaxSessions is
-# 10. Above that the server answers `mux_client_request_session: session request failed: Session open
-# refused by peer` and the fetch dies. init_fetch_semaphore() clamps every request to this cap.
+# One master carries every parallel fetch as a separate SSH session, and sshd's default MaxSessions is 10.
+# Above that the server refuses the session and the fetch dies. init_fetch_semaphore() clamps to this cap.
 DEFAULT_MAX_CONCURRENT_FETCHES = 8
 
 # A UNIX socket path caps at 104 bytes on macOS and 108 on Linux, and ssh expands %C to 40 hex chars.
-# A control dir that leaves no room for that produces `unix_listener: path too long`, so the chooser
-# below measures every candidate against this budget.
+# A control dir with no room for that fails `unix_listener: path too long`, so the chooser measures each candidate.
 _MAX_SOCKET_PATH = 100
 _CONTROL_SUBDIR = 'mama-cm'
 
 
 def _control_dir_candidates() -> list:
-    """Where to keep our control sockets, best first. A container can mount ~/.ssh read-only, and mama
-    then loses multiplexing, so a writable temp dir comes first. The uid keeps two users on one shared
-    /tmp apart, because a dir another user owns is a dir we cannot write.
-
-    The joins stay f-strings. normalized_join() calls abspath, which rewrites the POSIX '/tmp' fallback
-    into 'C:/tmp' on Windows. mama.util also costs about 200ms to import, and mama_ssh.py imports this
-    module on every git ssh spawn."""
+    """Where to keep our control sockets, best first. A read-only ~/.ssh loses multiplexing, so a writable
+    temp dir comes first, and the uid keeps two users on one shared /tmp apart.
+    The joins stay f-strings: normalized_join() calls abspath, which rewrites '/tmp' into 'C:/tmp' on
+    Windows, and mama.util costs about 200ms to import on every git ssh spawn."""
     uid = getattr(os, 'geteuid', lambda: 0)()  # Windows has no geteuid, and never opens a master anyway
     runtime = os.environ.get('XDG_RUNTIME_DIR')
     dirs = [f'{runtime.rstrip("/")}/{_CONTROL_SUBDIR}'] if runtime else []
@@ -55,9 +50,8 @@ _DEFAULT_KEEPALIVE_INTERVAL = '60'
 _DEFAULT_KEEPALIVE_COUNT    = '3'
 _DEFAULT_CONTROL_PERSIST    = '10m'
 
-# Always-on so a parallel clone never freezes on an SSH prompt: bound the TCP connect + auto-accept
-# NEW host keys (still rejects CHANGED). NOT BatchMode, which would break interactive-passphrase keys.
-# The SubProcess idle-timeout is the backstop for stuck auth prompts.
+# Always-on so a parallel clone never freezes on a prompt: bound the TCP connect, auto-accept NEW host keys (reject CHANGED).
+# NOT BatchMode, which breaks interactive-passphrase keys. The SubProcess idle-timeout backstops a stuck auth prompt.
 _SAFETY_OPTS = ['-oConnectTimeout=30', '-oStrictHostKeyChecking=accept-new']
 
 
@@ -71,25 +65,14 @@ _fetch_semaphore: threading.Semaphore | None = None
 
 # URL parsing --------------------------------------------------------------
 
-# scp-style git URL: [user@]host:path  (the path must NOT start with //, that
-# would be ssh://). The regex anchors on a colon that is not followed by //.
+# scp-style git URL: [user@]host:path. The regex anchors on a colon not followed by //, which would be ssh://.
 _SCP_RE = re.compile(r'^(?:(?P<user>[^@/\s]+)@)?(?P<host>[^:/\s]+):(?!//)')
 
 
 def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
-    """
-    Return (user, host, port_or_None) for an SSH-using git URL, or None.
-
-    Accepts:
-        git@github.com:user/repo.git           -> ('git', 'github.com', None)
-        ssh://git@host:2222/user/repo.git      -> ('git', 'host', '2222')
-    Rejects:
-        https://github.com/user/repo.git
-        /path/to/local/repo
-        file:///...
-        C:/foo                                 (Windows path, not scp-style)
-        host:                                  (no path after the colon)
-    """
+    """Return (user, host, port_or_None) for an SSH git URL: scp-style `git@host:path`, or `ssh://user@host:port/path`.
+    Returns None for a https/file URL, a local or Windows drive path, or a colon with no path after it.
+    url: the git remote url"""
     if not url:
         return None
     if url.startswith('ssh://'):
@@ -103,8 +86,7 @@ def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
         return (p.username or 'git', p.hostname, port)
     if '://' in url:
         return None
-    # Reject Windows-style absolute paths: a single drive letter followed by
-    # `:` and then `/` or `\`. Git itself does not treat these as scp URLs.
+    # a drive letter + ':' + slash is a Windows absolute path, which git itself does not treat as an scp URL
     if len(url) >= 3 and url[1] == ':' and url[0].isalpha() and url[2] in ('/', '\\'):
         return None
     m = _SCP_RE.match(url)
@@ -120,18 +102,14 @@ def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
 # ssh -G probe -------------------------------------------------------------
 
 def probe_ssh_config(ssh_args: list[str], timeout: float = 5.0) -> dict[str, str]:
-    """
-    Run `ssh -G <ssh_args>` and return the effective config (lower-cased keys).
-    Empty dict on failure: the probe must never block the build.
-
-    `ssh_args` is whatever ssh takes after `-G` - typically just
-    `[f'{user}@{host}']`, optionally with `-p PORT` etc.
-
-    Raw subprocess.run with capture_output, not SubProcess.run: every ssh helper in this module must
-    stay silent. ssh writes a warning per bad line in the user's ssh_config, and a probe that echoed
-    those would print the same block once per dependency. It also runs from mama_ssh.py, a standalone
-    wrapper process with no display to route output to. The same applies to every other ssh call below.
-    """
+    """Run `ssh -G <ssh_args>` and return the effective config (lower-cased keys). Empty dict on failure:
+    the probe must never block the build.
+    ssh_args: whatever ssh takes after `-G`, typically `[f'{user}@{host}']`, optionally with `-p PORT`
+    timeout: seconds before the probe gives up
+    Raw subprocess.run with capture_output, not SubProcess.run: every ssh helper in this module must stay
+    silent. ssh warns per bad line in the user's ssh_config, and an echoed probe would print that block
+    once per dependency. It also runs from mama_ssh.py, a standalone wrapper process with no display to
+    route output to. The same applies to every other ssh call below."""
     try:
         cp = subprocess.run(['ssh', '-G', *ssh_args],
                             capture_output=True, text=True, timeout=timeout)
@@ -146,7 +124,7 @@ def probe_ssh_config(ssh_args: list[str], timeout: float = 5.0) -> dict[str, str
             continue
         parts = line.split(None, 1)
         if len(parts) == 2:
-            # `ssh -G` prints each key only once, keep the first.
+            # `ssh -G` prints each key only once, keep the first
             out.setdefault(parts[0].lower(), parts[1])
     return out
 
@@ -159,20 +137,16 @@ def is_multiplex_configured(probe: dict[str, str]) -> bool:
 
 
 def multiplex_known_broken() -> bool:
-    """Native Windows: skip multiplex entirely. Microsoft OpenSSH's ControlMaster is unreliable:
-    `mux_client_request_session: read from master failed: Connection reset by peer` mid-fetch, and a
-    stale `ControlSocket ... already exists, disabling multiplexing` after a master drops.
-    WSL/Cygwin/Git-Bash report as Linux (`System.windows == False`) and keep multiplex."""
+    """Native Windows: skip multiplex entirely. Microsoft OpenSSH's ControlMaster resets connections
+    mid-fetch and leaves stale sockets that disable multiplexing. WSL/Cygwin/Git-Bash report as Linux
+    (`System.windows == False`) and keep multiplex."""
     return System.windows
 
 
 def _control_dir_usable() -> bool:
-    """Make our control dir, and report False instead of raising when we cannot. A CI container often
-    runs as a uid that does not own $HOME (GitHub Actions: `/github/home/.ssh` gives Errno 13), and
-    multiplexing is an optimization - it must never be the thing that fails a build. Without a dir we
-    just skip the multiplex flags and every fetch opens its own connection, as it always could.
-
-    Walks the candidates, so a read-only ~/.ssh costs one fallback instead of the whole optimization."""
+    """Make our control dir, and report False instead of raising: multiplexing is an optimization and must
+    never fail a build. Walks the candidates, so a read-only ~/.ssh costs one fallback, not the whole
+    optimization. Without a dir the multiplex flags are skipped and every fetch opens its own connection."""
     global _OUR_CONTROL_DIR, _OUR_CONTROL_PATH
     for candidate in [_OUR_CONTROL_DIR] + _control_dir_candidates():
         try: os.makedirs(candidate, mode=0o700, exist_ok=True)
@@ -185,11 +159,9 @@ def _control_dir_usable() -> bool:
 
 
 def options_to_add(probe: dict[str, str]) -> tuple[list[str], bool]:
-    """
-    Return (-o args, we_own_master). `we_own_master` is True when mama configures multiplex itself,
-    which makes mama responsible for the pre-warm and the cleanup. False when the user already has
-    multiplex configured, or when multiplex is known-broken on this platform.
-    """
+    """Return (-o args, we_own_master). `we_own_master` is True when mama configures multiplex itself and
+    so owns the pre-warm and the cleanup. False when the user already has multiplex, or it is known-broken.
+    probe: the effective ssh config from probe_ssh_config()"""
     opts: list[str] = list(_SAFETY_OPTS)
     we_own_master = False
     if not multiplex_known_broken() and not is_multiplex_configured(probe) and _control_dir_usable():
@@ -223,14 +195,10 @@ def _probe_args(user: str, host: str, port: str | None) -> list[str]:
 
 
 def ensure_master_for_url(url: str) -> None:
-    """
-    Idempotent. Probes the host's SSH config. When the user has no multiplex of their own, opens a
-    master connection and remembers it for cleanup. Sets GIT_SSH_COMMAND so later git ops use the
-    mama_ssh.py wrapper.
-
-    Safe to call concurrently from multiple threads. Blocks the FIRST caller per host while the
-    master opens. Later callers return immediately.
-    """
+    """Idempotent, thread-safe. When the user has no multiplex of their own, opens a master connection,
+    remembers it for cleanup, and sets GIT_SSH_COMMAND so later git ops use the mama_ssh.py wrapper.
+    Blocks the FIRST caller per host while the master opens, later callers return immediately.
+    url: the git remote url, a non-SSH url is ignored"""
     ep = parse_ssh_endpoint(url)
     if ep is None:
         return
@@ -247,18 +215,14 @@ def ensure_master_for_url(url: str) -> None:
 
         if we_own_master:
             state = _open_master(user, host, port, opts)
-            # ADOPTED: a master was already listening (a parallel mama run, or an earlier run's
-            # ControlPersist master on a runner that keeps $HOME). Use it, but never `ssh -O exit` it at
-            # exit - closing another job's connection kills its fetches mid-transfer.
+            # ADOPTED: another run's master was already listening. Use it, but never `ssh -O exit` it at
+            # exit: closing another job's connection kills its fetches mid-transfer.
             if state == _MASTER_ADOPTED:
                 we_own_master = False
             elif state == _MASTER_FAILED:
-                # Pre-warm failed (auth declined, network blip, host key prompt,
-                # MFA timeout). With ControlMaster/ControlPath left in opts,
-                # every later fetch would race to BECOME the master and trigger
-                # N concurrent auths instead of one - the exact thing
-                # multiplexing is meant to prevent. Strip the multiplex flags
-                # so each fetch makes its own simple connection.
+                # Pre-warm failed. With the multiplex flags left in opts, every later fetch would race to
+                # BECOME the master and trigger N concurrent auths instead of one, the exact thing
+                # multiplexing prevents. Strip the flags so each fetch makes its own simple connection.
                 opts = [o for o in opts
                         if not (o.startswith('-oControlMaster=')
                                 or o.startswith('-oControlPath=')
@@ -268,8 +232,7 @@ def ensure_master_for_url(url: str) -> None:
         with _state_lock:
             _warmed[ep] = {'opts': opts, 'we_own_master': we_own_master}
 
-        # Only install the wrapper when it has something to do -
-        # otherwise it costs a fork+exec per git op for no benefit.
+        # only install the wrapper when it has something to do, otherwise it costs a fork+exec per git op
         if opts:
             _set_git_ssh_command()
 
@@ -296,13 +259,9 @@ def _master_alive(user: str, host: str, port: str | None, opts: list[str]) -> bo
 
 
 def _remove_stale_socket(user: str, host: str, port: str | None, opts: list[str]) -> None:
-    """
-    `ssh -fN -oControlMaster=yes` refuses to open a master while the socket file exists, even when
-    nothing listens on it: it prints `ControlSocket ... already exists, disabling multiplexing` and
-    connects unmultiplexed. A killed master, or a CI runner that keeps $HOME between jobs, leaves
-    exactly that. Delete the dead socket, but ONLY under mama's own control dir: a user-configured
-    ControlPath is theirs to manage. `ssh -G` expands the %C token.
-    """
+    """ssh refuses to open a master while the socket file exists, even dead, and connects unmultiplexed.
+    Delete the dead socket, but ONLY under mama's own control dir: a user-configured ControlPath is
+    theirs to manage. `ssh -G` expands the %C token."""
     probe = probe_ssh_config(_master_control_args(opts) + _probe_args(user, host, port))
     path = probe.get('controlpath', '')
     if not path.startswith(_OUR_CONTROL_DIR):
@@ -312,25 +271,20 @@ def _remove_stale_socket(user: str, host: str, port: str | None, opts: list[str]
 
 
 def _open_master(user: str, host: str, port: str | None, opts: list[str]) -> str:
-    """
-    Make a master usable on this ControlPath. Returns one of:
-      _MASTER_ADOPTED - one was already listening. Use it, but it is not mama's to close.
-      _MASTER_STARTED - mama opened it, so mama owns its cleanup.
-      _MASTER_FAILED  - none available. The caller must drop the multiplex flags, so concurrent
-                        fetches do not race to be the master and trigger N parallel auths.
-    """
+    """Make a master usable on this ControlPath. Returns _MASTER_ADOPTED (one already listened, not mama's
+    to close), _MASTER_STARTED (mama owns its cleanup), or _MASTER_FAILED (the caller must drop the
+    multiplex flags)."""
     if _master_alive(user, host, port, opts):
         return _MASTER_ADOPTED
     _remove_stale_socket(user, host, port, opts)
-    # Force ControlMaster=yes for the master itself, replacing any =auto.
+    # force ControlMaster=yes for the master itself, replacing any =auto
     cmd = ['ssh', '-fN'] + [o for o in opts if not o.startswith('-oControlMaster=')]
     cmd += ['-oControlMaster=yes']
     if port:
         cmd += ['-p', port]
     cmd += [f'{user}@{host}']
     try:
-        # 30s is generous for password/2FA prompts. -fN backgrounds AFTER auth
-        # but BEFORE the ControlPath socket binds, so a readiness poll follows.
+        # 30s is generous for password/2FA prompts. -fN backgrounds AFTER auth but BEFORE the socket binds, so a poll follows.
         cp = subprocess.run(cmd, timeout=30, capture_output=True, text=True)
         if cp.returncode != 0:
             return _MASTER_FAILED
@@ -341,12 +295,8 @@ def _open_master(user: str, host: str, port: str | None, opts: list[str]) -> str
 
 def _wait_master_ready(user: str, host: str, port: str | None,
                        opts: list[str], deadline_s: float = 5.0) -> bool:
-    """
-    Poll `ssh -O check` until the master responds or the deadline passes.
-    `ssh -fN` returns as soon as auth+fork happen, but the ControlPath socket
-    can take a brief moment to bind. Without this poll the first racing
-    fetches see "no socket yet" and each open their own connection.
-    """
+    """Poll `ssh -O check` until the master responds or the deadline passes. `ssh -fN` returns before the
+    ControlPath socket binds, and without this poll the first racing fetches each open their own connection."""
     end = time.monotonic() + deadline_s
     delay = 0.05
     while time.monotonic() < end:
@@ -378,8 +328,7 @@ atexit.register(cleanup_masters)
 
 
 def _set_git_ssh_command() -> None:
-    # An already-set GIT_SSH_COMMAND stays untouched: either the user made an
-    # explicit choice, or the wrapper is already installed.
+    # an already-set GIT_SSH_COMMAND stays untouched: a user choice, or the wrapper is already installed
     if os.environ.get('GIT_SSH_COMMAND'):
         return
     wrapper = os.path.join(os.path.dirname(__file__), 'mama_ssh.py')
@@ -391,10 +340,9 @@ def _set_git_ssh_command() -> None:
 # Concurrent-fetch semaphore -----------------------------------------------
 
 def init_fetch_semaphore(max_concurrent: int = DEFAULT_MAX_CONCURRENT_FETCHES) -> None:
-    """Initialize the global semaphore that caps concurrent git fetches. The cap clamps to
-    DEFAULT_MAX_CONCURRENT_FETCHES whatever the caller asks for. `parallel_max` also sizes the
-    scheduler's LOAD pool, where artifactory downloads want a high number. The server refuses
-    every git session above its MaxSessions on the shared master."""
+    """Initialize the global semaphore that caps concurrent git fetches, clamped to DEFAULT_MAX_CONCURRENT_FETCHES.
+    max_concurrent: the requested cap. `parallel_max` also sizes the scheduler's LOAD pool, where
+    artifactory downloads want a high number, so the clamp stays independent of it."""
     global _fetch_semaphore
     n = max(1, min(int(max_concurrent), DEFAULT_MAX_CONCURRENT_FETCHES))
     with _state_lock:
@@ -403,21 +351,15 @@ def init_fetch_semaphore(max_concurrent: int = DEFAULT_MAX_CONCURRENT_FETCHES) -
 
 
 def fetch_slot():
-    """
-    Context manager that holds a slot in the fetch semaphore. No-op if
-    `init_fetch_semaphore` has not been called (e.g. for non-parallel runs).
-    """
+    """Context manager that holds a slot in the fetch semaphore. No-op when `init_fetch_semaphore` has not run."""
     return _fetch_semaphore or contextlib.nullcontext()
 
 
 # Connection pacing --------------------------------------------------------
 
-# Pacing is REACTIVE, and off until a host pushes back. A wave of parallel clones opens its TCP and
-# auth handshakes inside a few milliseconds, and a git host can answer that by closing the connection
-# mid-handshake. Multiplexing removes the handshakes on a shared SSH host, but an https remote still
-# connects per clone and Windows has no multiplexing at all. An unconditional stagger would cost wall
-# clock on every run to protect the few that need it, so the first dropped connection turns it on
-# instead and everything after that arrives spread out.
+# Pacing is REACTIVE, off until a host pushes back: a git host can answer a wave of parallel handshakes
+# by closing connections mid-handshake, and multiplexing does not cover https remotes or Windows.
+# An unconditional stagger would cost wall clock on every run, so the first dropped connection turns it on.
 THROTTLED_CONNECT_INTERVAL = 0.25  # seconds between the START of two git network commands, once throttled
 _connect_lock = threading.Lock()
 _connect_interval = 0.0
@@ -432,9 +374,8 @@ def note_connection_throttled() -> None:
 
 
 def pace_new_connection() -> None:
-    """Hold a git network command back until the pacing interval has passed since the last one
-    started. No-op until note_connection_throttled() fires. Only the START of each connection is
-    staggered, so the transfers themselves stay fully parallel."""
+    """Hold a git network command back until the pacing interval has passed since the last one started.
+    No-op until note_connection_throttled() fires. Only the START staggers, transfers stay fully parallel."""
     global _last_connect
     with _connect_lock:  # held across the sleep, so N waiters stagger instead of waking together
         if not _connect_interval: return

--- a/mama/utils/ssh_multiplex.py
+++ b/mama/utils/ssh_multiplex.py
@@ -1,26 +1,5 @@
-"""
-SSH connection multiplexing for git operations.
-
-When mama runs `update` against many private git repositories on the same SSH
-host (e.g. github.com), each `git fetch` opens a fresh SSH connection and pays
-the full auth cost. Multiplexing lets a single auth'd master socket carry many
-parallel git ops.
-
-Design rules:
-* Probe via `ssh -G user@host` to read the user's effective config. We never
-  override settings the user already has (ControlMaster, ControlPath,
-  ServerAliveInterval, ServerAliveCountMax). Our `-o` flags are added only
-  for keys the user has not set.
-* `GIT_SSH_COMMAND` points at a small wrapper (`mama_ssh.py`) so per-host
-  options can be applied just-in-time. A single global GIT_SSH_COMMAND can't
-  encode per-host decisions, so the wrapper does it on each invocation.
-* Pre-warm one master per host with `ssh -fN` BEFORE we kick off parallel git
-  ops, so 20 concurrent fetches don't trigger 20 concurrent auths.
-* Track which masters we started; clean them up at exit. Pre-existing masters
-  the user manages are left alone.
-* Never touch ssh-agent: no IdentityAgent, no IdentityFile, no manipulation of
-  SSH_AUTH_SOCK. The user's keys and agent stay exactly as configured.
-"""
+"""SSH connection multiplexing for git operations: one authenticated master socket per host carries many
+parallel git fetches. Adds only options the user has not set, and never touches ssh-agent or the user's keys."""
 
 from __future__ import annotations
 
@@ -41,7 +20,7 @@ from .system import System
 
 # One master carries every parallel fetch as a separate SSH session, and sshd's default MaxSessions is
 # 10. Above that the server answers `mux_client_request_session: session request failed: Session open
-# refused by peer` and the fetch dies. Raise it per project with `parallel=N` when the host allows more.
+# refused by peer` and the fetch dies. init_fetch_semaphore() clamps every request to this cap.
 DEFAULT_MAX_CONCURRENT_FETCHES = 8
 
 # A UNIX socket path caps at 104 bytes on macOS and 108 on Linux, and ssh expands %C to 40 hex chars.
@@ -63,7 +42,7 @@ def _control_dir_candidates() -> list:
     runtime = os.environ.get('XDG_RUNTIME_DIR')
     dirs = [f'{runtime.rstrip("/")}/{_CONTROL_SUBDIR}'] if runtime else []
     dirs.append(f'{tempfile.gettempdir().rstrip("/")}/{_CONTROL_SUBDIR}-{uid}')
-    dirs.append(f'/tmp/{_CONTROL_SUBDIR}-{uid}')  # macOS $TMPDIR is long enough to blow the socket budget
+    dirs.append(f'/tmp/{_CONTROL_SUBDIR}-{uid}')  # macOS $TMPDIR is long enough to exceed the socket budget
     dirs.append(os.path.expanduser('~/.ssh/cm'))  # where mama kept them before, for a host with no temp
     fits = [d for d in dirs if len(d) + 41 <= _MAX_SOCKET_PATH]
     return fits or dirs[-1:]  # every candidate is too long: try the old spot and let ssh report it
@@ -77,8 +56,8 @@ _DEFAULT_KEEPALIVE_COUNT    = '3'
 _DEFAULT_CONTROL_PERSIST    = '10m'
 
 # Always-on so a parallel clone never freezes on an SSH prompt: bound the TCP connect + auto-accept
-# NEW host keys (still rejects CHANGED). NOT BatchMode (would break interactive-passphrase keys);
-# the SubProcess idle-timeout is the backstop for stuck auth prompts.
+# NEW host keys (still rejects CHANGED). NOT BatchMode, which would break interactive-passphrase keys.
+# The SubProcess idle-timeout is the backstop for stuck auth prompts.
 _SAFETY_OPTS = ['-oConnectTimeout=30', '-oStrictHostKeyChecking=accept-new']
 
 
@@ -93,7 +72,7 @@ _fetch_semaphore: threading.Semaphore | None = None
 # URL parsing --------------------------------------------------------------
 
 # scp-style git URL: [user@]host:path  (the path must NOT start with //, that
-# would be ssh://). We anchor on a colon that isn't followed by //.
+# would be ssh://). The regex anchors on a colon that is not followed by //.
 _SCP_RE = re.compile(r'^(?:(?P<user>[^@/\s]+)@)?(?P<host>[^:/\s]+):(?!//)')
 
 
@@ -109,7 +88,7 @@ def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
         /path/to/local/repo
         file:///...
         C:/foo                                 (Windows path, not scp-style)
-        host:                                  (no path after colon)
+        host:                                  (no path after the colon)
     """
     if not url:
         return None
@@ -125,7 +104,7 @@ def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
     if '://' in url:
         return None
     # Reject Windows-style absolute paths: a single drive letter followed by
-    # `:` and then `/` or `\`. Git itself doesn't treat these as scp URLs.
+    # `:` and then `/` or `\`. Git itself does not treat these as scp URLs.
     if len(url) >= 3 and url[1] == ':' and url[0].isalpha() and url[2] in ('/', '\\'):
         return None
     m = _SCP_RE.match(url)
@@ -142,10 +121,10 @@ def parse_ssh_endpoint(url: str) -> tuple[str, str, str | None] | None:
 
 def probe_ssh_config(ssh_args: list[str], timeout: float = 5.0) -> dict[str, str]:
     """
-    Run `ssh -G <ssh_args>` and return effective config (lower-cased keys).
-    Empty dict on failure - probe must never block the build.
+    Run `ssh -G <ssh_args>` and return the effective config (lower-cased keys).
+    Empty dict on failure: the probe must never block the build.
 
-    `ssh_args` is whatever you'd pass to ssh after `-G` - typically just
+    `ssh_args` is whatever ssh takes after `-G` - typically just
     `[f'{user}@{host}']`, optionally with `-p PORT` etc.
 
     Raw subprocess.run with capture_output, not SubProcess.run: every ssh helper in this module must
@@ -167,7 +146,7 @@ def probe_ssh_config(ssh_args: list[str], timeout: float = 5.0) -> dict[str, str
             continue
         parts = line.split(None, 1)
         if len(parts) == 2:
-            # `ssh -G` prints each key only once; keep first.
+            # `ssh -G` prints each key only once, keep the first.
             out.setdefault(parts[0].lower(), parts[1])
     return out
 
@@ -180,12 +159,10 @@ def is_multiplex_configured(probe: dict[str, str]) -> bool:
 
 
 def multiplex_known_broken() -> bool:
-    """Native Windows: skip multiplex entirely. Microsoft OpenSSH's
-    ControlMaster is unreliable in practice - `mux_client_request_session:
-    read from master failed: Connection reset by peer` mid-fetch and stale
-    `ControlSocket ... already exists, disabling multiplexing` after a master
-    drops. WSL/Cygwin/Git-Bash run as Linux from Python's POV
-    (`System.windows == False`) and keep multiplex."""
+    """Native Windows: skip multiplex entirely. Microsoft OpenSSH's ControlMaster is unreliable:
+    `mux_client_request_session: read from master failed: Connection reset by peer` mid-fetch, and a
+    stale `ControlSocket ... already exists, disabling multiplexing` after a master drops.
+    WSL/Cygwin/Git-Bash report as Linux (`System.windows == False`) and keep multiplex."""
     return System.windows
 
 
@@ -209,10 +186,9 @@ def _control_dir_usable() -> bool:
 
 def options_to_add(probe: dict[str, str]) -> tuple[list[str], bool]:
     """
-    Return (-o args, we_own_master). `we_own_master` is True when we are the
-    one configuring multiplex (and therefore responsible for pre-warming and
-    cleaning it up). False if the user already has multiplex configured, or
-    if multiplex is known-broken on this platform.
+    Return (-o args, we_own_master). `we_own_master` is True when mama configures multiplex itself,
+    which makes mama responsible for the pre-warm and the cleanup. False when the user already has
+    multiplex configured, or when multiplex is known-broken on this platform.
     """
     opts: list[str] = list(_SAFETY_OPTS)
     we_own_master = False
@@ -248,13 +224,12 @@ def _probe_args(user: str, host: str, port: str | None) -> list[str]:
 
 def ensure_master_for_url(url: str) -> None:
     """
-    Idempotent. Probes the host's SSH config and, if multiplexing isn't
-    already set up by the user, opens a master connection and remembers it
-    for cleanup. Sets GIT_SSH_COMMAND so subsequent git ops use our wrapper.
+    Idempotent. Probes the host's SSH config. When the user has no multiplex of their own, opens a
+    master connection and remembers it for cleanup. Sets GIT_SSH_COMMAND so later git ops use the
+    mama_ssh.py wrapper.
 
-    Safe to call concurrently from multiple threads. Blocks the FIRST caller
-    per host while the master is being established; subsequent callers return
-    immediately.
+    Safe to call concurrently from multiple threads. Blocks the FIRST caller per host while the
+    master opens. Later callers return immediately.
     """
     ep = parse_ssh_endpoint(url)
     if ep is None:
@@ -279,11 +254,11 @@ def ensure_master_for_url(url: str) -> None:
                 we_own_master = False
             elif state == _MASTER_FAILED:
                 # Pre-warm failed (auth declined, network blip, host key prompt,
-                # MFA timeout). If we left ControlMaster/ControlPath in opts,
-                # every subsequent fetch would race to BECOME the master and
-                # we'd trigger N concurrent auths instead of one - the exact
-                # thing multiplexing is meant to prevent. Strip the multiplex
-                # flags so each fetch makes its own simple connection.
+                # MFA timeout). With ControlMaster/ControlPath left in opts,
+                # every later fetch would race to BECOME the master and trigger
+                # N concurrent auths instead of one - the exact thing
+                # multiplexing is meant to prevent. Strip the multiplex flags
+                # so each fetch makes its own simple connection.
                 opts = [o for o in opts
                         if not (o.startswith('-oControlMaster=')
                                 or o.startswith('-oControlPath=')
@@ -293,8 +268,8 @@ def ensure_master_for_url(url: str) -> None:
         with _state_lock:
             _warmed[ep] = {'opts': opts, 'we_own_master': we_own_master}
 
-        # Only install the wrapper when there's something for it to do -
-        # otherwise it's a fork+exec per git op for no benefit.
+        # Only install the wrapper when it has something to do -
+        # otherwise it costs a fork+exec per git op for no benefit.
         if opts:
             _set_git_ssh_command()
 
@@ -323,10 +298,10 @@ def _master_alive(user: str, host: str, port: str | None, opts: list[str]) -> bo
 def _remove_stale_socket(user: str, host: str, port: str | None, opts: list[str]) -> None:
     """
     `ssh -fN -oControlMaster=yes` refuses to open a master while the socket file exists, even when
-    nothing listens on it - it prints `ControlSocket ... already exists, disabling multiplexing` and
+    nothing listens on it: it prints `ControlSocket ... already exists, disabling multiplexing` and
     connects unmultiplexed. A killed master, or a CI runner that keeps $HOME between jobs, leaves
-    exactly that. Delete the dead socket, but ONLY under our own control dir: a user-configured
-    ControlPath is theirs to manage. `ssh -G` expands the %C token for us.
+    exactly that. Delete the dead socket, but ONLY under mama's own control dir: a user-configured
+    ControlPath is theirs to manage. `ssh -G` expands the %C token.
     """
     probe = probe_ssh_config(_master_control_args(opts) + _probe_args(user, host, port))
     path = probe.get('controlpath', '')
@@ -339,15 +314,15 @@ def _remove_stale_socket(user: str, host: str, port: str | None, opts: list[str]
 def _open_master(user: str, host: str, port: str | None, opts: list[str]) -> str:
     """
     Make a master usable on this ControlPath. Returns one of:
-      _MASTER_ADOPTED - one was already listening. Use it, but it is not ours to close.
-      _MASTER_STARTED - we opened it, so we own its cleanup.
+      _MASTER_ADOPTED - one was already listening. Use it, but it is not mama's to close.
+      _MASTER_STARTED - mama opened it, so mama owns its cleanup.
       _MASTER_FAILED  - none available. The caller must drop the multiplex flags, so concurrent
-                        fetches don't all race to be the master and trigger N parallel auths.
+                        fetches do not race to be the master and trigger N parallel auths.
     """
     if _master_alive(user, host, port, opts):
         return _MASTER_ADOPTED
     _remove_stale_socket(user, host, port, opts)
-    # Force ControlMaster=yes for the master itself; replace any =auto.
+    # Force ControlMaster=yes for the master itself, replacing any =auto.
     cmd = ['ssh', '-fN'] + [o for o in opts if not o.startswith('-oControlMaster=')]
     cmd += ['-oControlMaster=yes']
     if port:
@@ -355,7 +330,7 @@ def _open_master(user: str, host: str, port: str | None, opts: list[str]) -> str
     cmd += [f'{user}@{host}']
     try:
         # 30s is generous for password/2FA prompts. -fN backgrounds AFTER auth
-        # but BEFORE the ControlPath socket is bound, so we still need to poll.
+        # but BEFORE the ControlPath socket binds, so a readiness poll follows.
         cp = subprocess.run(cmd, timeout=30, capture_output=True, text=True)
         if cp.returncode != 0:
             return _MASTER_FAILED
@@ -367,7 +342,7 @@ def _open_master(user: str, host: str, port: str | None, opts: list[str]) -> str
 def _wait_master_ready(user: str, host: str, port: str | None,
                        opts: list[str], deadline_s: float = 5.0) -> bool:
     """
-    Poll `ssh -O check` until the master responds or we hit the deadline.
+    Poll `ssh -O check` until the master responds or the deadline passes.
     `ssh -fN` returns as soon as auth+fork happen, but the ControlPath socket
     can take a brief moment to bind. Without this poll the first racing
     fetches see "no socket yet" and each open their own connection.
@@ -383,7 +358,7 @@ def _wait_master_ready(user: str, host: str, port: str | None,
 
 
 def cleanup_masters() -> None:
-    """Run `ssh -O exit` for masters we started. Don't touch user-owned ones."""
+    """Run `ssh -O exit` for the masters mama started. Never touch a user-owned one."""
     with _state_lock:
         snapshot = list(_warmed.items())
     for (user, host, port), info in snapshot:
@@ -403,8 +378,8 @@ atexit.register(cleanup_masters)
 
 
 def _set_git_ssh_command() -> None:
-    # If GIT_SSH_COMMAND is already set we leave it alone - either the user
-    # made an explicit choice or we already installed our wrapper.
+    # An already-set GIT_SSH_COMMAND stays untouched: either the user made an
+    # explicit choice, or the wrapper is already installed.
     if os.environ.get('GIT_SSH_COMMAND'):
         return
     wrapper = os.path.join(os.path.dirname(__file__), 'mama_ssh.py')
@@ -416,10 +391,10 @@ def _set_git_ssh_command() -> None:
 # Concurrent-fetch semaphore -----------------------------------------------
 
 def init_fetch_semaphore(max_concurrent: int = DEFAULT_MAX_CONCURRENT_FETCHES) -> None:
-    """Initialise the global semaphore that caps concurrent git fetches. Clamped to
-    DEFAULT_MAX_CONCURRENT_FETCHES whatever the caller asks for: `parallel_max` also sizes the
-    scheduler's LOAD pool, where artifactory downloads want a high number, but every git session above
-    the server's MaxSessions is refused outright on the shared master."""
+    """Initialize the global semaphore that caps concurrent git fetches. The cap clamps to
+    DEFAULT_MAX_CONCURRENT_FETCHES whatever the caller asks for. `parallel_max` also sizes the
+    scheduler's LOAD pool, where artifactory downloads want a high number. The server refuses
+    every git session above its MaxSessions on the shared master."""
     global _fetch_semaphore
     n = max(1, min(int(max_concurrent), DEFAULT_MAX_CONCURRENT_FETCHES))
     with _state_lock:

--- a/mama/utils/sub_process.py
+++ b/mama/utils/sub_process.py
@@ -4,18 +4,16 @@ from . import abort
 from .system import System, console, error, report_subprocess, capture_to, capture_context
 
 
-# Linux/macOS: we allocate a PTY for the child so git etc. still see a TTY
-# (preserves progress output and isatty checks). The pty.openpty() syscall
-# does NOT fork - it just creates a master/slave fd pair - so it's safe to
-# call from a worker thread. subprocess.Popen does the actual fork via
-# posix_spawn/vfork which is multi-thread-safe, unlike the older os.forkpty
-# which Python 3.12 flags with a DeprecationWarning specifically because of
-# the threaded-deadlock risk.
+# Linux/macOS: the child gets a PTY, so git etc. still see a TTY and keep their
+# progress output and isatty checks. pty.openpty() does NOT fork, it only makes a
+# master/slave fd pair, so a worker thread can call it. subprocess.Popen forks via
+# posix_spawn/vfork, which is multi-thread safe, unlike the older os.forkpty,
+# which Python 3.12 deprecates for its deadlock risk in threaded programs.
 if not System.windows:
     import pty
 
 
-READER_IDLE_TIMEOUT = 0.1  # seconds; how long to wait before flushing a \r-progress partial
+READER_IDLE_TIMEOUT = 0.1  # seconds to wait before flushing a \r-progress partial
 READER_CHUNK = 8192
 
 
@@ -25,10 +23,10 @@ _live_procs = set()   # live SubProcess instances. terminate_all() stops every o
 
 def _kill_group(gid) -> bool:
     """Hard-kill a whole process group (UNIX) or a pid's process tree (Windows), and report whether the
-    call went through. A group whose members already exited is empty, so the call fails and that is the
+    call succeeded. A group whose members already exited is empty, so the call fails and that is the
     intended no-op: nothing survived to kill.
-    Raw subprocess.run (not SubProcess.run): the killer must not register in _live_procs, and the abort
-    flag must not block it - it runs precisely while mama aborts."""
+    Raw subprocess.run (not SubProcess.run): the killer must not register in _live_procs. The abort
+    flag must not block it, because it runs precisely while mama aborts."""
     try:
         if System.windows:
             subprocess.run(['taskkill', '/F', '/T', '/PID', str(gid)],
@@ -44,16 +42,12 @@ class SubProcess:
     """
     Subprocess wrapper with optional line-by-line output capture.
 
-    With ``io_func`` set, child's combined stdout+stderr is fed to ``io_func``
-    one line at a time by a background reader thread. On UNIX a PTY is
-    allocated so the child sees a TTY (gets coloured/progress output).
+    With ``io_func`` set, a background reader thread feeds the child's combined
+    stdout+stderr to ``io_func`` one line at a time. On UNIX the child runs on a
+    PTY, so it sees a TTY and prints colored/progress output.
 
-    Without ``io_func``, the child inherits the parent's stdout/stderr -
-    used for things like `mama test` where output should flow directly.
-
-    Replaces the previous os.fork/os.forkpty-based implementation which
-    was unsafe in multi-threaded programs (Python 3.12 deprecation warning,
-    real deadlocks under heavy parallel load).
+    Without ``io_func``, the child inherits the parent's stdout/stderr, for
+    commands like `mama test` whose output must flow directly.
     """
     def __init__(self, cmd, cwd=None, env=None, io_func=None):
         self.io_func = io_func
@@ -61,17 +55,16 @@ class SubProcess:
         self.process = None
         self._reader_thread = None
         self._reader_exc = None        # exception raised inside io_func (re-raised in run())
-        self._master_fd = None         # UNIX PTY master fd; None on Windows or no-io_func paths
+        self._master_fd = None         # UNIX PTY master fd, None on Windows or no-io_func paths
         self._swallow_lf = False       # after \r-progress idle-flush, swallow a leading \n (or \r\n) in next chunk
-        self._last_output = time.monotonic()  # bumped on every chunk; drives the idle-timeout watchdog
+        self._last_output = time.monotonic()  # bumped on every chunk, drives the idle-timeout watchdog
         self._group = False            # True: child leads its own group/session -> kill() tears down its whole tree
-        self._killed = False           # set by kill(); close() only force-closes the pipe early when we killed
+        self._killed = False           # set by kill(). close() only force-closes the pipe early after a kill
 
         env = env if env else os.environ.copy()
         args = shlex.split(cmd) if isinstance(cmd, str) else list(cmd)
 
-        # Resolve the executable ourselves so we don't have to ask the shell
-        # (avoids shell quoting/escaping pitfalls; same logic as before).
+        # Resolve the executable here instead of asking a shell, so no shell quoting or escaping applies.
         executable = args[0]
         if os.path.isfile(executable):
             executable = os.path.abspath(executable)
@@ -90,7 +83,7 @@ class SubProcess:
             return
 
         if System.windows:
-            # No PTY on Windows; merge stderr into stdout pipe. Binary mode so the
+            # No PTY on Windows: merge stderr into the stdout pipe. Binary mode so the
             # reader can byte-level split on \r as well as \n (ninja/cmake progress).
             # CREATE_NEW_PROCESS_GROUP: the child leads its own group, so interrupt() can send it a
             # console CTRL_BREAK without a signal to mama itself. A console Ctrl+C then stops at mama
@@ -100,7 +93,7 @@ class SubProcess:
                                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             self._group = True  # kill() uses taskkill /T to take down cmake's ninja/compiler subtree
         else:
-            # Allocate a PTY pair; child gets the slave end as its stdin/stdout/stderr.
+            # Allocate a PTY pair. The child gets the slave end as its stdin/stdout/stderr.
             self._master_fd, slave = pty.openpty()
             try:
                 # start_new_session: child leads its own session so kill() can killpg the whole tree
@@ -109,9 +102,9 @@ class SubProcess:
                                                 stderr=slave, close_fds=True, start_new_session=True)
                 self._group = True
             finally:
-                os.close(slave) # parent doesn't need the slave once Popen has it
+                os.close(slave) # the parent does not need the slave once Popen has it
 
-        # io_func runs on the reader thread; carry the caller's console-capture context onto it so its
+        # io_func runs on the reader thread. Carry the caller's console-capture context onto it so its
         # console() lines feed the owning display task instead of leaking above the live region.
         self._capture_ctx = capture_context()
         self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
@@ -125,15 +118,15 @@ class SubProcess:
                      (self.process.stdout.fileno() if self.process.stdout else None)
                 if fd is not None: self._read_loop_queued(fd)
         except Exception as e:
-            self._reader_exc = e  # captured so run() can surface it; don't crash the reader thread
+            self._reader_exc = e  # captured so run() can surface it, do not crash the reader thread
 
 
     def _read_loop_queued(self, fd):
         """One reader for both PTY (UNIX) and pipe (Windows): a pump thread does the blocking
-        os.read(fd) and hands chunks to a queue; this drain loop turns them into lines with the
-        \\r-progress idle-flush (queue.get timeout). Decoupling the read from io_func means a slow
-        consumer (or GIL contention from CPU sampling) never stalls os.read, so the child's PTY/pipe
-        can't fill and block the read."""
+        os.read(fd) and hands chunks to a queue, and this drain loop turns them into lines with the
+        \\r-progress idle-flush (queue.get timeout). The read is decoupled from io_func, so a slow
+        consumer (or GIL contention from CPU sampling) never stalls os.read, and the child's PTY/pipe
+        cannot fill and block the read."""
         chunks: queue.Queue = queue.Queue()
         def pump():
             while True:
@@ -198,7 +191,7 @@ class SubProcess:
             try:
                 self.io_func(self, buf.decode('utf-8', errors='replace'))
             except Exception as e:
-                # Capture so run() can surface it. Don't crash the reader thread.
+                # Capture so run() can surface it. Do not crash the reader thread.
                 self._reader_exc = e
 
 
@@ -298,7 +291,7 @@ class SubProcess:
     def _kill_tree(self, p):
         """Kill the child AND its descendants (ninja + compilers). A plain terminate()/kill() hits only
         the spawned cmake/git pid. On Windows TerminateProcess and on UNIX a single SIGKILL both leave
-        the compiler grandchildren running. Falls back to a single-process kill if the group call fails."""
+        the compiler grandchildren running. Uses a single-process kill when the group call fails."""
         if not _kill_group(self.group_id() or p.pid):
             try: p.kill()
             except Exception: pass
@@ -307,7 +300,7 @@ class SubProcess:
 
 
     def close(self):
-        self.kill()  # no-op if the child already exited; sets self._killed if it had to kill a live one
+        self.kill()  # no-op if the child already exited, sets self._killed if it had to kill a live one
         win_out = self.process.stdout if (System.windows and self.process) else None
         # Force the Windows read-end shut ONLY when we killed the child: its grandchildren (ninja/compilers)
         # may still hold the write end, so the pump would block in os.read forever. On a CLEAN exit the write
@@ -333,8 +326,8 @@ class SubProcess:
 
 
     def try_wait(self):
-        """Returns the exit status if the child has finished, else None.
-        Kept for backwards-compat with callers that used the old polling API."""
+        """Returns the exit status when the child has finished, else None.
+        Kept for backward compatibility with callers of the old polling API."""
         if self.process is None:
             return self.status
         rc = self.process.poll()
@@ -344,9 +337,9 @@ class SubProcess:
 
 
     def _wait_idle(self, timeout, idle_timeout):
-        """Wait for the child, killing it if it's silent for `idle_timeout` s (or exceeds total
-        `timeout`). The idle bound catches a git op stuck on an auth prompt / hung server without
-        aborting a slow-but-streaming clone. Raises TimeoutExpired on either bound."""
+        """Wait for the child. Kill it when it stays silent for `idle_timeout` seconds, or exceeds the
+        total `timeout`. The idle bound catches a git op stuck on an auth prompt or a hung server
+        without aborting a slow-but-streaming clone. Raises TimeoutExpired on either bound."""
         start = time.monotonic()
         while True:
             try:
@@ -366,11 +359,12 @@ class SubProcess:
         - cmd:     command string (shlex.split) or list of args.
         - cwd:     working directory for the child.
         - env:     environment dict, defaults to os.environ.
-        - io_func: callback `(SubProcess, line:str)` for each output line;
-                   if None, child inherits parent's std streams.
+        - io_func: callback `(SubProcess, line:str)` for each output line.
+                   If None, the child inherits the parent's std streams.
         - timeout: kill the child after this many seconds total (raises TimeoutExpired).
-        - idle_timeout: kill if silent this many seconds (raises TimeoutExpired). Needs io_func set.
-                   For network git ops that may hang on a prompt; a streaming clone is never killed.
+        - idle_timeout: kill the child when silent this many seconds (raises TimeoutExpired). Needs
+                   io_func set. For a network git op that can hang on a prompt. A streaming clone
+                   is never killed.
         """
         abort.check()  # fast path: do not even spawn while the build stops
         p = SubProcess(cmd, cwd=cwd, env=env, io_func=io_func)
@@ -403,7 +397,7 @@ def execute(command, echo=False, throw=True):
     Executes a command and returns the status code.
     - command: command string
     - echo: if True, prints the command to console
-    - throw: if True, throws exception on status_code != 0
+    - throw: if True, throws an exception on status_code != 0
     - returns: status code
 
     os.system, so the child gets the real terminal and a shell: this is for INTERACTIVE commands only
@@ -420,17 +414,17 @@ def execute(command, echo=False, throw=True):
 
 def execute_piped(command, cwd=None, timeout=None, throw=True):
     """
-    Executes a command and returns the piped outout string
+    Executes a command and returns the piped output string
     - command: command string
     - cwd: working dir for the subprocess
     - timeout: timeout in seconds
-    - throw: if True, throws exception on status_code != 0
-    - returns: output string or None if throw=False
+    - throw: if True, raises on a spawn error or timeout. A non-zero exit status never raises here.
+    - returns: output string, or None on failure when throw=False
 
     stderr is CAPTURED, never inherited. A child that writes straight to the terminal (ssh complaining
     about the user's ssh_config, git's `fatal: Could not read from remote repository`) bypasses every
     mama filter, and it tears the live display, which redraws by counting the lines it wrote itself. The
-    caller wants stdout; a real failure still surfaces through the clone or fetch that follows.
+    caller wants stdout. A real failure still surfaces through the clone or fetch that follows.
     """
     if not isinstance(command, list):
         command = shlex.split(command)
@@ -450,13 +444,13 @@ def execute_echo(cwd, cmd, exit_on_fail=False, env=None, quiet=False):
     - cwd: working dir for the subprocess
     - cmd: command string
     - exit_on_fail: if True, exits the application with exit_status
-    - env: overrrides the environment for the subprocess, default is os.environ
-    - quiet: if True, drop the child's output entirely (it still runs and is exit-checked)
+    - env: overrides the environment for the subprocess, default is os.environ
+    - quiet: if True, drops the child's output entirely (the child still runs and gets exit-checked)
     """
     # Inside a scheduled build phase a capture sink is active: route the child's output through console()
     # so a custom build()'s commands land in the owning display task (and the log) instead of tearing the
     # live region. Outside it (serial path, interactive run/gdb/test post-pass) keep stdio direct - the
-    # child needs the real terminal for prompts, and there's nowhere to capture to anyway.
+    # child needs the real terminal for prompts, and there is no sink to capture to anyway.
     if quiet:               io = lambda p, line: None                # caller asked for silence: drop output
     elif capture_context()[0] is not None: io = lambda p, line: console(line)
     else:                   io = None
@@ -481,8 +475,8 @@ def execute_piped_echo(cwd, cmd, echo=True, env=None, out=None):
     - cwd: working dir for the subprocess
     - cmd: command string
     - echo: if True, also prints the output to console
-    - env: overrrides the environment for the subprocess, default is os.environ
-    - out: optional `(line) -> None` sink; when set, lines go there instead of being printed
+    - env: overrides the environment for the subprocess, default is os.environ
+    - out: optional `(line) -> None` sink. When set, lines go there instead of the console
     - returns: (exit_status, output_string)
     """
     lines = []  # list + join, NOT output += line: the latter is O(n^2) over a big build's output

--- a/mama/utils/sub_process.py
+++ b/mama/utils/sub_process.py
@@ -4,11 +4,9 @@ from . import abort
 from .system import System, console, error, report_subprocess, capture_to, capture_context
 
 
-# Linux/macOS: the child gets a PTY, so git etc. still see a TTY and keep their
-# progress output and isatty checks. pty.openpty() does NOT fork, it only makes a
-# master/slave fd pair, so a worker thread can call it. subprocess.Popen forks via
-# posix_spawn/vfork, which is multi-thread safe, unlike the older os.forkpty,
-# which Python 3.12 deprecates for its deadlock risk in threaded programs.
+# UNIX children get a PTY, so git etc. keep their progress output and isatty checks. pty.openpty() does
+# NOT fork, it only makes an fd pair, so a worker thread can call it. Popen forks via posix_spawn, which
+# is multi-thread safe, unlike os.forkpty, which Python 3.12 deprecates for deadlock risk under threads.
 if not System.windows:
     import pty
 
@@ -23,9 +21,8 @@ _live_procs = set()   # live SubProcess instances. terminate_all() stops every o
 
 def _kill_group(gid) -> bool:
     """Hard-kill a whole process group (UNIX) or a pid's process tree (Windows), and report whether the
-    call succeeded. A group whose members already exited is empty, so the call fails and that is the
-    intended no-op: nothing survived to kill.
-    Raw subprocess.run (not SubProcess.run): the killer must not register in _live_procs. The abort
+    call succeeded. A group whose members already exited is empty, so the call fails: the intended no-op.
+    Raw subprocess.run (not SubProcess.run): the killer must not register in _live_procs, and the abort
     flag must not block it, because it runs precisely while mama aborts."""
     try:
         if System.windows:
@@ -39,16 +36,10 @@ def _kill_group(gid) -> bool:
 
 
 class SubProcess:
-    """
-    Subprocess wrapper with optional line-by-line output capture.
-
-    With ``io_func`` set, a background reader thread feeds the child's combined
-    stdout+stderr to ``io_func`` one line at a time. On UNIX the child runs on a
-    PTY, so it sees a TTY and prints colored/progress output.
-
-    Without ``io_func``, the child inherits the parent's stdout/stderr, for
-    commands like `mama test` whose output must flow directly.
-    """
+    """Subprocess wrapper with optional line-by-line output capture. With `io_func` set, a background
+    reader thread feeds the child's combined stdout+stderr to `io_func` one line at a time, and on UNIX
+    the child runs on a PTY, so it prints colored/progress output. Without `io_func`, the child inherits
+    the parent's stdout/stderr, for commands whose output must flow directly."""
     def __init__(self, cmd, cwd=None, env=None, io_func=None):
         self.io_func = io_func
         self.status = None
@@ -83,12 +74,10 @@ class SubProcess:
             return
 
         if System.windows:
-            # No PTY on Windows: merge stderr into the stdout pipe. Binary mode so the
-            # reader can byte-level split on \r as well as \n (ninja/cmake progress).
-            # CREATE_NEW_PROCESS_GROUP: the child leads its own group, so interrupt() can send it a
-            # console CTRL_BREAK without a signal to mama itself. A console Ctrl+C then stops at mama
-            # and no longer reaches the child, which matches UNIX (start_new_session, below). Mama owns
-            # the shutdown and relays it, instead of a race with the child for the same signal.
+            # No PTY on Windows: merge stderr into the stdout pipe, binary mode so the reader can split on \r.
+            # CREATE_NEW_PROCESS_GROUP: the child leads its own group, so interrupt() can send it a console
+            # CTRL_BREAK without a signal to mama itself, and a console Ctrl+C stops at mama (matches UNIX):
+            # mama owns the shutdown and relays it, instead of a race with the child for the same signal.
             self.process = subprocess.Popen(args, cwd=cwd, env=env, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
                                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             self._group = True  # kill() uses taskkill /T to take down cmake's ninja/compiler subtree
@@ -96,16 +85,15 @@ class SubProcess:
             # Allocate a PTY pair. The child gets the slave end as its stdin/stdout/stderr.
             self._master_fd, slave = pty.openpty()
             try:
-                # start_new_session: child leads its own session so kill() can killpg the whole tree
-                # (cmake -> ninja -> compilers), not just the spawned pid.
+                # start_new_session: the child leads its own session, so kill() can killpg the whole tree, not one pid
                 self.process = subprocess.Popen(args, cwd=cwd, env=env, stdin=slave, stdout=slave,
                                                 stderr=slave, close_fds=True, start_new_session=True)
                 self._group = True
             finally:
                 os.close(slave) # the parent does not need the slave once Popen has it
 
-        # io_func runs on the reader thread. Carry the caller's console-capture context onto it so its
-        # console() lines feed the owning display task instead of leaking above the live region.
+        # carry the caller's console-capture context onto the reader thread, so io_func's console() lines
+        # feed the owning display task instead of leaking above the live region
         self._capture_ctx = capture_context()
         self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
         self._reader_thread.start()
@@ -122,18 +110,16 @@ class SubProcess:
 
 
     def _read_loop_queued(self, fd):
-        """One reader for both PTY (UNIX) and pipe (Windows): a pump thread does the blocking
-        os.read(fd) and hands chunks to a queue, and this drain loop turns them into lines with the
-        \\r-progress idle-flush (queue.get timeout). The read is decoupled from io_func, so a slow
-        consumer (or GIL contention from CPU sampling) never stalls os.read, and the child's PTY/pipe
-        cannot fill and block the read."""
+        """One reader for both PTY (UNIX) and pipe (Windows): a pump thread does the blocking os.read(fd)
+        and hands chunks to a queue, and this drain loop turns them into lines with the \\r-progress
+        idle-flush. A slow io_func never stalls os.read, so the child's PTY/pipe cannot fill and block."""
         chunks: queue.Queue = queue.Queue()
         def pump():
             while True:
                 try: chunk = os.read(fd, READER_CHUNK)
                 except OSError: chunk = b''  # EIO on a closed PTY slave / closed pipe = EOF
-                if chunk: self._last_output = time.monotonic()  # reset idle watchdog AS DATA ARRIVES, not
-                chunks.put(chunk)                                # when the drain processes it (drain can lag under load)
+                if chunk: self._last_output = time.monotonic()  # reset the idle watchdog AS DATA ARRIVES, the drain can lag
+                chunks.put(chunk)
                 if not chunk: break
         threading.Thread(target=pump, daemon=True).start()
         buf = bytearray()
@@ -149,13 +135,10 @@ class SubProcess:
 
 
     def _drain_buffer(self, buf:bytearray, idle=False, eof=False):
-        """Emit \\r- and \\n-delimited lines from buf. \\r alone is progress;
-        \\r\\n and bare \\n are line endings (trailing \\r stripped). A \\r at
-        buf end waits for more data unless idle/eof, then sets _swallow_lf so
-        the next chunk's leading \\n or \\r\\n (via PTY ONLCR) is consumed.
-
-        Scans with a moving `pos` cursor and trims consumed bytes in one
-        trailing `del` instead of a `del buf[:k]` per emitted line."""
+        """Emit \\r- and \\n-delimited lines from buf. A lone \\r is progress, \\r\\n and bare \\n end a line.
+        A \\r at buf end waits for more data unless idle/eof, then sets _swallow_lf so the next chunk's
+        leading \\n or \\r\\n (via PTY ONLCR) is consumed. Scans with a moving `pos` cursor and trims
+        consumed bytes in one trailing `del`, not a `del buf[:k]` per emitted line."""
         n = len(buf)
         pos = 0
         if self._swallow_lf and n:
@@ -191,13 +174,11 @@ class SubProcess:
             try:
                 self.io_func(self, buf.decode('utf-8', errors='replace'))
             except Exception as e:
-                # Capture so run() can surface it. Do not crash the reader thread.
-                self._reader_exc = e
+                self._reader_exc = e  # captured so run() can surface it, do not crash the reader thread
 
 
     def write(self, text: str):
-        """Send `text` to the child's stdin (used for interactive prompts
-        like SSH host-key acceptance)."""
+        """Send `text` to the child's stdin, for interactive prompts like SSH host-key acceptance."""
         data = text.encode('utf-8')
         if self._master_fd is not None:
             os.write(self._master_fd, data)
@@ -215,15 +196,14 @@ class SubProcess:
         1. Set the abort flag, so nothing new spawns and every phase gate closes.
         2. Ask each live child to stop, as a Ctrl+C does, then wait `grace` seconds.
         3. Kill each child that ignored the request.
-        The grace lets git remove its partial clone and its index.lock, and lets ninja remove the
-        object file it was writing. A hard kill leaves both behind for the next build to trip on."""
-        # The flag and the snapshot go under one lock, so a concurrent run() cannot register a child
-        # that this snapshot misses. run() re-checks the flag under the same lock after it spawns.
+        The grace lets git and ninja remove their partial files, which a hard kill leaves behind for the
+        next build to trip on."""
+        # the flag and the snapshot go under one lock, so a concurrent run() cannot register a child this
+        # snapshot misses: run() re-checks the flag under the same lock after it spawns
         with _procs_lock:
             abort.request(reason)
             procs = list(_live_procs)
-        # Read each group id NOW, while its leader still lives: getpgid() fails once the pid is gone,
-        # and stage 3 needs the group after a child of its own has exited.
+        # read each group id NOW, while its leader lives: getpgid() fails once the pid is gone, and stage 3 needs the group
         groups = [g for g in (p.group_id() for p in procs) if g]
         for p in procs: p.interrupt()
         deadline = time.monotonic() + grace
@@ -235,9 +215,8 @@ class SubProcess:
         for p in procs:
             try: p.kill()
             except Exception: pass
-        # Sweep the groups too. A child that stopped on its own leaves no process to kill above, but a
-        # GRANDCHILD can miss the group signal (it can be mid-exec when the signal lands) and then run
-        # on with nobody left to stop it. A group whose members all exited is empty and this is a no-op.
+        # Sweep the groups too: a GRANDCHILD can miss the group signal (mid-exec when it lands) and run on
+        # with nobody left to stop it. A group whose members all exited is empty and this is a no-op.
         for gid in groups: _kill_group(gid)
 
     @staticmethod
@@ -246,11 +225,10 @@ class SubProcess:
         abort.clear()
 
     def interrupt(self):
-        """Ask the child and its whole tree to stop, as a Ctrl+C does, so it can remove its own
-        leftovers. UNIX sends SIGINT to its session. Windows sends a console CTRL_BREAK to its process
-        group, which is the reason that group exists. A Windows child in mama's own group (io_func is
-        None, an interactive command) gets no signal, because mama cannot signal it without a signal to
-        itself. kill() stops that one."""
+        """Ask the child and its whole tree to stop, as a Ctrl+C does, so it can remove its own leftovers.
+        UNIX sends SIGINT to its session, Windows a console CTRL_BREAK to its process group. A Windows
+        child in mama's own group (an interactive command) gets no signal, because mama cannot signal it
+        without a signal to itself. kill() stops that one."""
         p = self.process
         if not p or p.poll() is not None: return
         try:
@@ -289,9 +267,8 @@ class SubProcess:
         except Exception: return None
 
     def _kill_tree(self, p):
-        """Kill the child AND its descendants (ninja + compilers). A plain terminate()/kill() hits only
-        the spawned cmake/git pid. On Windows TerminateProcess and on UNIX a single SIGKILL both leave
-        the compiler grandchildren running. Uses a single-process kill when the group call fails."""
+        """Kill the child AND its descendants: a plain terminate()/kill() hits only the spawned pid and
+        leaves the compiler grandchildren running. Uses a single-process kill when the group call fails."""
         if not _kill_group(self.group_id() or p.pid):
             try: p.kill()
             except Exception: pass
@@ -302,15 +279,13 @@ class SubProcess:
     def close(self):
         self.kill()  # no-op if the child already exited, sets self._killed if it had to kill a live one
         win_out = self.process.stdout if (System.windows and self.process) else None
-        # Force the Windows read-end shut ONLY when we killed the child: its grandchildren (ninja/compilers)
-        # may still hold the write end, so the pump would block in os.read forever. On a CLEAN exit the write
-        # end is already closed, so closing here would race the pump and DROP the final buffered lines (e.g.
-        # the compiler error that failed the build) - instead drain first (join) and close after.
+        # Force the Windows read-end shut ONLY after a kill: grandchildren may still hold the write end, so
+        # the pump would block in os.read forever. On a CLEAN exit closing here would race the pump and
+        # DROP the final buffered lines (the compiler error), so drain first (join) and close after.
         if win_out and self._killed:
             try: win_out.close()
             except OSError: pass
-        # Reader thread drains its queue then exits on EOF (Windows pipe closed, or UNIX PTY master closed
-        # below). Join so all trailing output reaches io_func before we return.
+        # the reader drains its queue then exits on EOF: join so all trailing output reaches io_func before we return
         if self._reader_thread:
             self._reader_thread.join(timeout=2.0)
             self._reader_thread = None
@@ -354,18 +329,14 @@ class SubProcess:
 
     @staticmethod
     def run(cmd, cwd=None, env=None, io_func=None, timeout=None, idle_timeout=None):
-        """
-        Runs `cmd` and returns its exit status.
-        - cmd:     command string (shlex.split) or list of args.
-        - cwd:     working directory for the child.
-        - env:     environment dict, defaults to os.environ.
-        - io_func: callback `(SubProcess, line:str)` for each output line.
-                   If None, the child inherits the parent's std streams.
-        - timeout: kill the child after this many seconds total (raises TimeoutExpired).
-        - idle_timeout: kill the child when silent this many seconds (raises TimeoutExpired). Needs
-                   io_func set. For a network git op that can hang on a prompt. A streaming clone
-                   is never killed.
-        """
+        """Runs `cmd` and returns its exit status.
+        cmd: command string (shlex.split) or list of args
+        cwd: working directory for the child
+        env: environment dict, defaults to os.environ
+        io_func: callback `(SubProcess, line:str)` per output line. If None, the child inherits the parent's std streams
+        timeout: kill the child after this many seconds total (raises TimeoutExpired)
+        idle_timeout: kill the child when silent this many seconds (raises TimeoutExpired). Needs io_func
+                      set. For a git op that can hang on a prompt, a streaming clone is never killed."""
         abort.check()  # fast path: do not even spawn while the build stops
         p = SubProcess(cmd, cwd=cwd, env=env, io_func=io_func)
         pid = p.process.pid if p.process else None
@@ -393,18 +364,13 @@ class SubProcess:
 
 
 def execute(command, echo=False, throw=True):
-    """
-    Executes a command and returns the status code.
-    - command: command string
-    - echo: if True, prints the command to console
-    - throw: if True, throws an exception on status_code != 0
-    - returns: status code
-
-    os.system, so the child gets the real terminal and a shell: this is for INTERACTIVE commands only
-    (`code`, `open`, an apt-get install that prompts for a sudo password). It inherits stdout and
-    stderr, so it tears the live display and no filter can reach its output. Use execute_echo or
-    SubProcess.run for anything on the build path.
-    """
+    """Executes a command and returns the status code.
+    command: command string
+    echo: if True, prints the command to console
+    throw: if True, throws an exception on status_code != 0
+    os.system, so the child gets the real terminal and a shell: for INTERACTIVE commands only (`code`,
+    a sudo prompt). It inherits stdout and stderr, so it tears the live display and no filter can reach
+    its output. Use execute_echo or SubProcess.run for anything on the build path."""
     if echo: console(command)
     retcode = os.system(command)
     if throw and retcode != 0:
@@ -413,19 +379,14 @@ def execute(command, echo=False, throw=True):
 
 
 def execute_piped(command, cwd=None, timeout=None, throw=True):
-    """
-    Executes a command and returns the piped output string
-    - command: command string
-    - cwd: working dir for the subprocess
-    - timeout: timeout in seconds
-    - throw: if True, raises on a spawn error or timeout. A non-zero exit status never raises here.
-    - returns: output string, or None on failure when throw=False
-
-    stderr is CAPTURED, never inherited. A child that writes straight to the terminal (ssh complaining
-    about the user's ssh_config, git's `fatal: Could not read from remote repository`) bypasses every
-    mama filter, and it tears the live display, which redraws by counting the lines it wrote itself. The
-    caller wants stdout. A real failure still surfaces through the clone or fetch that follows.
-    """
+    """Executes a command and returns the piped output string, or None on failure when throw=False.
+    command: command string
+    cwd: working dir for the subprocess
+    timeout: timeout in seconds
+    throw: if True, raises on a spawn error or timeout. A non-zero exit status never raises here.
+    stderr is CAPTURED, never inherited: a child that writes straight to the terminal bypasses every mama
+    filter and tears the live display, which redraws by counting the lines it wrote itself. The caller
+    wants stdout, and a real failure still surfaces through the clone or fetch that follows."""
     if not isinstance(command, list):
         command = shlex.split(command)
     try:
@@ -439,18 +400,15 @@ def execute_piped(command, cwd=None, timeout=None, throw=True):
 
 
 def execute_echo(cwd, cmd, exit_on_fail=False, env=None, quiet=False):
-    """
-    Wrapper around SubProcess.run(), by default throws if exit_status != 0
-    - cwd: working dir for the subprocess
-    - cmd: command string
-    - exit_on_fail: if True, exits the application with exit_status
-    - env: overrides the environment for the subprocess, default is os.environ
-    - quiet: if True, drops the child's output entirely (the child still runs and gets exit-checked)
-    """
-    # Inside a scheduled build phase a capture sink is active: route the child's output through console()
-    # so a custom build()'s commands land in the owning display task (and the log) instead of tearing the
-    # live region. Outside it (serial path, interactive run/gdb/test post-pass) keep stdio direct - the
-    # child needs the real terminal for prompts, and there is no sink to capture to anyway.
+    """Wrapper around SubProcess.run(), by default throws if exit_status != 0.
+    cwd: working dir for the subprocess
+    cmd: command string
+    exit_on_fail: if True, exits the application with exit_status
+    env: overrides the environment for the subprocess, default is os.environ
+    quiet: if True, drops the child's output entirely (the child still runs and gets exit-checked)"""
+    # Inside a scheduled build phase a capture sink is active: route the child's output through console(),
+    # so it lands in the owning display task and the log instead of tearing the live region. Outside it
+    # keep stdio direct: the child needs the real terminal for prompts, and there is no sink anyway.
     if quiet:               io = lambda p, line: None                # caller asked for silence: drop output
     elif capture_context()[0] is not None: io = lambda p, line: console(line)
     else:                   io = None
@@ -470,15 +428,12 @@ def execute_echo(cwd, cmd, exit_on_fail=False, env=None, quiet=False):
 
 
 def execute_piped_echo(cwd, cmd, echo=True, env=None, out=None):
-    """
-    Wrapper around SubProcess.run(), returns status code with piped output (status, output).
-    - cwd: working dir for the subprocess
-    - cmd: command string
-    - echo: if True, also prints the output to console
-    - env: overrides the environment for the subprocess, default is os.environ
-    - out: optional `(line) -> None` sink. When set, lines go there instead of the console
-    - returns: (exit_status, output_string)
-    """
+    """Wrapper around SubProcess.run(), returns (exit_status, output_string).
+    cwd: working dir for the subprocess
+    cmd: command string
+    echo: if True, also prints the output to console
+    env: overrides the environment for the subprocess, default is os.environ
+    out: optional `(line) -> None` sink. When set, lines go there instead of the console"""
     lines = []  # list + join, NOT output += line: the latter is O(n^2) over a big build's output
     def handle_output(p:SubProcess, line:str):
         if out:    out(line)

--- a/mama/utils/system.py
+++ b/mama/utils/system.py
@@ -20,15 +20,7 @@ class System:
     x86_64  = is_x86_64
     x86     = is_x86
 
-# Available text colors:
-#     black, red, green, yellow, blue, magenta, cyan, white,
-#     light_grey, dark_grey, light_red, light_green, light_yellow, light_blue,
-#     light_magenta, light_cyan.
-
-# Available text highlights:
-#     on_black, on_red, on_green, on_yellow, on_blue, on_magenta, on_cyan, on_white,
-#     on_light_grey, on_dark_grey, on_light_red, on_light_green, on_light_yellow,
-#     on_light_blue, on_light_magenta, on_light_cyan.
+# Values are termcolor color names. Extend from the termcolor palette when a new color is needed.
 class Color:
     DEFAULT = None
     RED = "red"
@@ -38,7 +30,7 @@ class Color:
     MAGENTA = "magenta"
 
 
-# on windows use colorama to enable ANSI color escape sequences
+# on Windows, colorama enables ANSI color escape sequences
 if System.windows:
     from colorama import just_fix_windows_console
     just_fix_windows_console()
@@ -49,11 +41,11 @@ def get_colored_text(text:str, color):
 
 
 # Serialize writes and finalize any pending progress line before a normal
-# status print, so parallel redraws don't get glued to status lines.
+# status print, so parallel redraws do not get glued to status lines.
 _console_lock = threading.Lock()
 _progress_active = False  # last write left cursor mid-row
 _ERASE_EOL = '\x1b[K'  # ANSI erase-to-end-of-line (colorama enables it on Windows)
-_active_display = None  # duck-typed BuildDisplay; routes normal lines above its live region
+_active_display = None  # duck-typed BuildDisplay, routes normal lines above its live region
 _capture = threading.local()  # per-thread sink: a running job's console() lines go to its display task
 
 # Set by GitHub Actions and GitLab CI (CI), Azure Pipelines, Jenkins and TeamCity.
@@ -75,10 +67,10 @@ def is_headless() -> bool:
 
 def _redraw_due() -> bool:
     """True when a progress redraw may print. Without a terminal a redraw appends a line instead of
-    overwriting one, so a CI log collects one flood of bars per download. Throttle those to one line
-    per _HEADLESS_PROGRESS_INTERVAL per thread, and let the first call only start the timer, so a
-    transfer that finishes inside one interval prints its final line and nothing else. A captured
-    redraw is exempt: it feeds the live display, which already decides what reaches the screen."""
+    overwriting one, so a CI log collects one flood of bars per download. Those throttle to one line
+    per _HEADLESS_PROGRESS_INTERVAL per thread. The first call only starts the timer, so a transfer
+    that finishes inside one interval prints its final line and nothing else. A captured redraw is
+    exempt: it feeds the live display, which already decides what reaches the screen."""
     if not is_headless() or getattr(_capture, 'sink', None) is not None: return True
     now = time.monotonic()
     last = getattr(_progress_at, 'at', None)
@@ -96,9 +88,9 @@ def set_active_display(display):
 
 def capture_context():
     """Snapshot this thread's console-capture state as a (sink, display, tid, build_slot) tuple. A
-    helper thread that runs io_func - SubProcess's reader thread - re-establishes it via
-    capture_to(*ctx); without that, io_func's console() lines have no sink and leak above the live
-    region instead of feeding the owning display task."""
+    helper thread that runs io_func - SubProcess's reader thread - restores it with capture_to(*ctx).
+    Without that, io_func's console() lines have no sink and leak above the live region instead of
+    feeding the owning display task."""
     return (getattr(_capture, 'sink', None), getattr(_capture, 'display', None),
             getattr(_capture, 'tid', None), getattr(_capture, 'build_slot', None))
 
@@ -106,8 +98,8 @@ def capture_context():
 @contextlib.contextmanager
 def capture_to(sink, display=None, tid=None, build_slot=None):
     """Route THIS thread's console() lines to `sink` (a display task feed) so a job's banners land
-    in its display line instead of tearing the live region; restores the previous sink on exit.
-    `display`/`tid` let SubProcess report child pids for CPU sampling; `build_slot` is the
+    in its display line instead of tearing the live region. Restores the previous sink on exit.
+    `display`/`tid` let SubProcess report child pids for CPU sampling. `build_slot` is the
     scheduler barrier so a custom build()'s cmake_build() can self-gate."""
     prev = capture_context()
     _capture.sink, _capture.display, _capture.tid, _capture.build_slot = sink, display, tid, build_slot
@@ -141,25 +133,25 @@ def report_subprocess(pid: int, started: bool):
 def console(text:str, color=None, end="\n"):
     """ Always flush to support most build environments """
     global _progress_active
-    is_redraw = text.startswith('\r')        # redraws start with \r (cursor reset); see progress()
+    is_redraw = text.startswith('\r')        # redraws start with \r (cursor reset), see progress()
     clean = text[1:] if is_redraw else text  # \r stripped: line-based sinks/region want a clean line
     # While a display owns the screen, route EVERYTHING through it - any direct stdout write (even a
     # \r-redraw or a partial) desyncs the region's cursor math and walks it down the screen. Owned
-    # output feeds the job's task preview; an ownerless full line goes above the region; an ownerless
-    # mid-progress redraw is dropped (can't place it in the line-based region without corrupting it).
+    # output feeds the job's task preview. An ownerless full line goes above the region. An ownerless
+    # mid-progress redraw is dropped: the line-based region cannot place it without corruption.
     sink = getattr(_capture, 'sink', None)
     if sink is not None or _active_display is not None:
         # Split an embedded-newline message into SEPARATE lines: the display is line-based, and a
         # multi-line string smuggled through as one 'line' shifts the terminal cursor, desyncing the
         # live region's cursor-up math and stranding running task lines in the scrollback.
         for part in (clean.split('\n') if '\n' in clean else (clean,)):
-            line = get_colored_text(part, color)  # not `colored`: that's termcolor's, imported above
+            line = get_colored_text(part, color)  # not `colored`: that name is termcolor's, imported above
             if sink is not None: sink(line)
             elif end == '\n': _active_display.print_above(line)
         return
     text = get_colored_text(text, color)
     with _console_lock:
-        # a status line right after an in-flight \r-progress needs a leading \n so it isn't overwritten
+        # a status line right after an in-flight \r-progress needs a leading \n so the redraw does not overwrite it
         if _progress_active and not is_redraw:
             print()
         if is_redraw: text += _ERASE_EOL  # erase-to-EOL so a shorter redraw clears the longer prev line
@@ -168,20 +160,20 @@ def console(text:str, color=None, end="\n"):
 
 
 def progress(text:str, color=None, final=False):
-    """Redraw an in-place progress line, always cleared to end-of-line. `final=True`
-    commits it with a newline; otherwise the cursor stays put for the next redraw. A final line always
-    prints; see _redraw_due() for why the rest throttle without a terminal."""
+    """Redraw an in-place progress line, always cleared to end-of-line. `final=True` commits it with a
+    newline. Otherwise the cursor stays on the line for the next redraw. A final line always prints.
+    See _redraw_due() for why the rest throttle without a terminal."""
     if not final and not _redraw_due(): return
     console('\r' + text, color=color, end='\n' if final else '')
 
 
 def error(text:str):
-    """ Prints a message as an error, usually colored red """
+    """ Prints an error message, colored red """
     console(text, color=Color.RED)
 
 
 def warning(text:str):
-    """ Prints a message as a warning, colored yellow """
+    """ Prints a warning message, colored yellow """
     console(text, color=Color.YELLOW)
 
 

--- a/mama/utils/system.py
+++ b/mama/utils/system.py
@@ -40,8 +40,7 @@ def get_colored_text(text:str, color):
     return colored(text, color=color) if color else text
 
 
-# Serialize writes and finalize any pending progress line before a normal
-# status print, so parallel redraws do not get glued to status lines.
+# serialize writes and finalize a pending progress line before a status print, so redraws do not glue to status lines
 _console_lock = threading.Lock()
 _progress_active = False  # last write left cursor mid-row
 _ERASE_EOL = '\x1b[K'  # ANSI erase-to-end-of-line (colorama enables it on Windows)
@@ -67,10 +66,9 @@ def is_headless() -> bool:
 
 def _redraw_due() -> bool:
     """True when a progress redraw may print. Without a terminal a redraw appends a line instead of
-    overwriting one, so a CI log collects one flood of bars per download. Those throttle to one line
-    per _HEADLESS_PROGRESS_INTERVAL per thread. The first call only starts the timer, so a transfer
-    that finishes inside one interval prints its final line and nothing else. A captured redraw is
-    exempt: it feeds the live display, which already decides what reaches the screen."""
+    overwriting one, so those throttle to one line per _HEADLESS_PROGRESS_INTERVAL per thread. The first
+    call only starts the timer, so a transfer that finishes inside one interval prints only its final
+    line. A captured redraw is exempt: it feeds the live display, which decides what reaches the screen."""
     if not is_headless() or getattr(_capture, 'sink', None) is not None: return True
     now = time.monotonic()
     last = getattr(_progress_at, 'at', None)
@@ -87,20 +85,19 @@ def set_active_display(display):
 
 
 def capture_context():
-    """Snapshot this thread's console-capture state as a (sink, display, tid, build_slot) tuple. A
-    helper thread that runs io_func - SubProcess's reader thread - restores it with capture_to(*ctx).
-    Without that, io_func's console() lines have no sink and leak above the live region instead of
-    feeding the owning display task."""
+    """Snapshot this thread's console-capture state as a (sink, display, tid, build_slot) tuple. A helper
+    thread that runs io_func restores it with capture_to(*ctx). Without that, io_func's console() lines
+    have no sink and leak above the live region instead of feeding the owning display task."""
     return (getattr(_capture, 'sink', None), getattr(_capture, 'display', None),
             getattr(_capture, 'tid', None), getattr(_capture, 'build_slot', None))
 
 
 @contextlib.contextmanager
 def capture_to(sink, display=None, tid=None, build_slot=None):
-    """Route THIS thread's console() lines to `sink` (a display task feed) so a job's banners land
-    in its display line instead of tearing the live region. Restores the previous sink on exit.
-    `display`/`tid` let SubProcess report child pids for CPU sampling. `build_slot` is the
-    scheduler barrier so a custom build()'s cmake_build() can self-gate."""
+    """Route THIS thread's console() lines to `sink` for the `with` block, restoring the previous sink on exit.
+    sink: a display task feed, so a job's banners land in its display line instead of tearing the live region
+    display, tid: let SubProcess report child pids for CPU sampling
+    build_slot: the scheduler barrier, so a custom build()'s cmake_build() can self-gate"""
     prev = capture_context()
     _capture.sink, _capture.display, _capture.tid, _capture.build_slot = sink, display, tid, build_slot
     try:
@@ -110,16 +107,16 @@ def capture_to(sink, display=None, tid=None, build_slot=None):
 
 
 def build_barrier(weight: int):
-    """Wrap a heavy compile (cmake_build's build step) so it occupies `weight` budget cores in the
-    active scheduler, suspending the worker until admitted. A no-op (null context) on the serial
-    path / in tests, so mamafile build() call sites need no changes."""
+    """Wrap a heavy compile so it occupies `weight` budget cores in the active scheduler, suspending the
+    worker until admitted. A no-op on the serial path and in tests, so mamafile call sites need no changes.
+    weight: the number of budget cores the compile occupies"""
     factory = getattr(_capture, 'build_slot', None)
     return factory(weight) if factory is not None else contextlib.nullcontext()
 
 
 def report_subprocess(pid: int, started: bool):
-    """SubProcess calls this on child start/exit, routing the pid to this thread's display task
-    (set by capture_to) for process-tree CPU sampling. Best-effort: never breaks a build."""
+    """SubProcess calls this on child start/exit, routing the pid to this thread's display task (set by
+    capture_to) for process-tree CPU sampling. Best-effort: never breaks a build."""
     display = getattr(_capture, 'display', None)
     tid = getattr(_capture, 'tid', None)
     if display is None or tid is None: return
@@ -135,15 +132,13 @@ def console(text:str, color=None, end="\n"):
     global _progress_active
     is_redraw = text.startswith('\r')        # redraws start with \r (cursor reset), see progress()
     clean = text[1:] if is_redraw else text  # \r stripped: line-based sinks/region want a clean line
-    # While a display owns the screen, route EVERYTHING through it - any direct stdout write (even a
-    # \r-redraw or a partial) desyncs the region's cursor math and walks it down the screen. Owned
-    # output feeds the job's task preview. An ownerless full line goes above the region. An ownerless
-    # mid-progress redraw is dropped: the line-based region cannot place it without corruption.
+    # While a display owns the screen, route EVERYTHING through it: any direct stdout write desyncs the
+    # region's cursor math. Owned output feeds the job's task preview, an ownerless full line goes above
+    # the region, and an ownerless mid-progress redraw is dropped: the region cannot place it.
     sink = getattr(_capture, 'sink', None)
     if sink is not None or _active_display is not None:
-        # Split an embedded-newline message into SEPARATE lines: the display is line-based, and a
-        # multi-line string smuggled through as one 'line' shifts the terminal cursor, desyncing the
-        # live region's cursor-up math and stranding running task lines in the scrollback.
+        # Split an embedded-newline message into SEPARATE lines: the display is line-based, and a multi-line
+        # string smuggled through as one 'line' shifts the cursor and strands task lines in the scrollback.
         for part in (clean.split('\n') if '\n' in clean else (clean,)):
             line = get_colored_text(part, color)  # not `colored`: that name is termcolor's, imported above
             if sink is not None: sink(line)
@@ -161,8 +156,7 @@ def console(text:str, color=None, end="\n"):
 
 def progress(text:str, color=None, final=False):
     """Redraw an in-place progress line, always cleared to end-of-line. `final=True` commits it with a
-    newline. Otherwise the cursor stays on the line for the next redraw. A final line always prints.
-    See _redraw_due() for why the rest throttle without a terminal."""
+    newline and always prints, else the cursor stays for the next redraw (throttled, see _redraw_due)."""
     if not final and not _redraw_due(): return
     console('\r' + text, color=color, end='\n' if final else '')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,7 @@ import os
 import sys
 import pytest
 
-# Tests/ for `import testutils`, project root for `from mama.x import y` -
-# so no test file repeats the same sys.path.insert setup.
+# tests/ for `import testutils`, the project root for `from mama.x import y`, so no test file repeats the sys.path setup.
 _here = os.path.dirname(__file__)
 _repo_root = os.path.abspath(os.path.join(_here, '..'))
 sys.path.insert(0, _here)
@@ -56,11 +55,7 @@ def no_cmake_writes(monkeypatch):
 
 
 def pytest_configure(config):
-    # tmp_path trees go in the gitignored repo subtree, not system temp, for self-contained
-    # CI-identical isolation. The temproot, NOT basetemp: pytest then makes its own numbered and
-    # locked pytest-<N> dir per session under it, and keeps the last 3. A fixed basetemp is one exact
-    # dir, and pytest WIPES it at session start. A second pytest run then deletes the tmp dirs of the
-    # first one while it still runs. An explicit --basetemp or temproot still wins.
+    # Temproot, not basetemp: pytest makes a locked pytest-<N> dir per run under it. A wiped basetemp kills a concurrent run.
     if not config.option.basetemp:
         temproot = os.path.join(_repo_root, '.pytest_tmp')
         os.makedirs(temproot, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 # Tests/ for `import testutils`, project root for `from mama.x import y` -
-# saves every new test file from repeating the same sys.path.insert dance.
+# so no test file repeats the same sys.path.insert setup.
 _here = os.path.dirname(__file__)
 _repo_root = os.path.abspath(os.path.join(_here, '..'))
 sys.path.insert(0, _here)

--- a/tests/test_archive_progress/test_archive_progress.py
+++ b/tests/test_archive_progress/test_archive_progress.py
@@ -99,7 +99,7 @@ def test_the_bar_names_the_file_currently_being_archived(capsys):
     bar.step(50*1024*1024, 'lib/libprotobuf.a')
     assert 'lib/libprotobuf.a' in capsys.readouterr().out
     bar.finish()
-    assert 'libprotobuf.a' not in capsys.readouterr().out  # nothing is in flight at 100%
+    assert 'libprotobuf.a' not in capsys.readouterr().out  # no file streams at 100%
 
 
 def test_a_long_path_is_truncated_from_the_left(capsys):
@@ -124,7 +124,7 @@ def test_archive_total_size_ignores_dir_entries(tmp_path):
 
 
 def test_a_large_file_advances_the_bar_while_it_is_written(tmp_path):
-    # the whole point: a 60MB lib used to leave the bar frozen, then jump
+    # the pinned bug: a 60MB lib left the bar frozen, then the bar jumped
     big = tmp_path / 'libbig.a'
     big.write_bytes(b'x' * (3*1024*1024 + 7))
     bar = Mock()

--- a/tests/test_archive_progress/test_archive_progress.py
+++ b/tests/test_archive_progress/test_archive_progress.py
@@ -124,7 +124,7 @@ def test_archive_total_size_ignores_dir_entries(tmp_path):
 
 
 def test_a_large_file_advances_the_bar_while_it_is_written(tmp_path):
-    # the pinned bug: a 60MB lib left the bar frozen, then the bar jumped
+    # a whole-file step would leave the bar frozen for a large lib, then jump
     big = tmp_path / 'libbig.a'
     big.write_bytes(b'x' * (3*1024*1024 + 7))
     bar = Mock()

--- a/tests/test_args_naming/test_args_naming.py
+++ b/tests/test_args_naming/test_args_naming.py
@@ -27,8 +27,7 @@ def test_the_suffix_normalizes_every_arg_shape(args, suffix):
 
 
 def test_a_dep_without_args_keeps_its_old_name():
-    # Regression guard. Every published archive was named without this field, so a dep that passes no
-    # args must stay byte-identical or the whole cache misses at once.
+    # No-args names predate this field: they must stay byte-identical or every published archive cache misses at once.
     assert art.artifactory_archive_name(_target()) == _NO_ARGS
 
 
@@ -64,9 +63,7 @@ def test_a_sanitizer_and_the_args_both_appear_coarsest_first():
 
 
 def test_the_archive_name_carries_the_dep_variant_suffix_verbatim():
-    # The unification: the dep computes one suffix at init, and the build dir (test_build_dir) and the
-    # archive name both use that exact string. Two spellings of one axis make a build and its package
-    # disagree about which variant they are.
+    # The dep computes one suffix at init. The build dir and the archive name use that exact string, so they cannot disagree.
     target = _target(sanitize='address', coverage='default', args=['LGPL', 'NEWMATH=1'])
     assert target.dep.variant_suffix == '-cov-asan-lgpl-newmath1'
     assert f'-release{target.dep.variant_suffix}-abc1234' in art.artifactory_archive_name(target)

--- a/tests/test_args_naming/test_args_naming.py
+++ b/tests/test_args_naming/test_args_naming.py
@@ -65,8 +65,8 @@ def test_a_sanitizer_and_the_args_both_appear_coarsest_first():
 
 def test_the_archive_name_carries_the_dep_variant_suffix_verbatim():
     # The unification: the dep computes one suffix at init, and the build dir (test_build_dir) and the
-    # archive name both use that exact string. Two spellings of one axis is how a build and its package
-    # end up disagreeing about which variant they are.
+    # archive name both use that exact string. Two spellings of one axis make a build and its package
+    # disagree about which variant they are.
     target = _target(sanitize='address', coverage='default', args=['LGPL', 'NEWMATH=1'])
     assert target.dep.variant_suffix == '-cov-asan-lgpl-newmath1'
     assert f'-release{target.dep.variant_suffix}-abc1234' in art.artifactory_archive_name(target)

--- a/tests/test_artifactory_shim/test_shim_buildtarget.py
+++ b/tests/test_artifactory_shim/test_shim_buildtarget.py
@@ -1,4 +1,4 @@
-"""BuildTarget-level shim behaviour: _require_source + _execute_deploy_tasks."""
+"""BuildTarget-level shim behavior: _require_source + _execute_deploy_tasks."""
 from unittest.mock import patch
 
 import pytest
@@ -50,7 +50,7 @@ def test_execute_deploy_tasks_runs_deploy_for_non_shim(tmp_path):
 
 @pytest.mark.parametrize('if_needed', [False, True])
 def test_execute_deploy_tasks_skips_upload_for_shim(tmp_path, if_needed):
-    # shim => already on artifactory; upload is a no-op success (returns, no raise) regardless of if_needed
+    # shim => already on artifactory. The upload is a no-op success (returns, no raise) regardless of if_needed.
     _, target = _make_target(tmp_path, as_shim=True, deploy=False, upload=True, if_needed=if_needed)
     with patch('mama.build_target.papa_upload_to') as upload_mock:
         target._execute_deploy_tasks()

--- a/tests/test_artifactory_shim/test_shim_guards.py
+++ b/tests/test_artifactory_shim/test_shim_guards.py
@@ -49,8 +49,7 @@ def _dep_with_changed_child(tmp_path, shim: bool):
 
 
 def test_after_load_never_marks_a_shim_for_rebuild(tmp_path):
-    # should_rebuild on a shim builds nothing. It does make _run_packaging drop the exports the
-    # fetched papa.txt carries, and re-derive them from the unzipped tree.
+    # should_rebuild on a shim builds nothing, but makes _run_packaging drop papa.txt's exports and re-derive them from the tree.
     dep = _dep_with_changed_child(tmp_path, shim=True)
     dep.after_load()
     assert dep.should_rebuild is False
@@ -104,8 +103,7 @@ def test_shim_marker_kept_when_no_clone_exists(tmp_path):
 
 
 def test_git_checkout_if_needed_short_circuits_for_shim(tmp_path):
-    # Without this guard, a shim with a missing src_dir falls through to
-    # dependency_checkout, which walks up the parent dir and queries the wrong remote.
+    # Without the guard, a shim with a missing src_dir falls through to dependency_checkout and queries the wrong remote.
     dep = make_mock_shim_dep(tmp_path, build=True)
     called = []
     with patch.object(Git, 'dependency_checkout', side_effect=lambda d: called.append(d) or True):

--- a/tests/test_artifactory_shim/test_shim_guards.py
+++ b/tests/test_artifactory_shim/test_shim_guards.py
@@ -72,7 +72,7 @@ def test_dirty_removes_shim_marker(tmp_path):
 
 
 def test_papa_deploy_to_refuses_with_shim_marker_in_destination(tmp_path):
-    # If deployed into the shim's build_dir, we'd corrupt the artifactory snapshot.
+    # A deploy into the shim's build_dir would corrupt the artifactory snapshot.
     dep = make_mock_shim_dep(tmp_path, build=True)
     target = Mock()
     target.config.print = False
@@ -121,13 +121,13 @@ def test_run_git_raises_on_shim(tmp_path):
 
 
 def test_run_git_returns_nonzero_when_not_throwing_on_shim(tmp_path):
-    # _has_local_modifications calls run_git(throw=False); must see a non-zero rc, not silent success.
+    # _has_local_modifications calls run_git(throw=False). It must see a non-zero rc, not silent success.
     dep = make_mock_shim_dep(tmp_path, build=True)
     assert dep.dep_source.run_git(dep, 'diff --quiet HEAD', throw=False) != 0
 
 
 def test_is_artifactory_shim_caches_filesystem_stat(tmp_path):
-    # Called per-progress-tick and per-git-op; must not stat on every call.
+    # Called per-progress-tick and per-git-op. It must not stat on every call.
     dep = make_mock_shim_dep(tmp_path, build=True)
     assert dep.is_artifactory_shim() is True
     with patch('os.path.exists', side_effect=AssertionError('stat called')):

--- a/tests/test_artifactory_shim/test_shim_marker.py
+++ b/tests/test_artifactory_shim/test_shim_marker.py
@@ -43,7 +43,6 @@ def test_remove_shim_marker_is_idempotent(tmp_path):
 
 
 def test_real_clone_takes_precedence_over_shim(tmp_path):
-    # is_artifactory_shim() must be False if both .git and the marker exist.
     dep = make_mock_dep(tmp_path, artifactory_ftp=None)
     dep.write_shim_marker(archive_name='x', commit_hash='y')
     os.makedirs(os.path.join(dep.src_dir, '.git'), exist_ok=True)

--- a/tests/test_artifactory_shim/test_shim_probe.py
+++ b/tests/test_artifactory_shim/test_shim_probe.py
@@ -58,8 +58,7 @@ def test_fetch_succeeds_writes_marker(tmp_path):
 
 
 def test_uses_resolved_hash_not_tag(tmp_path):
-    # Phase 1 contract: init_commit_hash with use_cache=True + fetch_remote=True.
-    # Tag-vs-hash logic lives in init_commit_hash. The probe trusts the returned hash.
+    # Tag-vs-hash logic lives in init_commit_hash (use_cache=True + fetch_remote=True). The probe trusts the returned hash.
     dep = make_mock_dep(tmp_path)
     with patch.object(Git, 'init_commit_hash', return_value='def5678') as hash_mock, \
          patch.object(artifactory_mod, 'artifactory_fetch_and_reconfigure',

--- a/tests/test_artifactory_shim/test_shim_probe.py
+++ b/tests/test_artifactory_shim/test_shim_probe.py
@@ -59,7 +59,7 @@ def test_fetch_succeeds_writes_marker(tmp_path):
 
 def test_uses_resolved_hash_not_tag(tmp_path):
     # Phase 1 contract: init_commit_hash with use_cache=True + fetch_remote=True.
-    # Tag-vs-hash logic lives in init_commit_hash; the probe just trusts what it gets.
+    # Tag-vs-hash logic lives in init_commit_hash. The probe trusts the returned hash.
     dep = make_mock_dep(tmp_path)
     with patch.object(Git, 'init_commit_hash', return_value='def5678') as hash_mock, \
          patch.object(artifactory_mod, 'artifactory_fetch_and_reconfigure',

--- a/tests/test_build_abort/test_build_abort.py
+++ b/tests/test_build_abort/test_build_abort.py
@@ -97,8 +97,7 @@ def _run_child(*args):
     that lands during interpreter startup kills the child before it installs its own handler."""
     lines = []
     def run():
-        # A killed child can raise out of run() (the reader hits a closed PTY). Unhandled in a thread,
-        # pytest reports that against whichever test is running, as a teardown error.
+        # A killed child can raise out of run() (reader hits a closed PTY). Unhandled in a thread, pytest logs a teardown error.
         try: SubProcess.run([PY, *args], io_func=lambda p, l: lines.append(l))
         except BaseException: pass
     threading.Thread(target=run, daemon=True).start()
@@ -120,8 +119,7 @@ _STUBBORN = ('import signal, time\n'
              'print("ready", flush=True)\n'
              'time.sleep(30)\n')
 
-# argv: the file the kid touches once it ignores SIGINT, then the file this parent writes the kid pid
-# to. The parent itself stops on the request, so only the group sweep can stop the kid.
+# argv: the kid's SIGINT-ignored marker file, then the kid pid file. The parent stops, so only the group sweep stops the kid.
 _PARENT_OF_A_STUBBORN_KID = '''
 import os, subprocess, sys, time
 ready, pidfile = sys.argv[1], sys.argv[2]
@@ -188,8 +186,7 @@ def test_a_failed_load_stops_the_clones_already_running():
     start = time.monotonic()
     with pytest.raises(SystemExit):
         dc.load_dependency_chain(root)
-    # The clones stop on the request, so the grace never runs out. Without the stop this waits the
-    # full 10s: the pool's shutdown drains every clone it started.
+    # The clones stop on the request, so the grace never runs out. Without the stop, the pool shutdown drains the full 10s clones.
     assert time.monotonic() - start < 3.0
 
 

--- a/tests/test_build_abort/test_build_abort.py
+++ b/tests/test_build_abort/test_build_abort.py
@@ -40,7 +40,7 @@ def test_a_flagged_build_spawns_nothing():
     abort.request('geo failed')
     with patch('mama.utils.sub_process.subprocess.Popen') as popen, pytest.raises(BuildAborted):
         SubProcess.run([PY, '-c', 'pass'])
-    popen.assert_not_called()  # the point of the flag: no new child, not a child killed after spawning
+    popen.assert_not_called()  # the flag's purpose: no new child, not a child killed after spawn
 
 
 def _phase_display():
@@ -56,7 +56,7 @@ def test_no_phase_transitions_while_stopping(kind):
     with pytest.raises(BuildAborted):
         dc._run_phase(display, dep, kind, body, build_slot=None)
     body.assert_not_called()
-    display.start_task.assert_not_called()  # a phase that never ran must not show up as a failed one
+    display.start_task.assert_not_called()  # a phase that never ran must not appear as a failed one
 
 
 def test_a_queued_load_does_not_clone_while_stopping():
@@ -172,8 +172,8 @@ def test_a_grandchild_that_missed_the_request_still_dies(tmp_path):
 
 
 def test_a_failed_load_stops_the_clones_already_running():
-    """The property the whole two-stage stop exists for: one failed load does not leave the user
-    waiting out every clone the thread pool already started."""
+    """The property the two-stage stop exists for: one failed load does not make the user wait for
+    every clone the thread pool already started."""
     def clone(): SubProcess.run([PY, '-c', 'import time; time.sleep(10)'], io_func=lambda p, l: None)
     def fail():
         end = time.monotonic() + 10  # fail only once the sibling clones really run, else this proves nothing

--- a/tests/test_build_banner/test_build_banner.py
+++ b/tests/test_build_banner/test_build_banner.py
@@ -42,7 +42,7 @@ def test_toolchain_names_the_clang_stdlib_on_linux(capsys):
         == f'Mama {__version__} building 3 target(s) linux x64 with clang 14.3 libstdc++'
     assert _banner(capsys, _cfg(msvc=True, linux=False, platform_class=Windows)) \
         == f'Mama {__version__} building windows x64 with msvc 14.44'
-    # off linux the stdlib isn't a choice, so it isn't reported
+    # off linux the stdlib is not a choice, so the banner omits it
     assert _banner(capsys, _cfg('/usr/bin/clang', linux=False)) \
         == f'Mama {__version__} building linux x64 with clang 14.3'
 
@@ -63,7 +63,7 @@ def _android(**over):
 
 
 def test_banner_names_the_android_api_arch_and_ndk(capsys):
-    # 'clang 21.0' alone can't tell an android cross build from a host clang - the platform must say so
+    # 'clang 21.0' alone cannot tell an android cross build from a host clang - the platform must say so
     assert _banner(capsys, _android()) \
         == f'Mama {__version__} building android-36 arm64 ndk-29.0.14206865 with clang 21.0'
 

--- a/tests/test_build_config/test_build_config.py
+++ b/tests/test_build_config/test_build_config.py
@@ -7,7 +7,7 @@ from mama.utils import system
 def test_default_jobs_leaves_one_core_free_on_linux(monkeypatch):
     monkeypatch.setattr(psutil, 'cpu_count', lambda: 32)
     monkeypatch.setattr(system.System, 'linux', True)
-    assert BuildConfig._default_build_jobs() == 31   # N-1: don't saturate the box into an OOM/freeze
+    assert BuildConfig._default_build_jobs() == 31   # N-1: do not saturate the box into an OOM/freeze
     monkeypatch.setattr(system.System, 'linux', False)
     assert BuildConfig._default_build_jobs() == 32   # Windows/macOS use all cores
 
@@ -19,7 +19,7 @@ def test_default_jobs_never_below_one(monkeypatch):
 
 
 def _bare_cfg(**attrs):
-    c = object.__new__(BuildConfig)  # skip the heavy __init__; set only what prefer_gcc touches
+    c = object.__new__(BuildConfig)  # skip the heavy __init__, set only what prefer_gcc touches
     c.linux = True; c.raspi = False; c.gcc = False; c.clang = True
     c.compiler_cmd = True; c.print = True; c.compiler_conflict_warned = False
     for k, v in attrs.items(): setattr(c, k, v)

--- a/tests/test_build_config/test_build_config.py
+++ b/tests/test_build_config/test_build_config.py
@@ -50,8 +50,7 @@ def test_the_retired_buildtimes_flag_is_no_longer_recognized():
 
 
 def test_announce_once_prints_a_key_only_the_first_time(monkeypatch):
-    # platform option builders run per fingerprint computation, not per configure - a plain console()
-    # repeats 'Toolchain: ...' several times per target with nothing new to say
+    # platform option builders run per fingerprint computation, so a plain console() repeats 'Toolchain: ...' per target
     printed = []
     monkeypatch.setattr('mama.build_config.console', lambda t, **k: printed.append(t))
     c = object.__new__(BuildConfig)

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -1,3 +1,4 @@
+"""Pins build dir names: sanitizer, coverage, compiler and dep-args suffixes."""
 import pytest
 from mama.build_names import build_dir_name
 from testutils import platform_config
@@ -90,7 +91,7 @@ def test_msan_uses_the_same_short_name_as_the_archive():
 
 def _dep_with_args(tmp_path, args, **cfg_overrides):
     """A real BuildDependency on a real BuildConfig. __init__ composes the variant suffix and the dirs
-    without any clone or disk write, which is the whole point: the name is known before the clone."""
+    without any clone or disk write, so the name is known before the clone."""
     from mama.build_dependency import BuildDependency
     from mama.types.git import Git
     cfg = linux_config()

--- a/tests/test_build_dir/test_build_dir.py
+++ b/tests/test_build_dir/test_build_dir.py
@@ -83,7 +83,7 @@ def test_a_yocto_board_is_named_by_its_own_build_dir():
 
 
 def test_msan_uses_the_same_short_name_as_the_archive():
-    # The dir used to say 'linux-memory' while the archive said 'msan': two tables, one axis.
+    # the dir and the archive must not spell one axis two ways ('linux-memory' vs 'msan')
     c = linux_config()
     c.sanitize = 'memory'
     assert build_dir_name(c) == 'linux-msan'

--- a/tests/test_build_display/test_build_display.py
+++ b/tests/test_build_display/test_build_display.py
@@ -207,8 +207,7 @@ def test_cpu_sampling_updates_task_and_renders_percent():
 
 
 def test_late_cpu_sample_does_not_resurrect_a_detached_task():
-    # The sampler runs off-lock. If the task detaches during that window, the sampler must NOT write
-    # back the stale CPU it computed - else a dead subprocess shows as busy until the task finishes.
+    # The sampler runs off-lock: a stale CPU written after a mid-scan detach shows a dead subprocess as busy until finish.
     d, _, _ = _disp(isatty=True, sample_interval=999)
     d.start_task(1, 'build', 'x'); d.attach_pid(1, 7)
     def sampler(snap):
@@ -277,8 +276,7 @@ def test_set_pending_shows_then_clears_the_blocked_task_line():
 
 
 def test_render_skips_when_another_thread_is_drawing():
-    # A non-forced render must not block while another thread holds the render lock (that block would
-    # stall the subprocess reader -> fill the pipe -> stall the compiler). It skips, a later draw covers it.
+    # A blocked non-forced render stalls the reader -> fills the pipe -> stalls the compiler. Skip, a later draw covers it.
     d, out, clk = _disp(isatty=True)
     d.start_task(1, 'build', 'x'); clk.tick(0.2)
     d._render_lock.acquire()
@@ -313,8 +311,7 @@ def test_build_barrier_is_noop_without_scheduler_else_uses_slot():
 
 
 def test_multiline_console_reaches_the_sink_as_separate_lines():
-    # A multi-line message smuggled through as ONE line shifts the terminal cursor and desyncs the
-    # live region's cursor-up math, stranding running task lines in the scrollback.
+    # A multi-line message passed as ONE line shifts the cursor and desyncs the live region's cursor-up math.
     sink = []
     with system.capture_to(sink.append):
         system.console('\n\n#### CMakeBuild myapp')
@@ -415,8 +412,7 @@ def test_scan_diagnostics_caps_and_counts_full_totals():
 
 
 def test_scan_diagnostics_catches_cmakes_error_at_form():
-    # 'CMake Error at <file>' has no colon after the severity, so the generic form missed it entirely -
-    # which is how a failing target's real error went absent from the end-of-build summary.
+    # 'CMake Error at <file>' has no colon after the severity, so the generic form alone misses it.
     diags, n_err, n_warn = scan_diagnostics([
         'CMake Error at /usr/share/cmake-3.28/Modules/FindOpenSSL.cmake:668 (find_package):',
         'CMake Warning at CMakeLists.txt:5 (message):'])
@@ -498,7 +494,7 @@ def test_a_cmake_block_keeps_its_body_not_just_the_header():
     assert (n_err, n_warn) == (0, 1)
     text = diags[0][1]
     assert text.startswith('CMake Warning:')
-    assert 'Manually-specified variables' in text and 'BUILD_APPS' in text  # the body used to be dropped
+    assert 'Manually-specified variables' in text and 'BUILD_APPS' in text  # the body must survive, not only the header
     assert 'Configuring done' not in text                                   # the blank pair ends the block
 
 
@@ -522,8 +518,7 @@ def test_a_runaway_cmake_block_is_capped_and_says_so():
 
 
 def test_a_render_after_close_cannot_redraw_over_the_final_output():
-    # the CPU sampler can outlive close()'s 1s join (a slow process scan) and would otherwise redraw
-    # the region below the build summary, with _drawn already reset to 0
+    # the CPU sampler can outlive close()'s 1s join and would redraw the region below the build summary
     d, out, clk = _disp(isatty=True)
     d.start_task('t', 'build', 'protobuf'); clk.tick(2.0)
     d.close()

--- a/tests/test_build_display/test_build_display.py
+++ b/tests/test_build_display/test_build_display.py
@@ -51,7 +51,7 @@ def test_phases_merge_into_one_summary_with_breakdown():
     d.start_task('geo', 'configure', 'geo'); clk.tick(0.3); d.finish_task('geo', ok=True, final=False)
     d.start_task('geo', 'build', 'geo', detail='J32'); clk.tick(0.5); d.finish_task('geo', ok=True, final=True)
     text = squeeze(out.getvalue())
-    assert text.count('geo') == 1 and 'build J32' in text  # one merged line; kind = last phase that did work
+    assert text.count('geo') == 1 and 'build J32' in text  # one merged line, kind = last phase that did work
     assert 'git 3.7s' in text and 'cfg 0.3s' in text and 'bld 0.5s' in text  # git pull, configure, build
 
 
@@ -102,7 +102,7 @@ def test_phase_tags_collapse_git_loads_and_label_each_source():
 def test_non_tty_verbose_dumps_full_output():
     d, out, clk = _disp(isatty=False, verbose=True)
     d.start_task(1, 'build', 'bar'); d.feed(1, 'compiling x.cpp'); d.feed(1, 'linking')
-    clk.tick(0.2); d.finish_task(1, ok=True)   # past reveal: a real build that emitted output isn't instant
+    clk.tick(0.2); d.finish_task(1, ok=True)   # past reveal: a real build that emitted output is not instant
     assert 'compiling x.cpp' in out.getvalue() and 'linking' in out.getvalue()
 
 
@@ -156,7 +156,7 @@ def test_tty_preview_strips_ansi_but_buffer_keeps_it():
 
 def test_region_line_drops_cursor_moves_smuggled_in_by_a_nested_display():
     """A nested build's own live region (a `mama` host-binary bootstrap, ninja) arrives as preview
-    text; one cursor-up reaching the terminal strands every finished task line in the scrollback."""
+    text. One cursor-up reaching the terminal strands every finished task line in the scrollback."""
     d, _, clk = _disp(isatty=True)
     d.start_task(1, 'build', 'protobuf'); clk.tick(0.5)
     d.feed(1, '\x1b[1A\x1b[2Knested frame')
@@ -207,8 +207,8 @@ def test_cpu_sampling_updates_task_and_renders_percent():
 
 
 def test_late_cpu_sample_does_not_resurrect_a_detached_task():
-    # The sampler runs off-lock; if the task detaches during that window, the stale CPU it computed
-    # must NOT be written back - else a dead subprocess shows as busy until the task finishes.
+    # The sampler runs off-lock. If the task detaches during that window, the sampler must NOT write
+    # back the stale CPU it computed - else a dead subprocess shows as busy until the task finishes.
     d, _, _ = _disp(isatty=True, sample_interval=999)
     d.start_task(1, 'build', 'x'); d.attach_pid(1, 7)
     def sampler(snap):
@@ -278,7 +278,7 @@ def test_set_pending_shows_then_clears_the_blocked_task_line():
 
 def test_render_skips_when_another_thread_is_drawing():
     # A non-forced render must not block while another thread holds the render lock (that block would
-    # stall the subprocess reader -> fill the pipe -> stall the compiler). It skips; a later draw covers it.
+    # stall the subprocess reader -> fill the pipe -> stall the compiler). It skips, a later draw covers it.
     d, out, clk = _disp(isatty=True)
     d.start_task(1, 'build', 'x'); clk.tick(0.2)
     d._render_lock.acquire()
@@ -462,7 +462,7 @@ def test_region_line_has_no_trailing_padding_before_a_preview_arrives():
     d, _, clk = _disp(isatty=True)
     d.start_task('t', 'configure', 'rpclib')
     line = d._task_line(d._tasks['t'], clk(), 200)
-    assert line == line.rstrip()          # trailing pad shows up as stray spaces in the region
+    assert line == line.rstrip()          # trailing pad appears as stray spaces in the region
     d.feed('t', 'compiling foo.cpp')
     assert d._task_line(d._tasks['t'], clk(), 200).endswith('compiling foo.cpp')
 
@@ -533,7 +533,7 @@ def test_a_render_after_close_cannot_redraw_over_the_final_output():
 
 
 def test_print_above_after_close_still_reaches_the_terminal():
-    # console() can race between display.close() and set_active_display(None); the line must not vanish
+    # console() can race between display.close() and set_active_display(None). The line must not vanish.
     d, out, clk = _disp(isatty=True)
     d.close()
     out.truncate(0); out.seek(0)

--- a/tests/test_build_insights/test_build_insights.py
+++ b/tests/test_build_insights/test_build_insights.py
@@ -132,7 +132,7 @@ def test_parse_clang_traces_aggregates_across_tus(tmp_path):
     assert st.frontend_s == pytest.approx(1.4) and st.backend_s == pytest.approx(0.3)
     assert [t[0] for t in st.tus] == ['a.cpp', 'b.cpp']            # slowest first, .json + source basename stripped
     files = dict((b, (s, n)) for b, s, n in st.files)
-    assert files['vector'] == (pytest.approx(0.9), 2) and 'a.cpp' not in files  # header summed; the .cpp isn't a header
+    assert files['vector'] == (pytest.approx(0.9), 2) and 'a.cpp' not in files  # header summed, the .cpp is not a header
     assert dict(st.symbols)['std::vector<Foo>'] == pytest.approx(0.15)          # clang details already readable
 
 

--- a/tests/test_build_insights/test_build_insights.py
+++ b/tests/test_build_insights/test_build_insights.py
@@ -10,9 +10,7 @@ def _b(name, ts, args=None): return {'ph': 'B', 'name': name, 'ts': ts, **({'arg
 def _e(ts): return {'ph': 'E', 'ts': ts}
 def _x(name, ts, dur): return {'ph': 'X', 'name': name, 'ts': ts, 'dur': dur}
 
-# Real vcperf shape: CL Invocation -> FrontEndPass -> C1DLL -> <source> (+ nested includes); BackEndPass ->
-# C2DLL -> codegen leaves. CL0 (a.cpp -> C:\proj): frontend 100us (incl big.h 60us), backend 60us (someFunc).
-# CL1 (b.cpp -> C:\other): frontend 60us, re-includes big.h 20us, no backend. Link 0 -> C:\proj, 50us.
+# Real vcperf nesting: CL Invocation -> FrontEndPass -> C1DLL -> <source> (+ nested includes), BackEndPass -> C2DLL -> leaves.
 def _fe(src, ts, dur, inc=None):  # one FrontEndPass: C1DLL -> source, optional nested include (name, ts, dur)
     body = [_b('C1DLL', ts), _b(src, ts)] + ([_x(inc[0], inc[1], inc[2])] if inc else []) + [_e(ts + dur), _e(ts + dur)]
     return [_b('FrontEndPass', ts), *body, _e(ts + dur)]

--- a/tests/test_build_scheduler/test_build_scheduler.py
+++ b/tests/test_build_scheduler/test_build_scheduler.py
@@ -121,8 +121,7 @@ def test_build_governor_respects_core_budget():
 
 
 def test_ungated_build_bypasses_cpu_and_budget_gate():
-    # The root build is ungated: it launches even when the budget is full and CPU is pegged (it runs
-    # alone after all deps), gated only by its own deps being done.
+    # The root build runs alone after all deps, so only its own deps gate it, never the budget or the CPU.
     sched = _sched(core_budget=8, overprovision=1.0, cpu_sampler=lambda: 100.0)
     sched._reserved = 8; sched._cpu_now = 100.0  # budget exhausted, CPU maxed
     assert sched._can_launch(Job('leaf', BUILD, lambda: None, weight=8)) is False    # normal build held back
@@ -161,8 +160,7 @@ def test_build_dep_jobs_marks_root_build_ungated():
 
 
 def test_many_small_leaf_builds_launch_in_parallel_under_busy_cpu():
-    # a wide project with ~20 small leaf deps ran one-at-a-time under the old CPU gate. Small TU
-    # weights must fill the core budget concurrently even while the sampler reads saturated.
+    # small TU weights must fill the core budget concurrently even while the CPU sampler reads saturated
     p = Probe()
     jobs = [Job(i, BUILD, p.body, weight=2) for i in range(12)]
     sched = _sched(cpu_sampler=lambda: 99.0, core_budget=16)  # 16/2 = 8 fit at once
@@ -303,8 +301,7 @@ def test_build_dep_jobs_resolves_weight_lazily_per_dep():
 
 
 def test_keyboard_interrupt_aborts_build_kills_children_and_returns_interrupted():
-    # Ctrl+C lands in the scheduler loop: abort_hook fires (kills children), the in-flight job is
-    # released, and run() returns a synthetic KeyboardInterrupt job so the caller fails the build.
+    # Ctrl+C in the scheduler loop: abort_hook kills children, run() returns a synthetic KeyboardInterrupt job to fail the build.
     released, hook, n = threading.Event(), [], {'i': 0}
     def sampler():
         n['i'] += 1
@@ -326,8 +323,7 @@ def test_build_slot_bails_when_build_already_failing():
 
 
 def test_pending_log_is_called_without_holding_the_scheduler_lock():
-    # The display writes to the terminal from this callback. Holding _cond across it stalls every
-    # job launch and completion behind a frame write.
+    # The display writes to the terminal from this callback. Holding _cond across it stalls every job behind a frame write.
     held = []
     def probe(hint):
         got = [None]

--- a/tests/test_build_scheduler/test_build_scheduler.py
+++ b/tests/test_build_scheduler/test_build_scheduler.py
@@ -13,7 +13,7 @@ def _wait_until(pred, timeout=2.0):
     return False
 
 
-_probes, _threads = [], []  # tracked so _drain() can release + join them even if an assertion bailed early
+_probes, _threads = [], []  # tracked so _drain() can release + join them even after an early assertion failure
 
 @pytest.fixture(autouse=True)
 def _drain():
@@ -79,7 +79,7 @@ def test_build_governor_high_load_blocks_overprovision():
     jobs = [Job(i, BUILD, p.body, weight=4) for i in range(4)]  # each fills half the budget
     sched = _sched(cpu_sampler=lambda: 100.0, core_budget=4, overprovision=2.0)  # busy
     t, _ = _run_bg(sched, jobs)
-    assert _wait_until(lambda: p.cur == 1)   # one fills the budget; busy CPU blocks over-provisioning
+    assert _wait_until(lambda: p.cur == 1)   # one fills the budget, busy CPU blocks over-provisioning
     time.sleep(0.05)
     assert p.cur == 1
     p.gate.set(); t.join(2.0)
@@ -91,7 +91,7 @@ def test_build_governor_low_load_overprovisions_past_budget():
     jobs = [Job(i, BUILD, p.body, weight=4) for i in range(4)]
     sched = _sched(cpu_sampler=lambda: 0.0, core_budget=4, overprovision=2.0)  # idle -> overprovision
     t, _ = _run_bg(sched, jobs)
-    assert _wait_until(lambda: p.cur == 2)   # 4+4 = budget*2; a third (12) exceeds even that
+    assert _wait_until(lambda: p.cur == 2)   # 4+4 = budget*2, a third (12) exceeds even that
     time.sleep(0.05)
     assert p.cur == 2
     p.gate.set(); t.join(2.0)
@@ -113,7 +113,7 @@ def test_build_governor_respects_core_budget():
     jobs = [Job(i, BUILD, p.body, weight=4) for i in range(4)]  # 4 cores each
     sched = _sched(cpu_sampler=lambda: 0.0, core_budget=8, overprovision=1.0)
     t, _ = _run_bg(sched, jobs)
-    assert _wait_until(lambda: p.cur == 2)  # 4+4 = budget; a third (12) won't fit
+    assert _wait_until(lambda: p.cur == 2)  # 4+4 = budget, a third (12) does not fit
     time.sleep(0.05)
     assert p.cur == 2
     p.gate.set(); t.join(2.0)
@@ -161,7 +161,7 @@ def test_build_dep_jobs_marks_root_build_ungated():
 
 
 def test_many_small_leaf_builds_launch_in_parallel_under_busy_cpu():
-    # a wide project with ~20 small leaf deps; with the old CPU gate they ran one-at-a-time. Small TU
+    # a wide project with ~20 small leaf deps ran one-at-a-time under the old CPU gate. Small TU
     # weights must fill the core budget concurrently even while the sampler reads saturated.
     p = Probe()
     jobs = [Job(i, BUILD, p.body, weight=2) for i in range(12)]
@@ -178,7 +178,7 @@ def test_build_slot_barrier_blocks_until_budget_frees():
     hog = Job('hog', BUILD, p.body, weight=8)
     acquired = []
     def runner():
-        with sched.build_slot(8):   # needs the whole budget; blocked while hog holds it
+        with sched.build_slot(8):   # needs the whole budget, blocked while hog holds it
             acquired.append(time.monotonic())
     t, _ = _run_bg(sched, [hog, Job('runner', BUILD, runner, weight=0)])
     assert _wait_until(lambda: p.cur == 1)   # hog running, holds budget=8
@@ -195,7 +195,7 @@ def test_resolve_weight_handles_int_and_callable():
 
 
 def test_assign_priorities_is_the_critical_path_depth():
-    # a feeds b (a -> b); c is independent. a's trunk depth (itself + b) beats c, so the trunk feeder runs first.
+    # a feeds b (a -> b), c is independent. a's trunk depth (itself + b) beats c, so the trunk feeder runs first.
     a, b, c = Job('a', BUILD, lambda: None), Job('b', BUILD, lambda: None), Job('c', BUILD, lambda: None)
     b.deps.add(a)
     assign_priorities([a, b, c])
@@ -209,7 +209,7 @@ def test_scheduler_launches_highest_priority_ready_job_first():
     hi = Job('hi', BUILD, lambda: body('hi'), weight=8); hi.priority = 100.0
     sched = _sched(core_budget=8, overprovision=1.0, cpu_sampler=lambda: 100.0)  # budget fits one weight-8 build
     t, _ = _run_bg(sched, [lo, hi])                # pending order is lo, hi - but priority must win
-    assert _wait_until(lambda: order == ['hi'])    # only hi launched; lo waits though it's also ready
+    assert _wait_until(lambda: order == ['hi'])    # only hi launched, lo waits though it is also ready
     gate.set(); t.join(3.0)
     assert order == ['hi', 'lo']
 
@@ -226,7 +226,7 @@ def test_fail_fast_returns_failed_job_and_blocks_dependents():
 
 
 def test_failure_fires_abort_hook_once_to_kill_in_flight():
-    # Fail-fast: the first failure fires the child-killer so in-flight compiles are killed, not drained.
+    # Fail-fast: the first failure fires the child-killer, which kills in-flight compiles instead of draining them.
     hook = []
     def boom(): raise RuntimeError('kaboom')
     failed = _sched(abort_hook=hook.append).run([Job('a', BUILD, boom), Job('b', BUILD, boom)])
@@ -326,12 +326,12 @@ def test_build_slot_bails_when_build_already_failing():
 
 
 def test_pending_log_is_called_without_holding_the_scheduler_lock():
-    # the display writes to the terminal from this callback; holding _cond across it stalls every
-    # job launch and completion behind a frame write
+    # The display writes to the terminal from this callback. Holding _cond across it stalls every
+    # job launch and completion behind a frame write.
     held = []
     def probe(hint):
         got = [None]
-        def grab():  # acquire AND release on the same thread: an RLock can't be released by another
+        def grab():  # acquire AND release on the same thread: an RLock cannot be released by another
             got[0] = sched._cond.acquire(timeout=0.2)
             if got[0]: sched._cond.release()
         t = threading.Thread(target=grab); t.start(); t.join(1.0)

--- a/tests/test_buildstats/test_buildstats.py
+++ b/tests/test_buildstats/test_buildstats.py
@@ -21,7 +21,7 @@ def test_bar_segments_are_proportional_in_load_cfg_build_order():
 
 
 def test_blocks_fall_back_to_ascii_on_a_legacy_code_page():
-    assert not dc._can_encode_blocks('cp1252')   # Windows legacy code page can't encode ░▒▓ -> ASCII
+    assert not dc._can_encode_blocks('cp1252')   # a Windows legacy code page cannot encode the shade glyphs -> ASCII
     assert dc._can_encode_blocks('utf-8')
 
 

--- a/tests/test_clean_only/test_clean_only.py
+++ b/tests/test_clean_only/test_clean_only.py
@@ -40,7 +40,7 @@ def _git_dep(tmp_path, **cfg):
 
 
 def _fetched_during_load(dep):
-    """Did loading this dep reach out to git? Returns the checkout call count."""
+    """Load the dep and return the git checkout call count."""
     def load_target(self):
         self.target = Mock(args='', build_products=[], name=self.name)
         return self.target
@@ -55,7 +55,7 @@ def _fetched_during_load(dep):
 
 def test_clean_does_not_clone_missing_sources(tmp_path):
     # `mama clean all` used to spend minutes cloning deps whose shim marker an earlier clean removed,
-    # only to delete the directory it just filled.
+    # then deleted the fresh clone.
     assert _fetched_during_load(_git_dep(tmp_path, clean=True, build=False)) == 0
 
 

--- a/tests/test_clean_only/test_clean_only.py
+++ b/tests/test_clean_only/test_clean_only.py
@@ -54,8 +54,7 @@ def _fetched_during_load(dep):
 
 
 def test_clean_does_not_clone_missing_sources(tmp_path):
-    # `mama clean all` used to spend minutes cloning deps whose shim marker an earlier clean removed,
-    # then deleted the fresh clone.
+    # a clean-only run must not clone a missing source that the clean deletes right after
     assert _fetched_during_load(_git_dep(tmp_path, clean=True, build=False)) == 0
 
 

--- a/tests/test_clean_sweep/test_clean_sweep.py
+++ b/tests/test_clean_sweep/test_clean_sweep.py
@@ -1,5 +1,5 @@
-"""Pins `clean all`'s disk sweep: it cleans every build dir of THIS config that the tree walk cannot
-reach, including a dep's args dirs, and it never touches another config's or a non-mama dir."""
+"""Pins `clean all`'s disk sweep: every unreachable build dir of THIS config goes, including a dep's
+args dirs. Another config's dir or a non-mama dir is never touched."""
 from types import SimpleNamespace
 import pytest
 from mama.build_names import is_build_dir_of

--- a/tests/test_clean_sweep/test_clean_sweep.py
+++ b/tests/test_clean_sweep/test_clean_sweep.py
@@ -44,7 +44,7 @@ def test_sweep_on_a_missing_workspace_is_a_noop(tmp_path):
 
 
 def test_sweep_reaches_the_args_dirs_of_one_dep(tmp_path):
-    # An unreachable dep declares no args, so its linux-lgpl dir used to survive every clean.
+    # an unreachable dep declares no args, so only the sweep can reach its linux-lgpl dir
     ws, root, config = _workspace(tmp_path)
     _marked(ws, 'libffmpeg', 'linux-lgpl')
     _marked(ws, 'libffmpeg', 'linux-cpp20-lgpl')

--- a/tests/test_clone_timing/test_clone_timing.py
+++ b/tests/test_clone_timing/test_clone_timing.py
@@ -19,13 +19,13 @@ from mama.util import get_time_str
     (42,       '42.0s'),
     (59.9,     '59.9s'),
 
-    # 1m–59m: 'Xm Ys' (note the space - already established project style)
+    # 1m-59m: 'Xm Ys' (note the space - already established project style)
     (60,       '1m 0s'),
     (67,       '1m 7s'),    # the example from the user request
     (125,      '2m 5s'),
     (3599,     '59m 59s'),
 
-    # 1h–23h: 'Xh Ym Zs'
+    # 1h-23h: 'Xh Ym Zs'
     (3600,     '1h 0m 0s'),
     (3661,     '1h 1m 1s'),
     (86399,    '23h 59m 59s'),

--- a/tests/test_clone_timing/test_clone_timing.py
+++ b/tests/test_clone_timing/test_clone_timing.py
@@ -21,7 +21,7 @@ from mama.util import get_time_str
 
     # 1m-59m: 'Xm Ys' (note the space - already established project style)
     (60,       '1m 0s'),
-    (67,       '1m 7s'),    # the example from the user request
+    (67,       '1m 7s'),
     (125,      '2m 5s'),
     (3599,     '59m 59s'),
 

--- a/tests/test_cmake_cache_repair/test_cmake_cache_repair.py
+++ b/tests/test_cmake_cache_repair/test_cmake_cache_repair.py
@@ -30,8 +30,7 @@ def test_cache_generator_reads_the_exact_key():
 
 
 def test_a_stale_other_build_system_file_does_not_count(tmp_path):
-    # Targets pick their own build system: a leftover Makefile must NOT make a Ninja-configured dir
-    # look complete, or `cmake --build` dies on the missing build.ninja every time.
+    # A leftover Makefile must not make a Ninja-configured dir look complete: `cmake --build` dies on the missing build.ninja.
     d = str(tmp_path / 'b')
     write_cmake_cache(d, NINJA); write_build_file(d, 'Makefile')
     assert not cc.is_cmake_cache_valid(d)
@@ -49,7 +48,7 @@ def test_a_visual_studio_dir_is_valid_with_either_solution_format(tmp_path):
 
 
 def test_a_visual_studio_slnx_dir_skips_the_reconfigure(tmp_path):
-    # the .slnx read as a killed configure, so every `mama build` wiped the dir and paid a full rebuild
+    # a .slnx that reads as a killed configure makes every `mama build` wipe the dir and pay a full rebuild
     t, dep = make_configured_target(tmp_path)
     write_cmake_cache(t.build_dir(), VS); write_build_file(t.build_dir(), 'Foo.slnx')
     assert _run_config_recording(t, dep) == []
@@ -63,8 +62,7 @@ def test_unknown_generator_is_trusted_not_wiped(tmp_path):
 
 
 def test_cache_without_generated_build_file_is_repaired(tmp_path):
-    # A find_package failure leaves a COMPLETE cache but no build.ninja. A skipped reconfigure then
-    # dies with "ninja: error: loading 'build.ninja'" on every later build until the dir is wiped.
+    # A find_package failure leaves a COMPLETE cache but no build.ninja. A skipped reconfigure then dies on every later build.
     t, dep = make_configured_target(tmp_path)
     write_cmake_cache(t.build_dir(), COMPLETE)
     assert _run_config_recording(t, dep) == ['conf']

--- a/tests/test_cmake_cache_repair/test_cmake_cache_repair.py
+++ b/tests/test_cmake_cache_repair/test_cmake_cache_repair.py
@@ -59,12 +59,12 @@ def test_a_visual_studio_slnx_dir_skips_the_reconfigure(tmp_path):
 def test_unknown_generator_is_trusted_not_wiped(tmp_path):
     d = str(tmp_path / 'b')
     write_cmake_cache(d, 'CMAKE_GENERATOR:INTERNAL=Green Hills MULTI\n')
-    assert cc.is_cmake_cache_valid(d)  # we don't know its build file - let cmake decide, don't wipe blindly
+    assert cc.is_cmake_cache_valid(d)  # unknown build file name - let cmake decide, do not wipe blindly
 
 
 def test_cache_without_generated_build_file_is_repaired(tmp_path):
-    # A find_package failure leaves a COMPLETE cache but no build.ninja; skipping the reconfigure then
-    # dies with "ninja: error: loading 'build.ninja'" on every later build until it's wiped.
+    # A find_package failure leaves a COMPLETE cache but no build.ninja. A skipped reconfigure then
+    # dies with "ninja: error: loading 'build.ninja'" on every later build until the dir is wiped.
     t, dep = make_configured_target(tmp_path)
     write_cmake_cache(t.build_dir(), COMPLETE)
     assert _run_config_recording(t, dep) == ['conf']
@@ -99,7 +99,7 @@ def test_complete_configure_still_skips_the_reconfigure(tmp_path):
 
 
 def _write_compiler_module(build_dir, ver='4.3.1', abi_done=True):
-    """CMakeFiles/<ver>/CMakeCXXCompiler.cmake; without the ABI line it's the stage-1 module a
+    """CMakeFiles/<ver>/CMakeCXXCompiler.cmake. Without the ABI line it is the stage-1 module that a
     configure killed mid-detection leaves behind."""
     d = os.path.join(build_dir, 'CMakeFiles', ver); os.makedirs(d, exist_ok=True)
     text = 'set(CMAKE_CXX_COMPILER "/usr/bin/g++")\n' + ('set(CMAKE_CXX_ABI_COMPILED TRUE)\n' if abi_done else '')
@@ -113,7 +113,7 @@ def test_killed_detection_is_wiped_and_reconfigured(tmp_path, with_cache):
     if with_cache: write_cmake_cache(t.build_dir(), NINJA); write_build_file(t.build_dir(), 'build.ninja')
     _write_compiler_module(t.build_dir(), abi_done=False)
     with patch('mama.buildsys.cmake.configure._cmake_version_number', return_value='4.3.1'):  # no `cmake --version` shell-out
-        assert _run_config_recording(t, dep) == ['conf']  # the dir looks complete but cmake would trust
+        assert _run_config_recording(t, dep) == ['conf']  # the dir looks complete, but cmake would trust the stale module
     assert not os.path.exists(os.path.join(t.build_dir(), 'CMakeFiles'))  # the stage-1 module: wipe, redetect
 
 

--- a/tests/test_compile_commands/test_compile_commands.py
+++ b/tests/test_compile_commands/test_compile_commands.py
@@ -1,4 +1,4 @@
-"""Pins that sanitized/coverage builds don't repoint c_cpp_properties.json compileCommands."""
+"""Pins that sanitized/coverage builds do not repoint c_cpp_properties.json compileCommands."""
 import json, os
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/test_compiler_cache/test_compiler_cache.py
+++ b/tests/test_compiler_cache/test_compiler_cache.py
@@ -195,12 +195,12 @@ def test_is_valid_rejects_a_single_language_seed(tmp_path):
     assert not cc.is_valid({**fp, 'langs': ['CXX']}, 'FP')
     assert not cc.is_valid({**fp, 'langs': []}, 'FP')
     assert cc.is_valid({**fp, 'langs': ['C', 'CXX']}, 'FP')
-    assert not cc.is_valid(fp, 'FP')  # no langs record -> can't prove it covers C+CXX
+    assert not cc.is_valid(fp, 'FP')  # no langs record -> cannot prove it covers C+CXX
 
 
 def test_inject_writes_no_marker_when_seed_has_no_files(tmp_path):
     # A vanished/empty seed must NOT leave a PLATFORM_INFO marker with zero compiler files - cmake
-    # would then trust detection that isn't there. inject bails (False); the caller redetects.
+    # would then trust detection that is not there. inject returns False and the caller redetects.
     seed = str(tmp_path / 'seed'); os.makedirs(seed)
     open(os.path.join(seed, cc._MANIFEST), 'w').write('{"files": [], "langs": []}')
     build = str(tmp_path / 'B')
@@ -424,8 +424,8 @@ def test_disabled_is_noop(tmp_path):
 
 
 def test_reprobes_when_seed_files_vanished(tmp_path):
-    # A concurrent heal can remove the toolchain files while the manifest lingers; prepare must never
-    # return a doomed 'use' - with a probe it just rebuilds the seed.
+    # A concurrent heal can remove the toolchain files while the manifest lingers. prepare must never
+    # return a doomed 'use' - with a probe it rebuilds the seed.
     calls = []
     co = _coord(tmp_path, seed_fn=_probe(tmp_path, calls=calls))
     a = _T(str(tmp_path / 'A'))
@@ -445,7 +445,7 @@ def test_abi_flags_reach_the_probe_and_the_fingerprint():
     cfg.sanitize = 'address'
     assert _abi_flags(cfg) == ('-fsanitize=address', '-fsanitize=address -stdlib=libstdc++')
     assert _abi_flags(SimpleNamespace(linux=True, clang=False, msvc=False, clang_stdlib='libc++',
-                                      sanitize=None)) == ('', '')   # gcc: stdlib isn't a choice
+                                      sanitize=None)) == ('', '')   # gcc: the stdlib is not a choice
 
 
 def test_probe_cmd_carries_the_cross_toolchain(tmp_path, monkeypatch):
@@ -471,7 +471,7 @@ def test_probe_cmd_carries_the_cross_toolchain(tmp_path, monkeypatch):
 
 
 def test_an_sdk_move_changes_the_fingerprint(tmp_path, monkeypatch):
-    # Yocto SDKs keep the compiler path stable across upgrades but move the sysroot; if that doesn't
+    # Yocto SDKs keep the compiler path stable across upgrades but move the sysroot. If that does not
     # reach the fingerprint, a cross build reuses a seed detected against the previous sysroot.
     from mama.buildsys.cmake import configure as cfg
     opts = ['CMAKE_SYSTEM_NAME=Linux', 'CMAKE_SYSROOT=/opt/sdk-1.0/sysroot']

--- a/tests/test_compiler_cache/test_compiler_cache.py
+++ b/tests/test_compiler_cache/test_compiler_cache.py
@@ -45,7 +45,7 @@ def test_publish_then_inject_reproduces_warm_state(tmp_path):
 
 
 def test_inject_writes_only_toolchain_markers_never_project_settings(tmp_path):
-    # Regression: injected cache is toolchain markers only (no ABI facts captured here), no project flags.
+    # the injected cache is toolchain markers only (no ABI facts captured here), never project flags
     bf = make_cmake_detection(str(tmp_path / 'A' / '4.2.3'))
     seed = str(tmp_path / 'seed'); cc.publish(seed, bf)
     build = str(tmp_path / 'B'); bfd = os.path.join(build, 'CMakeFiles', '4.2.3')
@@ -79,8 +79,7 @@ def test_seeded_cache_replays_the_abi_facts_the_probe_would_have_set(tmp_path):
 
 
 def test_seeded_cache_names_the_compiler_a_toolchain_file_left_uncached(tmp_path):
-    # A toolchain file names the compiler, so cmake caches none. Without the replay, a CMakeLists that
-    # runs `set(CMAKE_CXX_COMPILER $ENV{CXX})` with CXX unset leaves every ninja rule compiling with "".
+    # A toolchain file names the compiler, so cmake caches none. Without the replay, ninja rules can end up compiling with "".
     build = str(tmp_path / 'A')
     bf = make_cmake_detection(os.path.join(build, 'CMakeFiles', '4.2.3'))
     _write_cache(build, 'CMAKE_TOOLCHAIN_FILE:FILEPATH=/opt/sdk/tc.cmake\n')
@@ -118,8 +117,7 @@ def _break_compiler_module(build_files_dir, lang, line):
 
 @pytest.mark.parametrize('line', ['set(CMAKE_CXX_COMPILER "")', '', 'set(CMAKE_CXX_COMPILER "/gone/g++")'])
 def test_publish_refuses_a_seed_whose_compiler_is_not_usable(tmp_path, line):
-    # The seed costs one slow probe and every later build dir reuses it. A seed naming a compiler
-    # this machine cannot run therefore breaks every build, so detect again instead.
+    # Every later build dir reuses the seed, so a seed naming a compiler this machine cannot run breaks every build.
     bf = make_cmake_detection(str(tmp_path / 'A' / '4.2.3'))
     _break_compiler_module(bf, 'CXX', line)
     seed = str(tmp_path / 'seed')
@@ -167,8 +165,7 @@ def test_publish_refuses_a_half_detected_toolchain(tmp_path):
 
 
 def test_publish_refuses_a_seed_missing_a_core_language(tmp_path):
-    # backstop for the seeding invariant: a seed missing a core language would let a project that
-    # enables it skip detection and die on 'CMAKE_<lang>_COMPILER not set, after EnableLanguage'.
+    # a seed missing a core language lets a project that enables it skip detection and die at EnableLanguage
     for langs in (('C',), ('CXX',), ('C', 'RC')):
         bf = make_cmake_detection(str(tmp_path / '_'.join(langs) / '4.2.3'), langs=langs)
         seed = str(tmp_path / ('seed_' + '_'.join(langs)))
@@ -199,8 +196,7 @@ def test_is_valid_rejects_a_single_language_seed(tmp_path):
 
 
 def test_inject_writes_no_marker_when_seed_has_no_files(tmp_path):
-    # A vanished/empty seed must NOT leave a PLATFORM_INFO marker with zero compiler files - cmake
-    # would then trust detection that is not there. inject returns False and the caller redetects.
+    # An empty seed must not leave a PLATFORM_INFO marker with zero compiler files: cmake would trust absent detection.
     seed = str(tmp_path / 'seed'); os.makedirs(seed)
     open(os.path.join(seed, cc._MANIFEST), 'w').write('{"files": [], "langs": []}')
     build = str(tmp_path / 'B')
@@ -318,7 +314,7 @@ def test_probe_seeds_the_first_caller_and_every_later_one(tmp_path):
 
 
 def test_a_cxx_only_project_is_served_by_the_probe(tmp_path):
-    # the bug this design fixes: a C-only or CXX-only project used to decide the seed's languages
+    # a single-language project must never decide the seed's languages: the probe serves C+CXX
     co = _coord(tmp_path)
     assert co.prepare(_T(str(tmp_path / 'cxx_only'))) == 'use'
     assert cc.load(co.seed_dir(_T(str(tmp_path / 'x'))))['langs'] == ['C', 'CXX']
@@ -424,8 +420,7 @@ def test_disabled_is_noop(tmp_path):
 
 
 def test_reprobes_when_seed_files_vanished(tmp_path):
-    # A concurrent heal can remove the toolchain files while the manifest lingers. prepare must never
-    # return a doomed 'use' - with a probe it rebuilds the seed.
+    # A concurrent heal can remove the seed files while the manifest lingers: prepare must rebuild, not return a doomed 'use'.
     calls = []
     co = _coord(tmp_path, seed_fn=_probe(tmp_path, calls=calls))
     a = _T(str(tmp_path / 'A'))
@@ -437,8 +432,7 @@ def test_reprobes_when_seed_files_vanished(tmp_path):
 
 
 def test_abi_flags_reach_the_probe_and_the_fingerprint():
-    # the probe must detect with the same ABI inputs the real targets use, or its implicit link libs
-    # (libc++ vs libstdc++, a sanitizer runtime) describe a toolchain nobody is actually building with
+    # the probe must detect with the ABI inputs the real targets use, or its implicit link libs describe the wrong toolchain
     from mama.buildsys.cmake.configure import _abi_flags
     cfg = SimpleNamespace(linux=True, clang=True, msvc=False, clang_stdlib='libstdc++', sanitize=None)
     assert _abi_flags(cfg) == ('', '-stdlib=libstdc++')        # -stdlib is C++-only: clang warns on C
@@ -449,9 +443,7 @@ def test_abi_flags_reach_the_probe_and_the_fingerprint():
 
 
 def test_probe_cmd_carries_the_cross_toolchain(tmp_path, monkeypatch):
-    # Yocto/raspi inject the sysroot + cross binutils via the platform opts, NOT via the obvious
-    # CMAKE_*_COMPILER keys. A probe without them detects the HOST toolchain and publishes it for a
-    # cross fingerprint - every seeded cross target then links against host libs.
+    # Yocto/raspi inject sysroot + cross binutils via platform opts, not CMAKE_*_COMPILER: a probe without them detects the HOST.
     from mama.buildsys.cmake import configure as cfg
     platform = ['CMAKE_SYSROOT=/opt/sdk/sysroot', 'CMAKE_SYSTEM_NAME=Linux', 'CMAKE_AR=/opt/sdk/bin/aarch64-ar']
     monkeypatch.setattr(cfg, '_platform_opts', lambda t: list(platform))
@@ -471,8 +463,7 @@ def test_probe_cmd_carries_the_cross_toolchain(tmp_path, monkeypatch):
 
 
 def test_an_sdk_move_changes_the_fingerprint(tmp_path, monkeypatch):
-    # Yocto SDKs keep the compiler path stable across upgrades but move the sysroot. If that does not
-    # reach the fingerprint, a cross build reuses a seed detected against the previous sysroot.
+    # Yocto SDK upgrades keep the compiler path but move the sysroot, so the sysroot must reach the fingerprint.
     from mama.buildsys.cmake import configure as cfg
     opts = ['CMAKE_SYSTEM_NAME=Linux', 'CMAKE_SYSROOT=/opt/sdk-1.0/sysroot']
     monkeypatch.setattr(cfg, '_platform_opts', lambda t: list(opts))
@@ -483,9 +474,7 @@ def test_an_sdk_move_changes_the_fingerprint(tmp_path, monkeypatch):
 
 
 def test_seed_replays_the_compiler_and_toolchain_so_cmake_never_resets_the_cache(tmp_path):
-    # mama passes -DCMAKE_C/CXX_COMPILER on every configure. An injected cache without them makes cmake
-    # say "you have changed variables that require your cache to be deleted", wipe the cache MID-configure
-    # and re-run WITHOUT the toolchain file - so an android build silently re-detected as host x86_64.
+    # Without the -DCMAKE_C/CXX_COMPILER lines, cmake wipes the cache mid-configure and re-runs WITHOUT the toolchain file.
     build = str(tmp_path / 'A')
     bf = make_cmake_detection(os.path.join(build, 'CMakeFiles', '4.2.3'))
     _write_cache(build,
@@ -504,8 +493,7 @@ def test_seed_replays_the_compiler_and_toolchain_so_cmake_never_resets_the_cache
 
 
 def test_a_seed_from_an_older_mama_is_rejected_not_reused(tmp_path):
-    # the older shape has the SAME fingerprint but replays too few cache lines, so reusing it would
-    # reintroduce the cache reset. It must be re-probed instead.
+    # the older shape has the SAME fingerprint but replays too few cache lines, so it must be re-probed, not reused
     old = _live_manifest(tmp_path); old.pop('format')           # no 'format' key
     assert not cc.is_valid(old, 'FP')
     assert cc.is_valid({**old, 'format': cc._SEED_FORMAT}, 'FP')

--- a/tests/test_configure_build_split/test_configure_build_split.py
+++ b/tests/test_configure_build_split/test_configure_build_split.py
@@ -74,8 +74,7 @@ def test_configure_runs_once_across_phases(tmp_path):
 
 
 def test_custom_build_configures_exactly_once_in_build_phase(tmp_path):
-    # Custom build(): configure_phase is a no-op, so the once-guard must let build_phase's
-    # _run_configure_once() call configure() exactly once (and block any later call).
+    # Custom build(): configure_phase is a no-op, so the once-guard must let build_phase configure exactly once.
     t, dep = _target(tmp_path)
     es, _ = _wire(t, dep)
     es.enter_context(patch.object(t, '_has_custom_build', return_value=True))
@@ -108,8 +107,7 @@ def test_per_target_jobs_flow_into_j_flag_without_touching_config(tmp_path):
 
 
 def test_configure_phase_sizes_build_weight_from_tu_count(tmp_path):
-    # Regression: configure_phase must set _build_jobs from the TU probe. Left None, every build
-    # would reserve the whole budget and run one-at-a-time.
+    # A _build_jobs left None makes every build reserve the whole budget and run one-at-a-time.
     t, dep = _target(tmp_path)  # config.jobs = 8
     with open(t.build_dir('compile_commands.json'), 'w') as f:
         f.write('[{"file":"a"},{"file":"b"},{"file":"c"}]')
@@ -157,9 +155,7 @@ def test_reserved_cores_is_full_build_jobs_capped_at_total(tmp_path):
 
 
 def test_toolchain_inputs_cover_the_cross_setup_but_never_project_flags(tmp_path, monkeypatch):
-    # The fingerprint must invalidate on a toolchain/sysroot change (an SDK move keeps the compiler path
-    # but changes CMAKE_SYSROOT) yet NOT on project flags - else a flag tweak redoes detection, or a
-    # sysroot swap reuses a seed detected against the old one.
+    # The fingerprint must invalidate on a toolchain/sysroot change but not on project flags, which would redo detection.
     tc = tmp_path / 'arm.toolchain.cmake'; tc.write_bytes(b'set(SYSROOT /opt/arm)\n')
     platform = [f'CMAKE_TOOLCHAIN_FILE="{tc}"', 'CMAKE_SYSTEM_NAME=Linux', 'CMAKE_SYSROOT=/opt/sdk/sysroot',
                 'CMAKE_AR=/opt/sdk/bin/aarch64-ar']
@@ -200,8 +196,7 @@ def test_probe_counts_real_visualstudio_tus(tmp_path):
 
 
 def test_cmake_defines_survive_a_windows_path(tmp_path):
-    # SubProcess shlex-splits the command, which strips backslashes: a raw Windows path a mamafile
-    # passed through add_cmake_options() used to arrive as C:ProjectsGCSpackagesprotobufwindowsbinprotoc.exe
+    # SubProcess shlex-splits the command, which strips backslashes: a raw Windows path arrives with its separators eaten
     import shlex
     opt = r'PROTOC_EXECUTABLE=C:/proj/packages/protobuf\windows\bin\protoc.exe'
     defines = cc._opts_to_defines([opt])

--- a/tests/test_configure_build_split/test_configure_build_split.py
+++ b/tests/test_configure_build_split/test_configure_build_split.py
@@ -56,7 +56,7 @@ def test_custom_build_collapses_into_build_phase(tmp_path):
     es.enter_context(patch.object(t, 'build', side_effect=lambda: ev.append('user_build')))
     with es:
         t.configure_phase()
-        assert ev == []  # custom build owns its own configure; configure_phase is a no-op
+        assert ev == []  # custom build owns its own configure, configure_phase is a no-op
         t.build_phase()
     assert ev == ['user_build', 'successful_build', 'clean', 'package']
     assert 'run_config' not in ev and 'run_build' not in ev
@@ -108,7 +108,7 @@ def test_per_target_jobs_flow_into_j_flag_without_touching_config(tmp_path):
 
 
 def test_configure_phase_sizes_build_weight_from_tu_count(tmp_path):
-    # Regression: configure_phase must set _build_jobs from the TU probe; left None every build
+    # Regression: configure_phase must set _build_jobs from the TU probe. Left None, every build
     # would reserve the whole budget and run one-at-a-time.
     t, dep = _target(tmp_path)  # config.jobs = 8
     with open(t.build_dir('compile_commands.json'), 'w') as f:
@@ -200,8 +200,8 @@ def test_probe_counts_real_visualstudio_tus(tmp_path):
 
 
 def test_cmake_defines_survive_a_windows_path(tmp_path):
-    # SubProcess shlex-splits the command, which eats backslashes: a mamafile passing a raw Windows
-    # path through add_cmake_options() used to arrive as C:ProjectsGCSpackagesprotobufwindowsbinprotoc.exe
+    # SubProcess shlex-splits the command, which strips backslashes: a raw Windows path a mamafile
+    # passed through add_cmake_options() used to arrive as C:ProjectsGCSpackagesprotobufwindowsbinprotoc.exe
     import shlex
     opt = r'PROTOC_EXECUTABLE=C:/proj/packages/protobuf\windows\bin\protoc.exe'
     defines = cc._opts_to_defines([opt])

--- a/tests/test_configure_flags/test_configure_flags.py
+++ b/tests/test_configure_flags/test_configure_flags.py
@@ -31,8 +31,8 @@ def test_use_toolchain_file_records_and_formats(tmp_path):
 
 def test_a_toolchain_file_build_does_not_name_the_compiler(tmp_path):
     """The NDK toolchain rewrites our `bin/aarch64-linux-android29-clang` to `bin/clang`. On a build dir
-    that already holds a cache our -D then reads as a changed variable, so cmake DELETES the cache and
-    re-runs - losing the seeded platform info and re-detecting as the host."""
+    that already holds a cache our -D then reads as a changed variable. cmake DELETES the cache and
+    re-runs, loses the seeded platform info, and re-detects as the host."""
     t, dep = make_configured_target(tmp_path, cmake_toolchain_file='/ndk/android.toolchain.cmake')
     cmd = run_config_capturing(t, dep)[0]
     assert '-DCMAKE_C_COMPILER=' not in cmd and '-DCMAKE_CXX_COMPILER=' not in cmd

--- a/tests/test_console_progress/test_console_progress.py
+++ b/tests/test_console_progress/test_console_progress.py
@@ -26,8 +26,7 @@ class TestProgressFinalization:
 
     def test_progress_redraw_does_not_get_extra_newline(
             self, capsys, reset_progress_state):
-        # Repeated \r-redraws of the same progress bar must overwrite each
-        # other on the same row. Never inject a newline between them.
+        # Repeated \r-redraws of one progress bar must overwrite each other on the same row, never gain a newline.
         k = system._ERASE_EOL
         system.console('\r    | 20% |', end='')
         system.console('\r    | 40% |', end='')
@@ -53,8 +52,7 @@ class TestProgressFinalization:
 
     def test_initial_progress_bar_without_carriage_return_still_tracked(
             self, capsys, reset_progress_state):
-        # The artifactory upload prints its first bar frame without \r
-        # ('   |> ...| 0 %' with end=''). Later status writes must still finalize it.
+        # The artifactory upload prints its first bar frame without \r and with end=''. Later status must still finalize it.
         system.console('   |>          | 0 %', end='')
         system.console('  - Target X')
         assert capsys.readouterr().out == '   |>          | 0 %\n  - Target X\n'

--- a/tests/test_console_progress/test_console_progress.py
+++ b/tests/test_console_progress/test_console_progress.py
@@ -21,13 +21,13 @@ class TestProgressFinalization:
         system.console('\r    |====      | 40% (1s)', end='')
         system.console('  - Target foo SHIM FETCHED')
         out = capsys.readouterr().out
-        # The status line must start on its own row, not be glued to the bar.
+        # The status line must start on its own row, not on the bar row.
         assert f'40% (1s){system._ERASE_EOL}\n  - Target foo SHIM FETCHED\n' in out
 
     def test_progress_redraw_does_not_get_extra_newline(
             self, capsys, reset_progress_state):
         # Repeated \r-redraws of the same progress bar must overwrite each
-        # other on the same row; we must NOT inject a newline between them.
+        # other on the same row. Never inject a newline between them.
         k = system._ERASE_EOL
         system.console('\r    | 20% |', end='')
         system.console('\r    | 40% |', end='')
@@ -53,9 +53,8 @@ class TestProgressFinalization:
 
     def test_initial_progress_bar_without_carriage_return_still_tracked(
             self, capsys, reset_progress_state):
-        # The first frame of an upload progress bar is printed without \r
-        # (e.g. artifactory upload prints '   |> ...| 0 %' with end='').
-        # Subsequent status writes must still know to finalize it.
+        # The artifactory upload prints its first bar frame without \r
+        # ('   |> ...| 0 %' with end=''). Later status writes must still finalize it.
         system.console('   |>          | 0 %', end='')
         system.console('  - Target X')
         assert capsys.readouterr().out == '   |>          | 0 %\n  - Target X\n'

--- a/tests/test_coverage_report/test_coverage_report.py
+++ b/tests/test_coverage_report/test_coverage_report.py
@@ -50,12 +50,10 @@ class TestGcovrCommandShape:
     def test_permissive_parse_error_flags(self, capture_gcovr):
         mama_main.run_coverage_report(_make_target())
         cmd = capture_gcovr['calls'][0]['cmd']
-        # Both flags are needed: parse-errors covers UnknownLineType,
-        # ignore-errors covers gcov-invocation failures.
+        # Both flags are needed: parse-errors covers UnknownLineType, ignore-errors covers gcov-invocation failures.
         assert '--gcov-ignore-parse-errors all' in cmd
         assert '--gcov-ignore-errors all' in cmd
-        # Regression guard: the old value silently let UnknownLineType escape
-        # the parser as a non-zero exit. It must not return.
+        # negative_hits.warn alone lets UnknownLineType escape the parser as a non-zero exit, so it must not return
         assert 'negative_hits.warn' not in cmd
 
     def test_root_is_source_dir_and_build_dir_is_passed(self, capture_gcovr):
@@ -64,8 +62,7 @@ class TestGcovrCommandShape:
         call = capture_gcovr['calls'][0]
         assert '--root "/proj/src"' in call['cmd']
         assert '"/proj/build"' in call['cmd']
-        # gcovr runs from the source dir so relative paths in the
-        # report resolve consistently.
+        # gcovr runs from the source dir so relative paths in the report resolve consistently
         assert call['cwd'] == '/proj/src'
 
     def test_gcov_executable_derived_for_gcc_when_present(self, capture_gcovr, tmp_path):
@@ -79,16 +76,14 @@ class TestGcovrCommandShape:
         assert f'--gcov-executable "{gcov_path}"' in cmd
 
     def test_no_gcov_executable_when_clang(self, capture_gcovr, tmp_path):
-        # Even if a matching gcov-N existed, clang must not use it - the
-        # gcov-14 derived from gcc-14 would be wrong for llvm-cov anyway.
+        # a gcov-N derived from gcc-N is wrong for llvm-cov, so clang never uses it even when present
         (tmp_path / 'gcov-14').write_text('')
         target = _make_target(gcc=False, cc_path=str(tmp_path / 'gcc-14'))
         mama_main.run_coverage_report(target)
         assert '--gcov-executable' not in capture_gcovr['calls'][0]['cmd']
 
     def test_no_gcov_executable_when_derived_path_missing(self, capture_gcovr, tmp_path):
-        # gcc points somewhere but the gcov-N sibling does not exist - never
-        # pass a bogus --gcov-executable.
+        # gcc points somewhere but the gcov-N sibling does not exist: never pass a bogus --gcov-executable
         target = _make_target(gcc=True, cc_path=str(tmp_path / 'gcc-14'))
         mama_main.run_coverage_report(target)
         assert '--gcov-executable' not in capture_gcovr['calls'][0]['cmd']
@@ -101,7 +96,7 @@ class TestGcovrCommandShape:
 
 class TestFailureNeverPropagates:
     def test_nonzero_exit_is_a_warning_not_a_raise(self, capture_gcovr, capsys):
-        capture_gcovr['status'] = 120  # the exit status from the original bug report
+        capture_gcovr['status'] = 120
         mama_main.run_coverage_report(_make_target())
         out = capsys.readouterr().out
         assert 'WARNING' in out

--- a/tests/test_coverage_report/test_coverage_report.py
+++ b/tests/test_coverage_report/test_coverage_report.py
@@ -55,7 +55,7 @@ class TestGcovrCommandShape:
         assert '--gcov-ignore-parse-errors all' in cmd
         assert '--gcov-ignore-errors all' in cmd
         # Regression guard: the old value silently let UnknownLineType escape
-        # the parser as a non-zero exit. It must not come back.
+        # the parser as a non-zero exit. It must not return.
         assert 'negative_hits.warn' not in cmd
 
     def test_root_is_source_dir_and_build_dir_is_passed(self, capture_gcovr):
@@ -64,12 +64,12 @@ class TestGcovrCommandShape:
         call = capture_gcovr['calls'][0]
         assert '--root "/proj/src"' in call['cmd']
         assert '"/proj/build"' in call['cmd']
-        # gcovr is invoked from the source dir so relative paths in the
+        # gcovr runs from the source dir so relative paths in the
         # report resolve consistently.
         assert call['cwd'] == '/proj/src'
 
     def test_gcov_executable_derived_for_gcc_when_present(self, capture_gcovr, tmp_path):
-        # cc_path = /tmp/.../gcc-14 → derived gcov path = /tmp/.../gcov-14
+        # cc_path = /tmp/.../gcc-14 -> derived gcov path = /tmp/.../gcov-14
         gcov_path = tmp_path / 'gcov-14'
         gcov_path.write_text('')  # only existence is checked
         gcc_path = tmp_path / 'gcc-14'
@@ -79,7 +79,7 @@ class TestGcovrCommandShape:
         assert f'--gcov-executable "{gcov_path}"' in cmd
 
     def test_no_gcov_executable_when_clang(self, capture_gcovr, tmp_path):
-        # Even if a matching gcov-N existed, clang must not pick it up - the
+        # Even if a matching gcov-N existed, clang must not use it - the
         # gcov-14 derived from gcc-14 would be wrong for llvm-cov anyway.
         (tmp_path / 'gcov-14').write_text('')
         target = _make_target(gcc=False, cc_path=str(tmp_path / 'gcc-14'))
@@ -87,8 +87,8 @@ class TestGcovrCommandShape:
         assert '--gcov-executable' not in capture_gcovr['calls'][0]['cmd']
 
     def test_no_gcov_executable_when_derived_path_missing(self, capture_gcovr, tmp_path):
-        # gcc points somewhere but the gcov-N sibling doesn't exist - we
-        # must not pass a bogus --gcov-executable.
+        # gcc points somewhere but the gcov-N sibling does not exist - never
+        # pass a bogus --gcov-executable.
         target = _make_target(gcc=True, cc_path=str(tmp_path / 'gcc-14'))
         mama_main.run_coverage_report(target)
         assert '--gcov-executable' not in capture_gcovr['calls'][0]['cmd']
@@ -101,8 +101,7 @@ class TestGcovrCommandShape:
 
 class TestFailureNeverPropagates:
     def test_nonzero_exit_is_a_warning_not_a_raise(self, capture_gcovr, capsys):
-        capture_gcovr['status'] = 120  # what triggered this whole work
-        # Must return normally - no exception escapes.
+        capture_gcovr['status'] = 120  # the exit status from the original bug report
         mama_main.run_coverage_report(_make_target())
         out = capsys.readouterr().out
         assert 'WARNING' in out
@@ -118,7 +117,6 @@ class TestFailureNeverPropagates:
         def boom(**_kw):
             raise RuntimeError('subprocess blew up')
         monkeypatch.setattr(mama_main, 'execute_piped_echo', boom)
-        # Even an unexpected RuntimeError from the runner must not propagate.
         mama_main.run_coverage_report(_make_target())
         out = capsys.readouterr().out
         assert 'ERROR' in out

--- a/tests/test_dep_dir_lock/test_dep_dir_lock.py
+++ b/tests/test_dep_dir_lock/test_dep_dir_lock.py
@@ -23,8 +23,7 @@ def test_second_acquirer_times_out_but_still_runs_then_frees(tmp_path):
     d = str(tmp_path / 'dep')
     with interprocess_dir_lock(d, timeout=5) as first:
         assert first is True
-        # a distinct fd on the same file conflicts even within one process (flock is per-open-file) -> the
-        # nested acquire times out, but its block still runs (best-effort, never blocks the build forever)
+        # flock is per-open-file, so a second fd conflicts even in-process: the acquire times out but the block still runs
         with interprocess_dir_lock(d, timeout=0.3) as second:
             assert second is False
     with interprocess_dir_lock(d, timeout=5) as again:

--- a/tests/test_dep_dir_lock/test_dep_dir_lock.py
+++ b/tests/test_dep_dir_lock/test_dep_dir_lock.py
@@ -1,5 +1,5 @@
-"""Pins the cross-process dep-dir lock: an flock/msvcrt guard that serialises a dep's shim+checkout across
-concurrent mama processes (so a reclone-wipe can't rmtree a dir another builder is shimming into), never hangs."""
+"""Pins the cross-process dep-dir lock: an flock/msvcrt guard that serializes a dep's shim+checkout
+across concurrent mama processes, and never hangs."""
 import contextlib, os, pytest
 from unittest.mock import patch
 
@@ -8,13 +8,13 @@ from mama.utils.dir_lock import interprocess_dir_lock
 from mama import build_dependency as bd
 
 
-# ── the lock primitive ───────────────────────────────────────────────────────
+# --- the lock primitive -----------------------------------------------------
 
 def test_acquires_uncontended_and_puts_the_sidecar_beside_not_inside(tmp_path):
     d = str(tmp_path / 'pkg' / 'libfoo')
     with interprocess_dir_lock(d, timeout=5) as ok:
         assert ok is True
-        # beside libfoo, so a reclone-wipe rmtree of libfoo can't unlink a held lock and break exclusion
+        # beside libfoo, so a reclone-wipe rmtree of libfoo cannot unlink a held lock and break exclusion
         assert os.path.exists(str(tmp_path / 'pkg' / '.libfoo.mama.lock'))
         assert not os.path.exists(os.path.join(d, '.mama.lock'))
 
@@ -41,7 +41,7 @@ def test_lock_is_released_even_when_the_body_raises(tmp_path):
         assert again is True   # finally-released despite the exception
 
 
-# ── wiring into BuildDependency._load ────────────────────────────────────────
+# --- wiring into BuildDependency._load --------------------------------------
 
 def test_git_load_runs_shim_and_checkout_inside_the_dep_dir_lock(tmp_path):
     dep = make_mock_dep(tmp_path)   # a git dep, is_root=False
@@ -61,5 +61,5 @@ def test_git_load_runs_shim_and_checkout_inside_the_dep_dir_lock(tmp_path):
             dep._load()
 
     labels = [e[0] if isinstance(e, tuple) else e for e in seq]
-    assert labels == ['enter', 'shim', 'checkout', 'exit']   # both under the lock; released before the parse
+    assert labels == ['enter', 'shim', 'checkout', 'exit']   # both under the lock, released before the parse
     assert seq[0][1] == dep.dep_dir                            # keyed on the shared dep_dir

--- a/tests/test_deps_only/test_deps_only.py
+++ b/tests/test_deps_only/test_deps_only.py
@@ -1,3 +1,4 @@
+"""Pins dependency flattening, deps_only scoping, and the unified scheduler's deps_only behavior."""
 import threading
 from unittest.mock import Mock
 import pytest
@@ -8,7 +9,6 @@ from mama.dependency_chain import (get_flat_deps, get_flat_child_deps, get_deps_
 
 
 def make_dep(name, children=None):
-    """Create a mock BuildDependency with the given name and children"""
     dep = Mock()
     dep.name = name
     dep.children = children or []
@@ -29,15 +29,7 @@ def make_config(build=False, clean=False, update=False):
 
 
 def make_tree():
-    """
-    Create a mock dependency tree:
-        root
-        ├── A
-        │   ├── C
-        │   └── D
-        └── B
-            └── D  (shared with A)
-    """
+    """A mock dependency tree: root -> {A -> {C, D}, B -> {D}}. D is shared by A and B."""
     D = make_dep('D')
     C = make_dep('C')
     A = make_dep('A', children=[C, D])
@@ -66,7 +58,6 @@ def test_get_flat_child_deps_excludes_root():
 
 
 def test_get_flat_child_deps_of_subtarget():
-    """get_flat_child_deps(A) should return only A's children: C and D"""
     root, A, B, C, D = make_tree()
     children = get_flat_child_deps(A)
     assert set(children) == {C, D}
@@ -76,7 +67,6 @@ def test_get_flat_child_deps_of_subtarget():
 
 
 def test_get_flat_child_deps_of_leaf():
-    """A leaf node has no children"""
     root, A, B, C, D = make_tree()
     children = get_flat_child_deps(D)
     assert children == []
@@ -85,18 +75,15 @@ def test_get_flat_child_deps_of_leaf():
 # --- dependency order ---
 
 def test_flat_deps_preserves_linker_order():
-    """Parents before children for Unix linker order"""
+    # parent-before-child is the Unix linker order
     root, A, B, C, D = make_tree()
     flat = get_flat_deps(root)
-    # A is parent of C and D, so A must come before C and D
     assert flat.index(A) < flat.index(C)
     assert flat.index(A) < flat.index(D)
-    # B is parent of D, so B must come before D
     assert flat.index(B) < flat.index(D)
 
 
 def test_flat_child_deps_preserves_linker_order():
-    """get_flat_child_deps must also preserve parent-before-child order"""
     root, A, B, C, D = make_tree()
     children = get_flat_child_deps(root)
     assert children.index(A) < children.index(C)
@@ -105,16 +92,13 @@ def test_flat_child_deps_preserves_linker_order():
 
 
 def test_flat_child_deps_subtarget_preserves_order():
-    """get_flat_child_deps(A) must return [C, D] in parent-before-child order"""
     root, A, B, C, D = make_tree()
     children = get_flat_child_deps(A)
-    # C and D are both direct children of A (no ordering between them),
-    # but the order from mamafile should be preserved: C before D
+    # C and D are both direct children of A. The mamafile declaration order must survive: C before D.
     assert children == [C, D]
 
 
 def test_shared_dep_appears_once_at_correct_position():
-    """D is shared by A and B; it should appear once, after both parents"""
     root, A, B, C, D = make_tree()
     flat = get_flat_deps(root)
     assert flat.count(D) == 1
@@ -125,7 +109,6 @@ def test_shared_dep_appears_once_at_correct_position():
 # --- deps_only: no target (existing behavior) ---
 
 def test_deps_only_no_target_removes_root():
-    """deps_only without a target removes root from flat_deps"""
     root, A, B, C, D = make_tree()
     flat_deps = get_flat_deps(root)
     flat_deps.remove(root)
@@ -138,7 +121,6 @@ def test_deps_only_no_target_removes_root():
 # --- deps_only: with target ---
 
 def test_get_deps_only_targets_filters_to_subtarget_deps():
-    """deps_only targeting A returns only A's deps (C, D), excluding A itself"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True)
     flat_deps, flat_deps_reverse = get_deps_only_targets(root, 'A', config)
@@ -149,7 +131,6 @@ def test_get_deps_only_targets_filters_to_subtarget_deps():
 
 
 def test_get_deps_only_targets_preserves_linker_order():
-    """flat_deps from get_deps_only_targets must be in parent-before-child order"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True)
     flat_deps, flat_deps_reverse = get_deps_only_targets(root, 'A', config)
@@ -157,7 +138,6 @@ def test_get_deps_only_targets_preserves_linker_order():
 
 
 def test_get_deps_only_targets_reverse_is_build_order():
-    """flat_deps_reverse is child-before-parent (build order)"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True)
     flat_deps, flat_deps_reverse = get_deps_only_targets(root, 'A', config)
@@ -165,7 +145,6 @@ def test_get_deps_only_targets_reverse_is_build_order():
 
 
 def test_get_deps_only_targets_marks_should_rebuild():
-    """With config.build=True, all target deps get should_rebuild=True"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True)
     get_deps_only_targets(root, 'A', config)
@@ -176,7 +155,6 @@ def test_get_deps_only_targets_marks_should_rebuild():
 
 
 def test_get_deps_only_targets_cleans_on_rebuild():
-    """With config.clean=True, deps get cleaned and build dir recreated"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True, clean=True)
     get_deps_only_targets(root, 'A', config)
@@ -189,7 +167,6 @@ def test_get_deps_only_targets_cleans_on_rebuild():
 
 
 def test_get_deps_only_targets_no_clean_on_build():
-    """With config.build=True but clean=False, deps are NOT cleaned"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True, clean=False)
     get_deps_only_targets(root, 'A', config)
@@ -198,7 +175,6 @@ def test_get_deps_only_targets_no_clean_on_build():
 
 
 def test_get_deps_only_targets_B_only_gets_D():
-    """deps_only targeting B should only include D"""
     root, A, B, C, D = make_tree()
     config = make_config(build=True)
     flat_deps, flat_deps_reverse = get_deps_only_targets(root, 'B', config)
@@ -245,7 +221,7 @@ def test_unified_deps_only_builds_every_dep_but_not_the_root(unified):
 
 
 def test_unified_deps_only_target_builds_only_that_targets_deps(unified):
-    # root -> {A -> {C -> {E}}, B -> {D}}; deps_only A must build C and E, not A, B, D or root
+    # root -> {A -> {C -> {E}}, B -> {D}}. deps_only A must build C and E, not A, B, D or root.
     ev, _, _root = unified([('A', [('C', [('E', ())])]), ('B', [('D', ())])], target_name='A')
     assert _named(ev, 'load') == {'root', 'A', 'B', 'C', 'D', 'E'}
     assert _named(ev, 'bld') == {'C', 'E'}

--- a/tests/test_download_cache/test_download_cache.py
+++ b/tests/test_download_cache/test_download_cache.py
@@ -94,15 +94,12 @@ class TestTargetPrefix:
         # parallel run's status lines have no way to indicate which target
         # they belong to.
         assert 'libfoo' in out
-        # And the existing bar format is preserved.
-        assert '|' in out and '%' in out
+        assert '|' in out and '%' in out  # the bar format itself is unchanged
 
     def test_no_name_keeps_unprefixed_format(self, tmp_path, capsys):
         local_dir = str(tmp_path)
         (tmp_path / 'a.zip').write_bytes(b'x')
         download_file('http://x/a.zip', local_dir, force=False)
         out = capsys.readouterr().out
-        # When no name is given, the line uses plain 4-space indent (no '- ').
         assert 'Using locally cached' in out
-        # Must not produce a "- " bullet prefix when there's no target context.
-        assert '  - ' not in out
+        assert '  - ' not in out  # no target context -> plain 4-space indent, no '- ' bullet

--- a/tests/test_download_cache/test_download_cache.py
+++ b/tests/test_download_cache/test_download_cache.py
@@ -90,9 +90,7 @@ class TestTargetPrefix:
         with patch('mama.util.request.urlopen', return_value=opened):
             download_file('http://x/a.zip', local_dir, force=True, name='libfoo')
         out = capsys.readouterr().out
-        # The redrawn progress line must carry the target name, otherwise a
-        # parallel run's status lines have no way to indicate which target
-        # they belong to.
+        # The redrawn progress line must carry the target name, or a parallel run's status lines name no target.
         assert 'libfoo' in out
         assert '|' in out and '%' in out  # the bar format itself is unchanged
 

--- a/tests/test_git_local_mods/test_git_local_mods.py
+++ b/tests/test_git_local_mods/test_git_local_mods.py
@@ -1,5 +1,5 @@
-"""Pins the update guard: a dirty working tree fails `mama update` loudly (marked `x`) even when
-upstream is unchanged, instead of a swallowed pull error leaving the dep silently un-updated."""
+"""Pins the update guard: a dirty working tree fails `mama update` with a clear error (marked `x`)
+even when upstream is unchanged. A swallowed pull error left the dep silently un-updated."""
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_git_pin_change/mamafile.py
+++ b/tests/test_git_pin_change/mamafile.py
@@ -8,12 +8,11 @@ class test(mama.BuildTarget):
         self.nothing_to_build()
 
     def dependencies(self):
-        stage = os.environ.get('GIT_PIN_CHANGE_TEST') # Uses env variable to dynamically change the pinned commit
+        stage = os.environ.get('GIT_PIN_CHANGE_TEST') # the env variable selects the pin per stage
 
         remote_name = 'ExampleRemote'
         remote_url = 'https://github.com/BatteredBunny/MamaExampleRemote.git'
 
-        # Switches between having REMOTE_VERSION and not to demonstrate that the contents actually change
         if stage == '0':
             self.add_git(remote_name, remote_url, git_commit='4acd9052f27a459314651dd485ae8fa79a04d49d') # has no REMOTE_VERSION
         elif stage == '1':

--- a/tests/test_git_pin_change/test_git_pin_change.py
+++ b/tests/test_git_pin_change/test_git_pin_change.py
@@ -12,7 +12,6 @@ def stage(num: int, expects: bool, assert_message: str = ""):
     else:
         assert not result, assert_message
 
-# Test that switches between having REMOTE_VERSION and not to demonstrate that the contents actually change when changing git_tag pins
 def test_git_pin_change(tmp_path):
     init(__file__, tmp_path)
 

--- a/tests/test_git_pin_change/test_local_work_protection.py
+++ b/tests/test_git_pin_change/test_local_work_protection.py
@@ -9,59 +9,51 @@ OLD_SHORT  = OLD_COMMIT[:7]
 def get_git_status_path():
     return f'packages/ExampleRemote/{native_platform_name()}/git_status'
 
-# Test that mama update does not overwrite local modifications
-# and instead shows an error suggesting mama wipe
 def test_local_work_protection(tmp_path):
     init(__file__, tmp_path)
 
-    # Clone with branch pin (stage 5 = branch 'master')
+    # stage 5 = branch 'master'
     os.environ['GIT_PIN_CHANGE_TEST'] = '5'
     mama_exec(['update'])
 
     src_file = 'packages/ExampleRemote/ExampleRemote/remote.cpp'
     assert os.path.isfile(src_file), "Source file should exist after clone"
 
-    # Simulate local work by modifying a tracked file
     with open(src_file, 'a') as f:
         f.write('\n// local modification by developer\n')
 
-    # Fake a stale commit in git_status so mama thinks there's an upstream change
+    # Fake a stale commit in git_status so mama sees an upstream change.
     status_file = get_git_status_path()
     with open(status_file, 'w') as f:
         f.write(Git.format_git_status(REPO_URL, '', 'master', OLD_SHORT))
 
-    # mama update should refuse to overwrite local work
     result = mama_exec(['update'], exit_on_fail=False)
     assert result != 0, "mama update should fail when local modifications exist"
 
-    # Verify local work was NOT overwritten
     with open(src_file, 'r') as f:
         current_content = f.read()
     assert '// local modification by developer' in current_content, \
         "Local modifications should be preserved after failed update"
 
 
-# Test that mama update does not overwrite local modifications even when switching pin types
 def test_local_work_protection_on_pin_change(tmp_path):
     init(__file__, tmp_path)
 
-    # Clone with tag pin (stage 2 = tag v1.0.0)
+    # stage 2 = tag v1.0.0
     os.environ['GIT_PIN_CHANGE_TEST'] = '2'
     mama_exec(['update'])
 
     src_file = 'packages/ExampleRemote/ExampleRemote/remote.cpp'
     assert os.path.isfile(src_file), "Source file should exist after clone"
 
-    # Simulate local work by modifying a tracked file
     with open(src_file, 'a') as f:
         f.write('\n// local work in progress\n')
 
-    # Switch pin type from tag to branch (stage 4 = branch 'old')
+    # Switch the pin type from tag to branch (stage 4 = branch 'old').
     os.environ['GIT_PIN_CHANGE_TEST'] = '4'
     result = mama_exec(['update'], exit_on_fail=False)
     assert result != 0, "mama update should fail when local modifications exist during pin change"
 
-    # Verify local work was NOT overwritten
     with open(src_file, 'r') as f:
         current_content = f.read()
     assert '// local work in progress' in current_content, \

--- a/tests/test_git_pinning/test_git_pinning.py
+++ b/tests/test_git_pinning/test_git_pinning.py
@@ -3,12 +3,11 @@ from testutils import init, mama_exec, file_contains
 def remote_file_contains(dep_name, text):
     return file_contains(f'packages/{dep_name}/{dep_name}/remote.h', text)
 
-# Make sure different git pinning methods work
 def test_git_pinning(tmp_path):
     init(__file__, tmp_path)
-    mama_exec(['update'])   # clone the pinned deps; `clean` deliberately fetches nothing
+    mama_exec(['update'])   # clone the pinned deps
 
-    # https://github.com/BatteredBunny/MamaExampleRemote repo has different commits that either do or dont have the REMOTE_VERSION line
+    # The MamaExampleRemote commits differ: some hold the REMOTE_VERSION line and some do not.
     assert not remote_file_contains('ExampleRemote', 'REMOTE_VERSION'), "Tag pinning went wrong"
     assert remote_file_contains('ExampleRemote2', 'REMOTE_VERSION 2'), "Tag pinning went wrong"
     assert not remote_file_contains('ExampleRemote3', 'REMOTE_VERSION'), "Commit pinning went wrong"

--- a/tests/test_git_repo_heal/test_git_repo_heal.py
+++ b/tests/test_git_repo_heal/test_git_repo_heal.py
@@ -36,7 +36,7 @@ def test_has_source_content_ignores_what_mama_generated(tmp_path):
     d.mkdir()
     assert not has_source_content(str(d))
     (d / 'mama.cmake').write_text('')
-    assert not has_source_content(str(d))             # the exact shape of the reported broken ffmpeg dir
+    assert not has_source_content(str(d))             # mama's own proxy file is not source
     (d / '.git').mkdir()
     assert not has_source_content(str(d))             # a half-finished clone has no working tree to lose
     (d / 'ffmpeg.c').write_text('')
@@ -44,8 +44,7 @@ def test_has_source_content_ignores_what_mama_generated(tmp_path):
 
 
 def test_has_source_content_sees_source_hidden_in_subdirs(tmp_path):
-    # is_dir_empty only names the subdirs that prove a checkout. An rsync'd tree of project-specific
-    # dirs still reads as 'empty' to it, so the wipe guard must not inherit that gap.
+    # is_dir_empty only names the subdirs that prove a checkout, so the wipe guard must not inherit that gap.
     d = tmp_path / 'dep'
     (d / 'libavcodec').mkdir(parents=True)
     assert is_dir_empty(str(d)) and has_source_content(str(d))
@@ -68,7 +67,7 @@ def test_a_dir_with_nothing_in_it_is_still_empty(tmp_path):
 
 
 def test_a_dir_holding_only_mama_generated_files_heals(tmp_path):
-    # the reported case: ffmpeg/ held nothing but the mama.cmake proxy mama wrote there itself
+    # a dep dir can hold nothing but the mama.cmake proxy mama wrote there itself
     dep = make_mock_dep(tmp_path)
     _seed(dep, 'mama.cmake')
     assert _checkout(dep) == (True, True, True)
@@ -81,8 +80,7 @@ def test_a_broken_git_with_nothing_checked_out_heals(tmp_path):
 
 
 def test_an_rsynced_sandbox_copy_without_git_is_never_clobbered(tmp_path):
-    # Sandbox builds rsync a dep's source (often excluding .git) and may edit it. A re-clone over
-    # that destroys the sandbox the local development depends on.
+    # Sandbox builds rsync a dep's source without .git and may edit it. A re-clone over that destroys the sandbox.
     dep = make_mock_dep(tmp_path)
     _seed(dep, 'mama.cmake', 'ffmpeg.c')
     assert _checkout(dep) == (False, False, False)
@@ -122,8 +120,7 @@ def _wipe_call(dep, broken=False):
 
 
 def test_an_automatic_heal_wipes_only_the_source(tmp_path):
-    # Every platform shares dep_dir: a tree broken for THIS one must not delete a sibling's
-    # artifactory package/shim/build output - a concurrent `mama <host> build` may be reading it.
+    # Every platform shares dep_dir: a concurrent `mama <host> build` may be reading a sibling's package/shim/build output.
     dep = make_mock_dep(tmp_path)
     _seed(dep, '.git')
     assert _wipe_call(dep, broken=True).kwargs == {'source_only': True}

--- a/tests/test_git_repo_heal/test_git_repo_heal.py
+++ b/tests/test_git_repo_heal/test_git_repo_heal.py
@@ -7,7 +7,7 @@ from mama.util import has_source_content, is_dir_empty
 
 
 def _seed(dep, *names):
-    """Materialise src_dir with the given entries; '.git' is created as a directory."""
+    """Materialize src_dir with the given entries. '.git' becomes a directory."""
     os.makedirs(dep.src_dir, exist_ok=True)
     for n in names:
         if n == '.git': os.makedirs(f'{dep.src_dir}/.git', exist_ok=True)
@@ -16,7 +16,7 @@ def _seed(dep, *names):
 
 @contextlib.contextmanager
 def _stubbed(dep, broken):
-    """dependency_checkout with the git side stubbed; yields the (wipe, clone) mocks."""
+    """dependency_checkout with the git side stubbed. Yields the (wipe, clone) mocks."""
     git = dep.dep_source
     with patch.object(git, '_is_repo_broken', return_value=broken), patch.object(git, '_sync_remote_url'), \
          patch.object(git, 'reclone_wipe') as wipe, patch.object(git, 'clone_or_pull') as clone:
@@ -32,7 +32,7 @@ def _checkout(dep, broken=False):
 
 def test_has_source_content_ignores_what_mama_generated(tmp_path):
     d = tmp_path / 'dep'
-    assert not has_source_content(str(d))             # doesn't exist
+    assert not has_source_content(str(d))             # does not exist
     d.mkdir()
     assert not has_source_content(str(d))
     (d / 'mama.cmake').write_text('')
@@ -44,8 +44,8 @@ def test_has_source_content_ignores_what_mama_generated(tmp_path):
 
 
 def test_has_source_content_sees_source_hidden_in_subdirs(tmp_path):
-    # is_dir_empty only names the subdirs that prove a checkout; an rsync'd tree of project-specific
-    # dirs still reads as 'empty' to it, so the wipe guard must not inherit that blind spot
+    # is_dir_empty only names the subdirs that prove a checkout. An rsync'd tree of project-specific
+    # dirs still reads as 'empty' to it, so the wipe guard must not inherit that gap.
     d = tmp_path / 'dep'
     (d / 'libavcodec').mkdir(parents=True)
     assert is_dir_empty(str(d)) and has_source_content(str(d))
@@ -81,8 +81,8 @@ def test_a_broken_git_with_nothing_checked_out_heals(tmp_path):
 
 
 def test_an_rsynced_sandbox_copy_without_git_is_never_clobbered(tmp_path):
-    # sandbox builds rsync a dep's source (often excluding .git) and may edit it; re-cloning over
-    # that destroys the sandbox, which is the whole point of modular local development
+    # Sandbox builds rsync a dep's source (often excluding .git) and may edit it. A re-clone over
+    # that destroys the sandbox the local development depends on.
     dep = make_mock_dep(tmp_path)
     _seed(dep, 'mama.cmake', 'ffmpeg.c')
     assert _checkout(dep) == (False, False, False)
@@ -103,7 +103,7 @@ def test_wiping_the_target_still_forces_the_reclone(tmp_path):
 
 
 def test_wiping_a_different_target_does_not_clobber_this_one(tmp_path):
-    dep = make_mock_dep(tmp_path, reclone=True)  # `mama wipe other` must not take out a sandboxed dep
+    dep = make_mock_dep(tmp_path, reclone=True)  # `mama wipe other` must not delete a sandboxed dep
     _seed(dep, 'ffmpeg.c')
     assert _checkout(dep) == (False, False, False)
 
@@ -115,15 +115,15 @@ def test_checkout_leaves_a_healthy_clone_alone(tmp_path):
 
 
 def _wipe_call(dep, broken=False):
-    """The reclone_wipe(...) call dependency_checkout makes; None if it never wiped."""
+    """The reclone_wipe(...) call dependency_checkout makes. None if it never wiped."""
     with _stubbed(dep, broken) as (wipe, _):
         dep.dep_source.dependency_checkout(dep)
     return wipe.call_args
 
 
 def test_an_automatic_heal_wipes_only_the_source(tmp_path):
-    # dep_dir is shared by every platform: a tree broken for THIS one must not delete a sibling's
-    # artifactory package/shim/build output - a concurrent `mama <host> build` may be reading it
+    # Every platform shares dep_dir: a tree broken for THIS one must not delete a sibling's
+    # artifactory package/shim/build output - a concurrent `mama <host> build` may be reading it.
     dep = make_mock_dep(tmp_path)
     _seed(dep, '.git')
     assert _wipe_call(dep, broken=True).kwargs == {'source_only': True}

--- a/tests/test_git_retry/test_git_retry.py
+++ b/tests/test_git_retry/test_git_retry.py
@@ -11,7 +11,7 @@ from testutils import make_git_and_mock_dep as _git_and_dep
 
 @pytest.fixture(autouse=True)
 def unpaced(monkeypatch):
-    """The pacer is process-global state and sleeps for real; keep it off unless a test asks for it."""
+    """The pacer is process-global state and sleeps for real. Keep it off unless a test asks for it."""
     monkeypatch.setattr(sm, '_connect_interval', 0.0)
     monkeypatch.setattr(sm, '_last_connect', 0.0)
     monkeypatch.setattr('mama.types.git.time.sleep', lambda s: None)
@@ -61,7 +61,7 @@ def test_the_partial_tree_is_removed_before_a_retry(monkeypatch):
     attempts = iter([(128, 'Connection reset by peer'), (0, '')])
     monkeypatch.setattr(Git, '_run_git_with_filtered_progress', lambda *a, **k: (*next(attempts), '1.0s'))
     git.clone_with_filtered_progress(dep, '--depth 1 url', '/tmp/target')
-    assert removed == ['/tmp/target']  # a second clone into a non-empty dir fails on the dir, hiding the real error
+    assert removed == ['/tmp/target']  # a second clone into a non-empty dir fails on the dir and hides the real error
 
 
 def test_a_retry_turns_the_connection_pacer_on(monkeypatch):

--- a/tests/test_git_url_override/test_git_url_override.py
+++ b/tests/test_git_url_override/test_git_url_override.py
@@ -92,7 +92,7 @@ def test_is_progress_line_matches_git_and_download_bars():
 
 
 def test_run_git_collapses_progress_flood_but_keeps_real_lines(tmp_path):
-    # The regression: run_git printed every per-percent progress line raw. Now it collapses them.
+    # run_git must collapse the per-percent progress lines instead of printing every one raw
     dep = make_mock_dep(tmp_path, print=True)
     flood = [f'Receiving objects: {p}% ({p}/100)' for p in range(101)]
     real = ['From https://github.com/RedFox20/ReCpp', ' * [new branch] main -> origin/main']

--- a/tests/test_git_url_override/test_git_url_override.py
+++ b/tests/test_git_url_override/test_git_url_override.py
@@ -92,7 +92,7 @@ def test_is_progress_line_matches_git_and_download_bars():
 
 
 def test_run_git_collapses_progress_flood_but_keeps_real_lines(tmp_path):
-    # The regression: run_git printed every per-percent progress line raw; now it collapses them.
+    # The regression: run_git printed every per-percent progress line raw. Now it collapses them.
     dep = make_mock_dep(tmp_path, print=True)
     flood = [f'Receiving objects: {p}% ({p}/100)' for p in range(101)]
     real = ['From https://github.com/RedFox20/ReCpp', ' * [new branch] main -> origin/main']

--- a/tests/test_hierarchical_libs/test_hierarchical_libs.py
+++ b/tests/test_hierarchical_libs/test_hierarchical_libs.py
@@ -83,9 +83,9 @@ _CC = shutil.which('cc') or shutil.which('gcc')
 _needs_toolchain = pytest.mark.skipif(not (_CC and shutil.which('ar')),
                                       reason='needs a C toolchain (cc/gcc + ar) to build real archives')
 
-# z_func and z_shared MUST be separate translation units: an archive member is pulled only when it
-# resolves a currently-undefined symbol, and that granularity is the whole point of the ordering rule.
-# Both splits return 0 from main(), so a successful link is also semantically verifiable by running it.
+# z_func and z_shared MUST be separate translation units: ld pulls an archive member only when it
+# resolves a currently-undefined symbol. That granularity is what the ordering rule exists for.
+# Both splits return 0 from main(), so running the linked app also verifies the resolved symbols.
 _SYMBOL_SPLITS = [('z_shared', 'z_func'),   # main pulls z_shared, lib1 pulls z_func
                   ('z_func', 'z_shared')]   # crossed: swapping WHICH symbol each consumer uses
 
@@ -130,7 +130,7 @@ def test_real_link_fails_with_the_naive_first_seen_order(tmp_path, main_calls, l
     assert r.returncode != 0
     # ld had already passed libz.a when lib1 introduced its need, so the unresolved symbol is always
     # whatever LIB1 wanted - main's own need was satisfied by that early scan. Which symbol that is
-    # doesn't change the outcome: the rule is about dependency direction, not symbol distribution.
+    # does not change the outcome: the rule is about dependency direction, not symbol distribution.
     assert lib1_calls in r.stderr
 
 

--- a/tests/test_hierarchical_libs/test_hierarchical_libs.py
+++ b/tests/test_hierarchical_libs/test_hierarchical_libs.py
@@ -24,8 +24,7 @@ def test_diamond_dependency_contributes_its_libs_once():
 
 
 def test_shared_leaf_is_not_repeated_once_per_path():
-    # a dep reachable through many parents: a raw per-path DFS emitted it once
-    # per path - 85 copies on one real link line.
+    # a dep reachable through many parents: a raw per-path DFS emits one copy per path on the link line
     leaf = _dep('ReCpp', libs=['libReCpp.a'])
     mids = [_dep(f'M{i}', libs=[f'libM{i}.a'], children=[leaf]) for i in range(5)]
     root = _dep('root', libs=['libroot.a'], children=mids)
@@ -57,9 +56,7 @@ def test_non_library_exports_are_still_filtered_out():
 
 
 def test_dep_shared_by_exe_and_a_lib_lands_after_both():
-    # The classic Unix trap: exe -> {libz, lib1} and lib1 -> libz. Emitting libz where it was FIRST
-    # seen gives 'libz lib1'; ld then drops libz members lib1 needs -> undefined references. Keep-last
-    # ordering emits 'lib1 libz', resolving exe's AND lib1's libz symbols with ONE copy of libz.
+    # The Unix trap: exe -> {libz, lib1} and lib1 -> libz. First-seen order 'libz lib1' makes ld drop libz members lib1 needs.
     libz = _dep('libz', libs=['libz.a'])
     lib1 = _dep('lib1', libs=['lib1.a'], children=[libz])
     exe = _dep('exe', libs=['exe.a'], children=[libz, lib1])   # libz declared FIRST: the risky order
@@ -74,8 +71,7 @@ def test_link_order_is_independent_of_declaration_order():
 
 
 # -- real-toolchain validation ------------------------------------------------
-# The unit tests above assert an ORDER; these prove that order is the one GNU ld actually needs, by
-# building real static archives and linking them.
+# The unit tests above assert an ORDER. These build and link real static archives to prove GNU ld needs that order.
 import shutil, subprocess  # noqa: E402
 import pytest  # noqa: E402
 
@@ -83,9 +79,7 @@ _CC = shutil.which('cc') or shutil.which('gcc')
 _needs_toolchain = pytest.mark.skipif(not (_CC and shutil.which('ar')),
                                       reason='needs a C toolchain (cc/gcc + ar) to build real archives')
 
-# z_func and z_shared MUST be separate translation units: ld pulls an archive member only when it
-# resolves a currently-undefined symbol. That granularity is what the ordering rule exists for.
-# Both splits return 0 from main(), so running the linked app also verifies the resolved symbols.
+# Separate TUs on purpose: ld pulls an archive member only to resolve an undefined symbol. main() returns 0 on the right defs.
 _SYMBOL_SPLITS = [('z_shared', 'z_func'),   # main pulls z_shared, lib1 pulls z_func
                   ('z_func', 'z_shared')]   # crossed: swapping WHICH symbol each consumer uses
 
@@ -128,9 +122,7 @@ def test_real_link_fails_with_the_naive_first_seen_order(tmp_path, main_calls, l
     _build_archives(tmp_path, main_calls, lib1_calls)
     r = _link(tmp_path, ['libz.a', 'lib1.a'])   # libz emitted where it was FIRST seen
     assert r.returncode != 0
-    # ld had already passed libz.a when lib1 introduced its need, so the unresolved symbol is always
-    # whatever LIB1 wanted - main's own need was satisfied by that early scan. Which symbol that is
-    # does not change the outcome: the rule is about dependency direction, not symbol distribution.
+    # ld had already passed libz.a when lib1 introduced its need, so the unresolved symbol is always the one lib1 wanted
     assert lib1_calls in r.stderr
 
 

--- a/tests/test_host_binary/test_host_binary.py
+++ b/tests/test_host_binary/test_host_binary.py
@@ -1,4 +1,4 @@
-"""Pins build_host_binary: obtain a HOST-built tool (e.g. protoc) while cross-compiling by cheap-checking the
+"""Pins build_host_binary: get a HOST-built tool (e.g. protoc) while cross-compiling by cheap-checking the
 host build dir, then bootstrapping via a `mama <host> build` child on a miss - plus host_platform_name/host_build_dir."""
 import os, sys, pytest
 from unittest.mock import patch
@@ -27,7 +27,7 @@ def _touch(path):
     return path
 
 
-# ── host_platform_name ───────────────────────────────────────────────────────
+# -- host_platform_name -------------------------------------------------------
 
 @pytest.mark.parametrize('windows,macos,expected', [
     (True, False, 'windows'), (False, True, 'macos'), (False, False, 'linux'),
@@ -38,7 +38,7 @@ def test_host_platform_name_follows_the_host_os(windows, macos, expected):
         assert cfg.host_platform_name() == expected
 
 
-# ── host_build_dir ───────────────────────────────────────────────────────────
+# -- host_build_dir -----------------------------------------------------------
 
 def test_host_build_dir_is_a_sibling_named_after_the_host(tmp_path):
     t, dep = _cross_target(tmp_path)  # build_dir=.../libfoo/android, host=linux
@@ -46,7 +46,7 @@ def test_host_build_dir_is_a_sibling_named_after_the_host(tmp_path):
     assert t.host_build_dir('bin/protoc').endswith('/libfoo/linux/bin/protoc')
 
 
-# ── build_host_binary ────────────────────────────────────────────────────────
+# -- build_host_binary --------------------------------------------------------
 
 def test_native_build_returns_the_local_binary_without_a_child(tmp_path):
     t, dep = make_configured_target(tmp_path)  # build_dir ends in 'linux'

--- a/tests/test_includes_root/test_includes_root.py
+++ b/tests/test_includes_root/test_includes_root.py
@@ -1,17 +1,5 @@
-"""
-Tests for the `as_includes_root` feature of export_include.
-
-When `export_include('src/mylib', as_includes_root=True)` is called:
-  1. The parent dir ('src/') becomes the exported include path
-  2. target.includes_root is set to (parent_path, src_path, alias_name)
-  3. CMake deps file references the parent path
-  4. Papa deploy copies src/mylib/ -> deploy/include/mylib/
-  5. papa.txt contains 'I include' (not 'I include/src')
-
-When a string alias is used, e.g. `export_include('src', as_includes_root='mylib')`:
-  - src/*.h -> deploy/include/mylib/*.h
-  - Consumers use: #include <mylib/mylib.h>
-"""
+"""Pins export_include(as_includes_root=...): the exported include path, the includes_root tuple,
+the cmake defines, and the papa deploy layout that lets a consumer write #include <mylib/mylib.h>."""
 import os
 import tempfile
 import shutil
@@ -24,12 +12,7 @@ from mama.dependency_chain import _get_dependency_cmake_defines
 from mama.platforms.linux import Linux
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 def make_mock_target(source_dir, build_dir=None):
-    """Create a mock BuildTarget rooted at source_dir."""
     target = Mock()
     target.source_dir.return_value = normalized_path(source_dir)
     target.build_dir.return_value = normalized_path(build_dir or os.path.join(source_dir, 'build'))
@@ -45,7 +28,6 @@ def make_mock_target(source_dir, build_dir=None):
 
 
 def make_mock_dep(target, name='TestLib', children=None):
-    """Create a mock BuildDependency wrapping a target."""
     dep = Mock()
     dep.name = name
     dep.target = target
@@ -55,18 +37,10 @@ def make_mock_dep(target, name='TestLib', children=None):
 
 
 def make_temp_lib_tree():
-    """
-    Create a temp directory tree:
-        tmpdir/
-          src/
-            mylib/
-              mylib.h
-              internal.h
-    """
+    """tmpdir/src/mylib/ with mylib.h and internal.h."""
     tmpdir = tempfile.mkdtemp(prefix='mama_test_')
     mylib = os.path.join(tmpdir, 'src', 'mylib')
     os.makedirs(mylib)
-    # create header files
     with open(os.path.join(mylib, 'mylib.h'), 'w') as f:
         f.write('#pragma once\nint mylib_func();\n')
     with open(os.path.join(mylib, 'internal.h'), 'w') as f:
@@ -75,13 +49,7 @@ def make_temp_lib_tree():
 
 
 def make_temp_flat_lib_tree():
-    """
-    Create a temp directory tree with headers directly in src/:
-        tmpdir/
-          src/
-            mylib.h
-            internal.h
-    """
+    """tmpdir/src/ with mylib.h and internal.h directly inside, no subfolder."""
     tmpdir = tempfile.mkdtemp(prefix='mama_test_')
     src = os.path.join(tmpdir, 'src')
     os.makedirs(src)
@@ -92,12 +60,10 @@ def make_temp_flat_lib_tree():
     return tmpdir
 
 
-# ===========================================================================
-# 1. export_include with as_includes_root sets correct state
-# ===========================================================================
+# -- export_include state --
 
 def test_export_include_sets_includes_root():
-    """includes_root tuple should be (parent_path, src_path, alias_name)."""
+    # includes_root is (parent_path, src_path, alias_name)
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -113,7 +79,6 @@ def test_export_include_sets_includes_root():
 
 
 def test_export_include_adds_parent_to_exported_includes():
-    """exported_includes should contain the parent dir, not the subfolder."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -128,7 +93,6 @@ def test_export_include_adds_parent_to_exported_includes():
 
 
 def test_export_include_without_includes_root():
-    """Without as_includes_root, the path itself is added and includes_root stays empty."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -143,7 +107,6 @@ def test_export_include_without_includes_root():
 
 
 def test_export_include_nonexistent_path_returns_false():
-    """export_include should return False for paths that don't exist."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -157,7 +120,6 @@ def test_export_include_nonexistent_path_returns_false():
 
 
 def test_export_include_no_duplicate_includes():
-    """Calling export_include twice with same path should not duplicate."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -170,12 +132,10 @@ def test_export_include_no_duplicate_includes():
         shutil.rmtree(tmpdir)
 
 
-# ===========================================================================
-# 1b. export_include with as_includes_root string alias
-# ===========================================================================
+# -- string alias --
 
 def test_export_include_string_alias_sets_includes_root():
-    """as_includes_root='mylib' should set alias_name to 'mylib', not basename of path."""
+    # as_includes_root='mylib' sets the alias to 'mylib', not to the basename of the path
     tmpdir = make_temp_flat_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -191,7 +151,6 @@ def test_export_include_string_alias_sets_includes_root():
 
 
 def test_export_include_string_alias_exports_parent():
-    """With string alias, exported_includes should contain parent of src/."""
     tmpdir = make_temp_flat_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -205,7 +164,6 @@ def test_export_include_string_alias_exports_parent():
 
 
 def test_export_include_bool_true_uses_basename_as_alias():
-    """as_includes_root=True should derive alias_name from basename of include_path."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -214,18 +172,14 @@ def test_export_include_bool_true_uses_basename_as_alias():
 
         src_dir = normalized_path(os.path.join(tmpdir, 'src'))
         mylib_dir = normalized_path(os.path.join(tmpdir, 'src', 'mylib'))
-        # bool True derives alias from basename: 'mylib'
         assert target.includes_root == (src_dir, mylib_dir, 'mylib')
     finally:
         shutil.rmtree(tmpdir)
 
 
-# ===========================================================================
-# 2. CMake dependency generation uses the parent include path
-# ===========================================================================
+# -- cmake defines --
 
 def test_cmake_defines_uses_parent_include_path():
-    """The cmake defines should reference the parent (src/) not src/mylib/."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -237,9 +191,7 @@ def test_cmake_defines_uses_parent_include_path():
 
         src_dir = normalized_path(os.path.join(tmpdir, 'src'))
         assert includes_var == '${TestLib_INCLUDES}'
-        # the cmake set() should contain the parent path
         assert src_dir in cmake_text
-        # and should NOT contain the mylib subfolder path directly in includes
         mylib_dir = normalized_path(os.path.join(tmpdir, 'src', 'mylib'))
         assert f'"{mylib_dir}"' not in cmake_text
     finally:
@@ -247,7 +199,6 @@ def test_cmake_defines_uses_parent_include_path():
 
 
 def test_cmake_defines_without_includes_root():
-    """Without as_includes_root, cmake should reference the exact subfolder."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -263,19 +214,15 @@ def test_cmake_defines_without_includes_root():
         shutil.rmtree(tmpdir)
 
 
-# ===========================================================================
-# 3. Papa deploy: _append_includes copies to correct location
-# ===========================================================================
+# -- papa deploy: _append_includes --
 
 def test_append_includes_deploys_to_include_foldername():
-    """With includes_root, headers from src/mylib/ should be copied to deploy/include/mylib/."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
         package.export_include(target, 'src/mylib', build_dir=False,
                                as_includes_root=True)
 
-        # set up config for _append_includes
         target.config.verbose = False
         target.config.print = False
 
@@ -288,13 +235,12 @@ def test_append_includes_deploys_to_include_foldername():
 
         _append_includes(target, deploy_dir, False, descr, includes)
 
-        # Check that headers were copied to deploy/TestLib/include/mylib/
         deployed_mylib_h = os.path.join(deploy_dir, 'include', 'mylib', 'mylib.h')
         deployed_internal_h = os.path.join(deploy_dir, 'include', 'mylib', 'internal.h')
         assert os.path.isfile(deployed_mylib_h), f'Expected {deployed_mylib_h} to exist'
         assert os.path.isfile(deployed_internal_h), f'Expected {deployed_internal_h} to exist'
 
-        # Check that 'I include' is in descr (not 'I include/src' or 'I include/mylib')
+        # the record is 'I include', not 'I include/src' or 'I include/mylib'
         assert 'I include' in descr
         assert not any('I include/' in d for d in descr), \
             f'Expected no I include/<subpath> entries, got {descr}'
@@ -303,11 +249,9 @@ def test_append_includes_deploys_to_include_foldername():
 
 
 def test_append_includes_without_includes_root_uses_subpath():
-    """Without includes_root, includes from 'mylib/' get deployed as include/mylib/."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
-        # export without as_includes_root
         package.export_include(target, 'src/mylib', build_dir=False,
                                as_includes_root=False)
 
@@ -323,14 +267,12 @@ def test_append_includes_without_includes_root_uses_subpath():
 
         _append_includes(target, deploy_dir, False, descr, includes)
 
-        # Without includes_root, it should use include/mylib in descr
         assert 'I include/mylib' in descr
     finally:
         shutil.rmtree(tmpdir)
 
 
 def test_append_includes_string_alias_remaps_dirname():
-    """With string alias, src/*.h should be copied to deploy/include/mylib/*.h."""
     tmpdir = make_temp_flat_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -349,13 +291,11 @@ def test_append_includes_string_alias_remaps_dirname():
 
         _append_includes(target, deploy_dir, False, descr, includes)
 
-        # Headers from src/ should be remapped to include/mylib/
         deployed_mylib_h = os.path.join(deploy_dir, 'include', 'mylib', 'mylib.h')
         deployed_internal_h = os.path.join(deploy_dir, 'include', 'mylib', 'internal.h')
         assert os.path.isfile(deployed_mylib_h), f'Expected {deployed_mylib_h} to exist'
         assert os.path.isfile(deployed_internal_h), f'Expected {deployed_internal_h} to exist'
 
-        # Should NOT have include/src/ directory
         assert not os.path.exists(os.path.join(deploy_dir, 'include', 'src')), \
             'Should NOT have include/src/ directory'
 
@@ -366,12 +306,9 @@ def test_append_includes_string_alias_remaps_dirname():
         shutil.rmtree(tmpdir)
 
 
-# ===========================================================================
-# 4. Full papa deploy writes correct papa.txt
-# ===========================================================================
+# -- full papa deploy --
 
 def test_papa_deploy_writes_correct_papa_txt():
-    """Full papa_deploy_to should produce papa.txt with 'I include' for includes_root."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -398,15 +335,12 @@ def test_papa_deploy_writes_correct_papa_txt():
             content = f.read()
         lines = content.strip().split('\n')
 
-        # First line is project name
         assert lines[0] == 'P TestLib'
 
-        # Should have 'I include' line
         include_lines = [l for l in lines if l.startswith('I ')]
         assert 'I include' in include_lines, \
             f'Expected "I include" in papa.txt, got: {include_lines}'
 
-        # Should NOT have 'I include/src' or similar subpath entries
         assert not any('I include/' in l for l in include_lines), \
             f'Expected no I include/<subpath> entries, got: {include_lines}'
     finally:
@@ -414,7 +348,6 @@ def test_papa_deploy_writes_correct_papa_txt():
 
 
 def test_papa_txt_parsed_correctly_with_includes_root():
-    """PapaFileInfo should parse a papa.txt generated with includes_root."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -442,7 +375,6 @@ def test_papa_txt_parsed_correctly_with_includes_root():
         assert papa.includes[0].endswith('include'), \
             f'Expected include path ending with "include", got: {papa.includes[0]}'
 
-        # The resolved include path should point to deploy/TestLib/include
         expected_include = normalized_path(os.path.join(deploy_dir, 'include'))
         assert normalized_path(papa.includes[0]) == expected_include
     finally:
@@ -450,7 +382,6 @@ def test_papa_txt_parsed_correctly_with_includes_root():
 
 
 def test_deployed_headers_are_accessible_via_includes_root():
-    """After deploy, headers should exist at include/mylib/*.h (the clean include path)."""
     tmpdir = make_temp_lib_tree()
     try:
         target = make_mock_target(tmpdir)
@@ -470,7 +401,7 @@ def test_deployed_headers_are_accessible_via_includes_root():
                        r_includes=False, r_dylibs=False,
                        r_syslibs=False, r_assets=False)
 
-        # Verify the include structure matches what #include <mylib/mylib.h> expects
+        # the layout #include <mylib/mylib.h> expects
         include_dir = os.path.join(deploy_dir, 'include')
         assert os.path.isdir(os.path.join(include_dir, 'mylib')), \
             'Expected include/mylib/ directory'
@@ -479,7 +410,6 @@ def test_deployed_headers_are_accessible_via_includes_root():
         assert os.path.isfile(os.path.join(include_dir, 'mylib', 'internal.h')), \
             'Expected include/mylib/internal.h'
 
-        # Verify no stale src/ prefix directory
         assert not os.path.exists(os.path.join(include_dir, 'src')), \
             'Should NOT have include/src/ directory'
     finally:

--- a/tests/test_log_writer/test_log_writer.py
+++ b/tests/test_log_writer/test_log_writer.py
@@ -16,7 +16,7 @@ def test_drains_in_order_strips_ansi_and_closes():
     w = AsyncLogWriter(cap)
     w.write('\x1b[31mred error\x1b[0m\n'); w.write('plain\n')
     w.close()   # enqueues the sentinel, joins the drain thread, flushes+closes the stream
-    assert ''.join(cap.data) == 'red error\nplain\n'   # colours stripped, order preserved
+    assert ''.join(cap.data) == 'red error\nplain\n'   # colors stripped, order preserved
     assert cap.closed
 
 

--- a/tests/test_noart_shim_cache/test_noart_shim_cache.py
+++ b/tests/test_noart_shim_cache/test_noart_shim_cache.py
@@ -1,4 +1,4 @@
-"""noart must honour an existing shim cache (no fetch, but ls-remote staleness check)."""
+"""noart must honor an existing shim cache (no fetch, but ls-remote staleness check)."""
 from unittest.mock import Mock, patch
 
 from testutils import make_mock_dep, make_mock_shim_dep

--- a/tests/test_packaging_preconditions/test_packaging_preconditions.py
+++ b/tests/test_packaging_preconditions/test_packaging_preconditions.py
@@ -10,7 +10,7 @@ from mama.build_target import BuildTarget
 
 
 def _target(tmp_path, built=False, **dep_over):
-    """A BuildTarget whose package() records whether it ran; `built` fakes real build work."""
+    """A BuildTarget whose package() records whether it ran. `built` fakes real build work."""
     dep = make_mock_dep(tmp_path)
     dep.nothing_to_build = False
     dep.from_artifactory = False
@@ -52,7 +52,7 @@ def test_packaging_runs_for_a_header_only_target(tmp_path):
 
 
 def test_an_artifactory_package_is_not_repackaged(tmp_path):
-    # pre-existing behaviour the new guard must leave alone: a fetched package already has its
+    # pre-existing behavior the new guard must leave alone: a fetched package already has its
     # papa.txt exports, so package() is skipped unless a local rebuild was asked for
     target = _target(tmp_path, from_artifactory=True)
     target._run_packaging()

--- a/tests/test_packaging_preconditions/test_packaging_preconditions.py
+++ b/tests/test_packaging_preconditions/test_packaging_preconditions.py
@@ -23,8 +23,7 @@ def _target(tmp_path, built=False, **dep_over):
 
 
 def test_packaging_is_skipped_when_nothing_was_built_and_nothing_is_on_disk(tmp_path):
-    # `mama wipe all` deletes every build product, then walks the task chain without building; the
-    # user's package() then asserted on libs that no longer exist
+    # `mama wipe all` walks the task chain without building: package() would assert on libs that no longer exist
     target = _target(tmp_path)
     target._run_packaging()
     target.package.assert_not_called()
@@ -52,8 +51,7 @@ def test_packaging_runs_for_a_header_only_target(tmp_path):
 
 
 def test_an_artifactory_package_is_not_repackaged(tmp_path):
-    # pre-existing behavior the new guard must leave alone: a fetched package already has its
-    # papa.txt exports, so package() is skipped unless a local rebuild was asked for
+    # a fetched package already has its papa.txt exports, so package() is skipped unless the user asked for a local rebuild
     target = _target(tmp_path, from_artifactory=True)
     target._run_packaging()
     target.package.assert_not_called()
@@ -84,8 +82,7 @@ def _declared(dep, *names):
 
 
 def test_reloading_an_artifactory_package_does_not_re_add_its_children(tmp_path):
-    # first-time `mama clean all`: the shim probe adds papa.txt's deps, then the post-clean re-extract
-    # reports the same list - add_child's duplicate raise used to kill the whole run
+    # the shim probe adds papa.txt's deps, then the post-clean re-extract reports the same list: no duplicate raise
     dep = make_mock_dep(tmp_path)
     sources = _declared(dep, 'ReCpp', 'zlib')
     dep.add_children(sources)  # shim probe

--- a/tests/test_papa_deploy/test_papa_deploy.py
+++ b/tests/test_papa_deploy/test_papa_deploy.py
@@ -1,6 +1,7 @@
+"""Integration: pins that build + deploy produce the consumer executable and its papa.txt."""
 from testutils import init, mama_exec, file_exists, executable_extension, native_platform_name
 
-# Generic test to verify basic build and deploy functions work
+
 def test_papa_deploy(tmp_path):
     init(__file__, tmp_path)
 

--- a/tests/test_papa_parse/test_papa_parse.py
+++ b/tests/test_papa_parse/test_papa_parse.py
@@ -1,7 +1,8 @@
+"""Pins PapaFileInfo: parsing every record kind of papa.txt, including the optional compiler record."""
 from testutils import init
 from mama.papa_deploy import PapaFileInfo
 
-# Test papa file format parsing
+
 def test_papa_parse(tmp_path):
     init(__file__, tmp_path)
 

--- a/tests/test_papa_parse/test_papa_parse.py
+++ b/tests/test_papa_parse/test_papa_parse.py
@@ -37,7 +37,7 @@ def test_compiler_record_round_trips(tmp_path):
 
 
 def test_a_package_without_a_compiler_record_still_loads(tmp_path):
-    # pre-change packages have no C record: unknown must not read as mismatch
+    # older packages have no C record: unknown must not read as mismatch
     papa = tmp_path / 'papa.txt'
     papa.write_text('P Example\nI include\n')
     info = PapaFileInfo(str(papa))

--- a/tests/test_papa_upload/test_papa_upload.py
+++ b/tests/test_papa_upload/test_papa_upload.py
@@ -1,3 +1,5 @@
+"""Pins papa_upload_to: the archive keeps every declared path, and validate_archive rejects
+missing or unexpected content."""
 import os
 import zipfile
 from pathlib import Path

--- a/tests/test_raspi/test_raspi.py
+++ b/tests/test_raspi/test_raspi.py
@@ -20,7 +20,7 @@ def _raspi(arch='arm64', **over):
 # --- arch selection ---
 
 def test_raspi_defaults_to_arm64():
-    """Every Pi since the 3 is ARMv8; 32-bit is the legacy path, not the default."""
+    """Every Pi since the 3 is ARMv8. 32-bit is the legacy path, not the default."""
     config = BuildConfig(['raspi'])
     assert config.arch == 'arm64' and config.raspi
 
@@ -157,7 +157,7 @@ def test_install_raspi_apt_installs_the_cross_triple(arch, triple, build_cmd, mo
 
 @pytest.mark.linux_host
 def test_install_raspi_fails_loudly_when_apt_did_not_deliver(monkeypatch):
-    """apt can 'succeed' with an unknown package; without this the next build silently uses host gcc."""
+    """apt can 'succeed' with an unknown package. Without this the next build silently uses host gcc."""
     config = BuildConfig([])
     monkeypatch.setattr(config, 'get_distro_info', lambda: ('ubuntu', 24, 4))
     monkeypatch.setattr('mama.build_config.execute', lambda *a, **k: 0)
@@ -175,8 +175,8 @@ def test_install_raspi_rejects_an_unknown_arch():
 # --- a distro cross package has no sysroot dir ---
 
 def test_a_distro_cross_package_passes_no_sysroot(tmp_path):
-    """Debian's gcc-aarch64-linux-gnu has no <triple>/sysroot; passing one that isn't there makes every
-    compile fail on missing system headers."""
+    """Debian's gcc-aarch64-linux-gnu has no <triple>/sysroot. Passing one that is not there makes
+    every compile fail on missing system headers."""
     (tmp_path / 'bin').mkdir()
     raspi = _raspi('arm64')
     raspi.init_toolchain(str(tmp_path))

--- a/tests/test_sanitizer_naming/test_sanitizer_naming.py
+++ b/tests/test_sanitizer_naming/test_sanitizer_naming.py
@@ -32,24 +32,19 @@ class TestVariantSuffix:
         assert _suffix('thread,leak') == '-tsan-lsan'
 
     def test_the_sanitizer_order_is_preserved(self):
-        # The order the user passes them in is the order in the suffix, so a different ordering produces
-        # a different name. Nothing in the build cares, and a deterministic function of the input is
-        # easier to reproduce.
+        # The suffix keeps the order the user passed. Nothing in the build cares, and a
+        # deterministic function of the input is easier to reproduce.
         assert _suffix('undefined,address') == '-ubsan-asan'
 
     def test_unknown_sanitizer_passed_through_verbatim(self):
-        # If clang adds a new sanitizer we do not know about, we still produce a distinct name rather
-        # than silently colliding with another.
+        # a sanitizer clang adds later still gets a distinct name instead of a silent collision
         assert _suffix('cfi') == '-cfi'
         assert _suffix('address,cfi') == '-asan-cfi'
 
     def test_whitespace_tolerated(self):
-        # The CLI passes 'sanitize=address,undefined' as-is, but be defensive
-        # in case any callers pass through with whitespace.
         assert _suffix(' address , undefined ') == '-asan-ubsan'
 
     def test_empty_segments_skipped(self):
-        # Trailing comma or doubled comma must not yield an empty short name.
         assert _suffix('address,') == '-asan'
         assert _suffix('address,,thread') == '-asan-tsan'
 
@@ -69,8 +64,6 @@ class TestArchiveName:
         assert name == 'pkg-linux-24-gcc14-x64-release-asan-abc1234'
 
     def test_tsan_and_asan_produce_distinct_names(self):
-        # The whole point of this field: asan and tsan are incompatible
-        # runtimes, so their archives MUST have different names.
         asan_name = art.artifactory_archive_name(_make_target(sanitize='address'))
         tsan_name = art.artifactory_archive_name(_make_target(sanitize='thread'))
         assert asan_name != tsan_name
@@ -92,8 +85,6 @@ class TestArchiveName:
         assert name == 'pkg-linux-24-gcc14-x64-release-cov-abc1234'
 
     def test_legacy_sanitized_suffix_is_gone(self):
-        # Regression guard: if someone reverts to the old '-sanitized' suffix
-        # this test fails immediately.
         for s in ['address', 'thread', 'leak', 'undefined', 'address,undefined']:
             name = art.artifactory_archive_name(_make_target(sanitize=s))
             assert 'sanitized' not in name, f'old suffix returned for sanitize={s!r}'

--- a/tests/test_sanitizer_naming/test_sanitizer_naming.py
+++ b/tests/test_sanitizer_naming/test_sanitizer_naming.py
@@ -26,14 +26,12 @@ class TestVariantSuffix:
         assert _suffix(long_name) == '-' + short
 
     def test_each_sanitizer_gets_its_own_field(self):
-        # One spelling for the build dir and the archive name. Nothing parses these names back into
-        # fields, so '-' can separate every token in both.
+        # Nothing parses these names back into fields, so '-' can separate every token in both names.
         assert _suffix('address,undefined') == '-asan-ubsan'
         assert _suffix('thread,leak') == '-tsan-lsan'
 
     def test_the_sanitizer_order_is_preserved(self):
-        # The suffix keeps the order the user passed. Nothing in the build cares, and a
-        # deterministic function of the input is easier to reproduce.
+        # The suffix keeps the order the user passed: a deterministic function of the input is easier to reproduce.
         assert _suffix('undefined,address') == '-ubsan-asan'
 
     def test_unknown_sanitizer_passed_through_verbatim(self):
@@ -79,8 +77,7 @@ class TestArchiveName:
         assert name == 'pkg-linux-24-gcc14-x64-debug-ubsan-abc1234'
 
     def test_a_coverage_build_no_longer_shares_the_plain_name(self):
-        # A coverage build produces instrumented binaries. It used to upload under the plain name and
-        # serve them to every consumer that asked for a normal build.
+        # A coverage build produces instrumented binaries, so the plain name would serve them to normal consumers.
         name = art.artifactory_archive_name(_make_target(coverage='default'))
         assert name == 'pkg-linux-24-gcc14-x64-release-cov-abc1234'
 

--- a/tests/test_self_version_probe/test_self_version_probe.py
+++ b/tests/test_self_version_probe/test_self_version_probe.py
@@ -106,9 +106,7 @@ class TestFetchSelfVersionFromRemote:
             mock_show.assert_not_called()
 
     def test_returns_none_for_local_mamafile_override(self):
-        # A parent-repo override (dep.mamafile is a resolved local path) is not in the remote
-        # repo: `git show HEAD:<local path>` can never work, and the local file was already
-        # checked by resolve_pinned_version. Must return None without any network work.
+        # A parent-repo override is a local path not in the remote repo: return None without any network work.
         dep, git = _make_dep()
         dep.mamafile = 'C:/parent/mamadeps/libfoo.py'
         with patch.object(Git, '_run_git_with_filtered_progress') as mock_clone, \
@@ -128,8 +126,7 @@ class TestFetchSelfVersionFromRemote:
         assert 'HEAD:subdir/mama_alt.py' in captured['cmd']
 
     def test_uses_blobless_no_checkout_clone_and_probe_label(self):
-        # PROBE label keeps update_stats.record_clone from firing for what is not a real clone.
-        # --filter=blob:none + --no-checkout keep the fetch under a kilobyte.
+        # PROBE label keeps record_clone from firing. --filter=blob:none + --no-checkout keep the fetch under a kilobyte.
         dep, git = _make_dep()
         captured = {}
         def fake_clone(self_, dep_, cmd, label):
@@ -213,9 +210,7 @@ class TestShimProbeFallback:
         assert fetch_versions == [None, '1.0']
 
     def test_pinned_probe_miss_gets_no_fallback(self):
-        # A local mamafile pin makes the FIRST probe version-named (applied inside
-        # fetch_and_reconfigure). On a miss there must be no hash-named re-probe: any
-        # hash-named archive predates the pin, which was bumped precisely to bury it.
+        # A pin makes the FIRST probe version-named. On a miss, no hash-named re-probe: such an archive predates the pin.
         dep, _ = _make_dep()
         def fake_fetch(target):
             target.version = '34.0'  # what resolve_pinned_version does on the real path
@@ -255,8 +250,7 @@ class TestResolvePinnedVersion:
         return dep
 
     def test_reads_pin_from_mamafile_on_disk(self, tmp_path):
-        # version pinned inside configure(): never executed on the download probe path,
-        # which is exactly why it must be read from disk instead.
+        # configure() never runs on the download probe path, so the pin must be read from disk
         mf = tmp_path / 'protobuf.py'
         mf.write_text("class protobuf:\n"
                       "    def configure(self):\n"

--- a/tests/test_self_version_probe/test_self_version_probe.py
+++ b/tests/test_self_version_probe/test_self_version_probe.py
@@ -128,7 +128,7 @@ class TestFetchSelfVersionFromRemote:
         assert 'HEAD:subdir/mama_alt.py' in captured['cmd']
 
     def test_uses_blobless_no_checkout_clone_and_probe_label(self):
-        # PROBE label keeps update_stats.record_clone from firing for what isn't a real clone.
+        # PROBE label keeps update_stats.record_clone from firing for what is not a real clone.
         # --filter=blob:none + --no-checkout keep the fetch under a kilobyte.
         dep, git = _make_dep()
         captured = {}

--- a/tests/test_source_change/test_source_change.py
+++ b/tests/test_source_change/test_source_change.py
@@ -69,7 +69,7 @@ def test_legacy_status_without_tree_line_treated_as_clean(tmp_path):
 def _should_build_reasons(dep, loaded_from_pkg):
     conf = dep.config; conf.print = True
     target = Mock(name='t'); target.name = dep.name; target.args = []; target.build_products = []
-    dep.target = target  # so the fall-through (no source change) path doesn't crash
+    dep.target = target  # so the fall-through (no source change) path does not crash
     with patch('mama.build_dependency.warning') as w:
         built = dep._should_build(conf, target, is_target=False, git_changed=False, loaded_from_pkg=loaded_from_pkg)
     return built, ' '.join(str(c) for c in w.call_args_list)

--- a/tests/test_source_change/test_source_change.py
+++ b/tests/test_source_change/test_source_change.py
@@ -76,8 +76,7 @@ def _should_build_reasons(dep, loaded_from_pkg):
 
 
 def test_source_edit_rebuilds_git_dep_even_when_from_artifactory(tmp_path):
-    # regression: a prebuilt pkg can also have a source clone on disk; a `not from_artifactory`
-    # guard wrongly skipped the working-tree check for exactly that dep.
+    # a prebuilt pkg can also have a source clone on disk, so from_artifactory must not skip the working-tree check
     dep = _git_dep_with_repo(tmp_path)
     dep.from_artifactory = True
     (Path(dep.src_dir) / 'lib.cpp').write_text('int f(){return 9;}\n')

--- a/tests/test_ssh_multiplex/test_ssh_multiplex.py
+++ b/tests/test_ssh_multiplex/test_ssh_multiplex.py
@@ -135,8 +135,7 @@ class TestOptionsToAdd:
         assert any(o.startswith('-oServerAliveInterval=') for o in opts)
 
     def test_windows_skips_multiplex_keeps_keepalives(self, monkeypatch, tmp_path):
-        # Microsoft OpenSSH ControlMaster is unreliable, so native Windows skips
-        # multiplex entirely. Keepalives still help.
+        # Microsoft OpenSSH ControlMaster is unreliable, so native Windows skips multiplex entirely. Keepalives still help.
         monkeypatch.setattr(sm.System, 'windows', True)
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
         monkeypatch.setattr(sm, '_OUR_CONTROL_PATH', str(tmp_path / 'cm' / '%C'))
@@ -151,8 +150,7 @@ class TestOptionsToAdd:
         assert any(o.startswith('-oServerAliveCountMax=') for o in opts)
 
     def test_windows_user_configured_multiplex_respected(self, monkeypatch):
-        # a user who configured multiplex (e.g. ~/.ssh/config pointing at Cygwin ssh)
-        # keeps their config untouched, even on Windows
+        # a user who configured multiplex (for example via Cygwin ssh) keeps their config untouched, even on Windows
         monkeypatch.setattr(sm.System, 'windows', True)
         probe = {
             'controlmaster': 'auto', 'controlpath': '~/.ssh/sockets/%C',
@@ -249,9 +247,7 @@ class TestEnsureMasterIdempotent:
         assert sm._warmed[('git', 'example.com', None)]['we_own_master'] is True
 
     def test_prewarm_failure_strips_multiplex_opts(self, monkeypatch, tmp_path):
-        # When _open_master fails, ControlMaster/Path/Persist must leave opts.
-        # Otherwise N parallel fetches race to be the master and trigger
-        # N concurrent auths, the exact thing this is meant to prevent.
+        # When _open_master fails, Control* must leave opts, or N parallel fetches race to be the master and auth N times.
         monkeypatch.setattr(sm, '_warmed', {})
         monkeypatch.setattr(sm, '_per_host_locks', {})
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
@@ -310,9 +306,7 @@ class TestWrapperPathSafety:
         wrapper = os.path.abspath(os.path.join(
             os.path.dirname(__file__), '..', '..', 'mama', 'utils', 'mama_ssh.py'))
         mama_dir = os.path.dirname(os.path.dirname(wrapper))
-        # A subprocess gives a fresh interpreter with no pre-cached `types`.
-        # os.execvp becomes a no-op BEFORE the wrapper runs, so the wrapper
-        # cannot replace the process before the probe reads sys.path back.
+        # A fresh interpreter has no pre-cached `types`. A no-op os.execvp lets the probe read sys.path back after the wrapper.
         probe = tmp_path / 'probe.py'
         probe.write_text(textwrap.dedent(f"""
             import json, os, sys

--- a/tests/test_ssh_multiplex/test_ssh_multiplex.py
+++ b/tests/test_ssh_multiplex/test_ssh_multiplex.py
@@ -18,7 +18,6 @@ class TestParseSshEndpoint:
         assert sm.parse_ssh_endpoint('alice@host.example:proj.git') == ('alice', 'host.example', None)
 
     def test_scp_form_no_user(self):
-        # Falls back to default 'git' user.
         assert sm.parse_ssh_endpoint('host.example:proj.git') == ('git', 'host.example', None)
 
     def test_ssh_url_with_port(self):
@@ -48,16 +47,15 @@ class TestParseSshEndpoint:
         assert sm.parse_ssh_endpoint(None) is None
 
     def test_windows_path_rejected(self):
-        # Windows drive paths must NOT be treated as scp-form.
+        # a drive letter also reads as an scp-form host
         assert sm.parse_ssh_endpoint('C:/foo/bar') is None
         assert sm.parse_ssh_endpoint('D:\\repos\\proj') is None
 
     def test_host_with_no_path_rejected(self):
-        # `host:` with nothing after isn't a real git URL.
         assert sm.parse_ssh_endpoint('git@host:') is None
 
     def test_bracketed_ipv6_rejected(self):
-        # git itself doesn't treat scp-form bracketed IPv6 as a URL.
+        # git itself does not treat scp-form bracketed IPv6 as a URL
         assert sm.parse_ssh_endpoint('git@[::1]:repo.git') is None
 
 
@@ -79,7 +77,7 @@ class TestIsMultiplexConfigured:
         assert not sm.is_multiplex_configured({'controlmaster': 'no', 'controlpath': '/tmp/sock'})
 
     def test_empty_probe(self):
-        # When ssh -G fails the probe is empty; treat as "not configured".
+        # when ssh -G fails, the probe is empty and must read as "not configured"
         assert not sm.is_multiplex_configured({})
 
 
@@ -96,9 +94,9 @@ class TestOptionsToAdd:
         assert we_own is False
 
     def test_user_has_nothing(self, tmp_path, monkeypatch):
-        # Pin the multiplex-enabled path; native-Windows skip has its own tests.
+        # pin the multiplex-enabled path. The native-Windows skip has its own tests.
         monkeypatch.setattr(sm.System, 'windows', False)
-        # Avoid mkdir on the user's actual ~/.ssh/cm.
+        # avoid mkdir on the user's actual ~/.ssh/cm
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
         monkeypatch.setattr(sm, '_OUR_CONTROL_PATH', str(tmp_path / 'cm' / '%C'))
         probe = {'controlmaster': 'no', 'controlpath': 'none'}
@@ -120,7 +118,7 @@ class TestOptionsToAdd:
         }
         opts, we_own = sm.options_to_add(probe)
         assert we_own is True
-        # We add multiplex but NOT keepalives (user has them already).
+        # multiplex added, keepalives not: the user already has them
         assert any(o.startswith('-oControlMaster=') for o in opts)
         assert not any(o.startswith('-oServerAliveInterval=') for o in opts)
         assert not any(o.startswith('-oServerAliveCountMax=') for o in opts)
@@ -132,14 +130,13 @@ class TestOptionsToAdd:
         }
         opts, we_own = sm.options_to_add(probe)
         assert we_own is False
-        # No control* options; only keepalives.
         assert not any(o.startswith('-oControlMaster=') for o in opts)
         assert not any(o.startswith('-oControlPath=') for o in opts)
         assert any(o.startswith('-oServerAliveInterval=') for o in opts)
 
     def test_windows_skips_multiplex_keeps_keepalives(self, monkeypatch, tmp_path):
-        # Native Windows: Microsoft OpenSSH ControlMaster is unreliable in
-        # practice, so we skip multiplex entirely. Keepalives still help.
+        # Microsoft OpenSSH ControlMaster is unreliable, so native Windows skips
+        # multiplex entirely. Keepalives still help.
         monkeypatch.setattr(sm.System, 'windows', True)
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
         monkeypatch.setattr(sm, '_OUR_CONTROL_PATH', str(tmp_path / 'cm' / '%C'))
@@ -154,9 +151,8 @@ class TestOptionsToAdd:
         assert any(o.startswith('-oServerAliveCountMax=') for o in opts)
 
     def test_windows_user_configured_multiplex_respected(self, monkeypatch):
-        # If the user has multiplex explicitly configured (e.g. via
-        # ~/.ssh/config pointing at Cygwin ssh) we respect their config and
-        # don't add anything - even on Windows.
+        # a user who configured multiplex (e.g. ~/.ssh/config pointing at Cygwin ssh)
+        # keeps their config untouched, even on Windows
         monkeypatch.setattr(sm.System, 'windows', True)
         probe = {
             'controlmaster': 'auto', 'controlpath': '~/.ssh/sockets/%C',
@@ -168,8 +164,8 @@ class TestOptionsToAdd:
 
 
 class TestMultiplexKnownBroken:
-    """Multiplex is disabled on native Windows; everywhere else it's fine.
-    WSL/Cygwin/Git-Bash run as Linux from Python's POV (System.windows=False)."""
+    """WSL, Cygwin and Git-Bash run as Linux from Python (System.windows is False), so only
+    native Windows disables multiplex."""
 
     def test_non_windows_not_broken(self, monkeypatch):
         monkeypatch.setattr(sm.System, 'windows', False)
@@ -223,7 +219,7 @@ class TestEnsureMasterIdempotent:
             return {'controlmaster': 'auto', 'controlpath': '/tmp/x'}
         monkeypatch.setattr(sm, 'probe_ssh_config', fake_probe)
 
-        # User already has multiplex => we DON'T start a master, just remember.
+        # the user already has multiplex, so no master is started, only remembered
         url = 'git@github.com:foo/bar.git'
         sm.ensure_master_for_url(url)
         sm.ensure_master_for_url(url)
@@ -253,10 +249,9 @@ class TestEnsureMasterIdempotent:
         assert sm._warmed[('git', 'example.com', None)]['we_own_master'] is True
 
     def test_prewarm_failure_strips_multiplex_opts(self, monkeypatch, tmp_path):
-        # When _open_master fails, we MUST clear ControlMaster/Path/Persist
-        # from opts. Otherwise N parallel fetches would race to be the master
-        # and trigger N concurrent auths - the exact thing this is meant to
-        # prevent.
+        # When _open_master fails, ControlMaster/Path/Persist must leave opts.
+        # Otherwise N parallel fetches race to be the master and trigger
+        # N concurrent auths, the exact thing this is meant to prevent.
         monkeypatch.setattr(sm, '_warmed', {})
         monkeypatch.setattr(sm, '_per_host_locks', {})
         monkeypatch.setattr(sm, '_OUR_CONTROL_DIR', str(tmp_path / 'cm'))
@@ -277,8 +272,6 @@ class TestEnsureMasterIdempotent:
         assert any(o.startswith('-oServerAliveInterval=') for o in info['opts'])
 
     def test_concurrent_ensure_probes_once(self, monkeypatch, tmp_path):
-        """50 threads racing on the same host must result in exactly one probe
-        and at most one master start."""
         import threading
         monkeypatch.setattr(sm, '_warmed', {})
         monkeypatch.setattr(sm, '_per_host_locks', {})
@@ -307,10 +300,8 @@ class TestEnsureMasterIdempotent:
 
 
 class TestWrapperPathSafety:
-    """Regression: running mama_ssh.py as a script must not shadow stdlib
-    modules. Earlier versions inserted `<...>/mama` onto sys.path, which made
-    `mama/types/` shadow Python's stdlib `types` module - breaking `contextlib`
-    on uv-installed Pythons that hadn't pre-imported it."""
+    """Running mama_ssh.py as a script must not put the mama dir on sys.path.
+    There `mama/types/` shadows the stdlib `types` module and breaks `contextlib`."""
 
     def test_invocation_does_not_put_mama_dir_on_syspath(self, tmp_path):
         import json
@@ -319,9 +310,9 @@ class TestWrapperPathSafety:
         wrapper = os.path.abspath(os.path.join(
             os.path.dirname(__file__), '..', '..', 'mama', 'utils', 'mama_ssh.py'))
         mama_dir = os.path.dirname(os.path.dirname(wrapper))
-        # Subprocess so we get a fresh interpreter (no pre-cached `types` etc).
-        # Monkey-patch os.execvp to a no-op BEFORE running the wrapper, so it
-        # can't replace the process before we read sys.path back.
+        # A subprocess gives a fresh interpreter with no pre-cached `types`.
+        # os.execvp becomes a no-op BEFORE the wrapper runs, so the wrapper
+        # cannot replace the process before the probe reads sys.path back.
         probe = tmp_path / 'probe.py'
         probe.write_text(textwrap.dedent(f"""
             import json, os, sys
@@ -347,12 +338,9 @@ class TestWrapperPathSafety:
 
 
 class TestWrapperMain:
-    """The wrapper passes options + destination unchanged to ssh -G, then
-    exec's ssh with whatever extra -o flags are needed."""
-
     def test_passthrough_when_user_has_full_config(self, monkeypatch):
         from mama.utils import mama_ssh
-        # Simulate ssh -G saying user has multiplex + keepalives configured.
+        # ssh -G reports that the user has multiplex and keepalives configured
         full = (
             "controlmaster auto\ncontrolpath /tmp/x\n"
             "serveraliveinterval 30\nserveralivecountmax 3\n"
@@ -368,7 +356,7 @@ class TestWrapperMain:
                        'git@github.com', "git-upload-pack 'foo/bar.git'"])
         prog, argv = execed
         assert prog == 'ssh'
-        # Only the always-on safety opts are added; user already has multiplex + keepalives.
+        # only the always-on safety opts are added: the user has the rest
         assert argv == ['ssh', *sm._SAFETY_OPTS, '-o', 'SendEnv=GIT_PROTOCOL', 'git@github.com',
                         "git-upload-pack 'foo/bar.git'"]
 
@@ -388,7 +376,6 @@ class TestWrapperMain:
         mama_ssh.main(['mama_ssh.py', 'git@example.com', 'git-upload-pack'])
         prog, argv = execed
         assert prog == 'ssh'
-        # Multiplex + keepalives are inserted before the original args.
         assert any(a.startswith('-oControlMaster=') for a in argv)
         assert any(a.startswith('-oControlPath=') for a in argv)
         assert any(a.startswith('-oServerAliveInterval=') for a in argv)
@@ -485,7 +472,7 @@ class TestControlDir:
         assert sm._control_dir_candidates()[0] == f'/run/user/1000/{sm._CONTROL_SUBDIR}'
 
     def test_a_long_temp_dir_falls_back_to_a_short_one(self, monkeypatch):
-        # macOS $TMPDIR is /var/folders/<2>/<27>/T/, long enough to blow the socket budget with %C
+        # macOS $TMPDIR is /var/folders/<2>/<27>/T/, long enough to exceed the socket budget with %C
         monkeypatch.delenv('XDG_RUNTIME_DIR', raising=False)
         monkeypatch.setattr(sm.tempfile, 'gettempdir', lambda: '/var/folders/ab/' + 'x' * 80 + '/T')
         assert sm._control_dir_candidates()[0].startswith('/tmp/')

--- a/tests/test_stale_dep/test_stale_dep.py
+++ b/tests/test_stale_dep/test_stale_dep.py
@@ -1,3 +1,4 @@
+"""Integration: pins that `mama update` moves a dependency clone reset to a stale commit back to the latest."""
 from testutils import init, mama_exec, shell_exec, file_contains, native_platform_name
 from mama.types.git import Git
 
@@ -19,7 +20,7 @@ def switch_to_stale_commit(dep_name):
     with open(status_file, 'w') as f:
         f.write(Git.format_git_status(REPO_URL, '', '', OLD_SHORT))
 
-# Simulates stale dependency updating
+
 def test_stale_dep(tmp_path):
     init(__file__, tmp_path)
 

--- a/tests/test_sub_process/test_sub_process.py
+++ b/tests/test_sub_process/test_sub_process.py
@@ -33,7 +33,7 @@ class TestExitStatus:
         assert status == 7
 
     def test_run_without_io_func_inherits_stdio(self, capfd):
-        # No io_func means child writes go straight to parent stdio; capfd hooks at OS level.
+        # no io_func means child writes go straight to parent stdio, and capfd hooks at the OS level
         status = SubProcess.run([PY, '-c', 'print("hello-no-iofunc")'])
         assert status == 0
         assert 'hello-no-iofunc' in capfd.readouterr().out
@@ -62,7 +62,7 @@ class TestIoFunc:
         assert not any(line.endswith('\r') or line.endswith('\n') for line in lines)
 
     def test_io_func_exception_is_re_raised_by_run(self):
-        # Reader-thread exceptions must surface; otherwise debugging is impossible.
+        # a reader-thread exception swallowed on its own thread is undebuggable
         def broken(p, line): raise RuntimeError(f'callback boom on line={line!r}')
         with pytest.raises(RuntimeError, match='callback boom'):
             SubProcess.run([PY, '-c', 'print("hi")'], io_func=broken)
@@ -144,7 +144,7 @@ class TestStdinWrite:
         assert 'READY' in lines and 'got:the-secret' in lines
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='PTY behaviour is UNIX-only')
+@pytest.mark.skipif(sys.platform == 'win32', reason='PTY behavior is UNIX-only')
 class TestPtyOnUnix:
     def test_child_sees_a_tty_when_io_func_is_set(self):
         # Why pty.openpty(): git inspects isatty(stderr) to decide whether to emit progress.
@@ -152,7 +152,7 @@ class TestPtyOnUnix:
         assert lines == ['True']
 
     def test_child_does_not_see_a_tty_without_io_func(self, capfd):
-        # No PTY allocated when capture isn't requested; child runs cleanly through to exit.
+        # no PTY is allocated when capture is not requested, and the child still runs to exit
         assert SubProcess.run([PY, '-c', 'import sys; sys.exit(0)']) == 0
 
 
@@ -346,13 +346,13 @@ class TestCtrlCTermination:
         while time.monotonic() < end and psutil.pid_exists(gc_pid): time.sleep(0.02)
         alive = psutil.pid_exists(gc_pid)
         if alive:
-            try: psutil.Process(gc_pid).kill()  # don't leak a 60s sleeper if the assert fails
+            try: psutil.Process(gc_pid).kill()  # do not leak a 60s sleeper if the assert fails
             except Exception: pass
         assert not alive  # grandchild died with the tree
 
 
 class TestNoForkptyDeprecationWarning:
-    # The whole point of the Popen+pty.openpty rewrite was to kill this warning
+    # The Popen+pty.openpty rewrite exists to remove this warning
     # (Python 3.12 flags forkpty() in MT programs - real deadlock risk).
     def test_run_does_not_emit_forkpty_warning(self):
         import warnings

--- a/tests/test_sub_process/test_sub_process.py
+++ b/tests/test_sub_process/test_sub_process.py
@@ -50,8 +50,7 @@ class TestIoFunc:
         assert 'out' in lines and 'err' in lines
 
     def test_all_output_drained_on_nonzero_exit(self):
-        # Regression: close() must drain the reader BEFORE shutting the pipe, or a burst of lines flushed
-        # right before a failing exit (e.g. the compiler error that failed the build) is lost.
+        # close() must drain the reader BEFORE shutting the pipe, or a burst flushed right before a failing exit is lost
         status, lines = _py_run('import sys\nfor i in range(300): print("line%d" % i)\nsys.exit(1)')
         assert status == 1
         assert [l for l in lines if l.startswith('line')][-1] == 'line299'   # the tail is never dropped
@@ -70,8 +69,7 @@ class TestIoFunc:
 
 class TestCaptureContextPropagation:
     def test_io_func_console_routes_to_callers_capture_sink(self):
-        # io_func fires on the reader thread; without the capture context carried over, its console()
-        # would miss the caller's sink and leak above the live region (the parallel-build checkout leak).
+        # io_func fires on the reader thread: without the carried capture context, console() leaks above the live region
         sink = []
         def echo(p, line): system.console(f'got:{line}')  # mirrors run_git's prefixed() callback
         with system.capture_to(sink.append):
@@ -179,8 +177,7 @@ class TestCarriageReturnProgress:
         assert lines == ['[1/3] foo', '[2/3] bar', '[3/3] baz']
 
     def test_cr_at_chunk_end_flushes_on_idle(self):
-        # The slow-step write isolates a \r in its own chunk; without idle-flush
-        # the line would only appear when the next chunk arrives seconds later.
+        # A \r isolated at a chunk end must idle-flush, or the line only appears when the next chunk arrives seconds later.
         _, lines = _py_run(
             r'import sys, time; '
             r'sys.stdout.write("[1/2] slow_step\r"); sys.stdout.flush(); '
@@ -189,8 +186,7 @@ class TestCarriageReturnProgress:
         assert lines == ['[1/2] slow_step', '[2/2] done']
 
     def test_lone_lf_after_cr_idle_flush_does_not_emit_empty_line(self):
-        # After idle-flushing on \r, a delayed \n (or PTY-ONLCR \r\n) is part
-        # of the same logical line and must be swallowed, not emit "".
+        # After idle-flushing on \r, a delayed \n (or PTY-ONLCR \r\n) is the same logical line: swallow it, do not emit "".
         _, lines = _py_run(
             r'import sys, time; '
             r'sys.stdout.write("partial\r"); sys.stdout.flush(); '
@@ -263,8 +259,7 @@ class TestDrainBuffer:
         assert d.feed(b'xyz\n') == ['prog', 'xyz']
 
     def test_crlf_split_across_chunks_is_not_progress(self):
-        # \r held at a non-idle boundary must pair with the next chunk's \n
-        # as one CRLF line, never flush as progress then swallow.
+        # A \r held at a non-idle boundary must pair with the next chunk's \n as one CRLF line, never flush as progress.
         d = _Drainer()
         assert d.feed(b'abc\r') == [] and d.buf == b'abc\r'
         assert d.feed(b'\ndef\n') == ['abc', 'def']
@@ -327,8 +322,7 @@ class TestCtrlCTermination:
         assert result.get('s', 0) != 0  # nonzero status from the kill
 
     def test_kill_takes_down_the_grandchild_subtree(self, tmp_path):
-        # The point of tree-kill: a killed cmake's ninja/compiler grandchildren must die too, not
-        # just the spawned pid. Stand-in: a child that spawns a long-sleeping grandchild.
+        # Tree-kill: a killed cmake's ninja/compiler grandchildren must die too, not just the spawned pid.
         import threading, time
         from mama.utils import sub_process
         psutil = pytest.importorskip('psutil')
@@ -352,8 +346,7 @@ class TestCtrlCTermination:
 
 
 class TestNoForkptyDeprecationWarning:
-    # The Popen+pty.openpty rewrite exists to remove this warning
-    # (Python 3.12 flags forkpty() in MT programs - real deadlock risk).
+    # The Popen+pty.openpty rewrite removes this warning. Python 3.12 flags forkpty() in MT programs, a real deadlock risk.
     def test_run_does_not_emit_forkpty_warning(self):
         import warnings
         with warnings.catch_warnings(record=True) as caught:
@@ -364,8 +357,7 @@ class TestNoForkptyDeprecationWarning:
 
 
 class TestExecuteEchoCapture:
-    # A custom build()'s self.run() -> execute_echo must feed the active display sink (not the raw
-    # terminal) while a build phase captures, but stay stdio-direct for interactive post-pass commands.
+    # execute_echo must feed the active display sink while a build phase captures, but stay stdio-direct for interactive commands
     def test_captures_into_active_sink(self):
         from mama.utils.sub_process import execute_echo
         captured = []

--- a/tests/test_subprocess_audit/test_subprocess_audit.py
+++ b/tests/test_subprocess_audit/test_subprocess_audit.py
@@ -6,8 +6,7 @@ import pytest
 
 _MAMA = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'mama')
 _SPAWN = re.compile(r'subprocess\.(run|Popen|check_output|call|check_call)\(|os\.(system|popen)\(')
-# Every raw spawn that is allowed, and why. sub_process.py IS the wrapper. ssh must stay silent,
-# because ssh warns once per bad ssh_config line. The two git probes swallow an expected `fatal:`.
+# Allowed raw spawns: sub_process.py IS the wrapper, ssh warns per bad ssh_config line, the git probes swallow a `fatal:`.
 _ALLOWED = {'utils/sub_process.py', 'utils/ssh_multiplex.py', 'types/git.py', 'util.py'}
 
 
@@ -37,8 +36,7 @@ def test_every_allowed_spawn_captures_stderr():
             call = ' '.join(lines[n - 1:n + 1])  # keyword args often wrap onto the next line
             if 'stderr=' in call or 'capture_output' in call: continue
             leaks.append(f'{rel}: {line.strip()}')
-    # Two stay by design: the no-capture Popen (io_func=None hands the child the real terminal) and
-    # execute(), the interactive launcher for `code` / `open` / a prompting apt-get. Pinned by code,
-    # not by line number, so an edit above them does not fail this test.
+    # Two stay by design: the no-capture Popen (io_func=None hands the child the real terminal) and the interactive
+    # execute(). Pinned by code, not by line number, so an edit above them does not fail this test.
     assert leaks == ['utils/sub_process.py: self.process = subprocess.Popen(args, cwd=cwd, env=env)',
                      'utils/sub_process.py: retcode = os.system(command)']

--- a/tests/test_subprocess_audit/test_subprocess_audit.py
+++ b/tests/test_subprocess_audit/test_subprocess_audit.py
@@ -6,8 +6,8 @@ import pytest
 
 _MAMA = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'mama')
 _SPAWN = re.compile(r'subprocess\.(run|Popen|check_output|call|check_call)\(|os\.(system|popen)\(')
-# Every raw spawn that is allowed, and why. sub_process.py IS the wrapper; ssh must stay silent because
-# ssh warns once per bad ssh_config line; the two git probes swallow an expected `fatal:`.
+# Every raw spawn that is allowed, and why. sub_process.py IS the wrapper. ssh must stay silent,
+# because ssh warns once per bad ssh_config line. The two git probes swallow an expected `fatal:`.
 _ALLOWED = {'utils/sub_process.py', 'utils/ssh_multiplex.py', 'types/git.py', 'util.py'}
 
 

--- a/tests/test_target_scoped_build/test_target_scoped_build.py
+++ b/tests/test_target_scoped_build/test_target_scoped_build.py
@@ -15,8 +15,7 @@ def _dep(name, children=(), usable=True):
 
 
 def _tree():
-    #  root -> X -> A(unbuilt), B(built)
-    #       -> C(unbuilt, unrelated to X)
+    #  root -> X -> {A(unbuilt), B(built)}, C(unbuilt, unrelated to X)
     a, b, c = _dep('A', usable=False), _dep('B'), _dep('C', usable=False)
     x = _dep('X', [a, b])
     return _dep('root', [x, c]), x, a, b, c
@@ -33,18 +32,14 @@ def test_an_unbuilt_dep_of_the_target_is_revived():
 
 
 def test_an_unbuilt_dep_outside_the_target_subtree_is_left_alone():
-    # Regression: marking every unbuilt dep in the workspace made `mama build target=protobuf` build
-    # unrelated targets - and a mamafile that shells out to `mama build target=Y` then re-entered
-    # itself, forking until the machine died.
+    # marking every unbuilt dep in the workspace builds unrelated targets and lets a shelling-out mamafile fork itself
     root, _, _, _, c = _tree()
     _mark(root)
     assert not c.should_rebuild
 
 
 def test_a_dep_that_depends_on_the_target_is_never_revived():
-    # The fork bomb, exactly: rpclib.configure() shells out to `mama build target=protobuf` to get a
-    # host protoc. If that child revives rpclib (it depends on protobuf, so it sits ABOVE it), the
-    # child re-enters the same configure() and spawns another child, forever.
+    # rpclib.configure() shells out to `mama build target=protobuf`. Reviving rpclib (ABOVE protobuf) re-enters it, forever.
     protobuf = _dep('protobuf', usable=False)
     rpc = _dep('rpclib', [protobuf], usable=False)
     root = _dep('myapp', [rpc], usable=False)
@@ -114,8 +109,7 @@ def _executed_deps(args, tmp_path):
 
 
 def test_building_one_target_does_not_execute_unrelated_targets(tmp_path):
-    # `mama build protobuf` used to hand every dep a job; the out-of-scope ones did no build work but
-    # still ran package(), which asserts on libs that were never built.
+    # an out-of-scope dep does no build work but would still run package(), which asserts on libs that were never built
     names = _executed_deps(['build', 'protobuf'], tmp_path)
     assert names == ['protobuf']
     assert 'rpcservice' not in names and 'myapp' not in names
@@ -127,8 +121,7 @@ def test_building_a_mid_tree_target_still_includes_what_it_needs(tmp_path):
 
 
 def test_uploading_one_target_does_not_execute_unrelated_targets(tmp_path):
-    # `mama upload protobuf` used to run build_phase (packaging) for the whole workspace; an unrelated
-    # dep then asserted on a lib that was never built. Scope it like a targeted build.
+    # upload must scope like a targeted build, or an unrelated dep packages libs that were never built
     names = _executed_deps(['upload', 'protobuf'], tmp_path)
     assert names == ['protobuf']
     assert 'rpcservice' not in names and 'myapp' not in names
@@ -159,8 +152,7 @@ def _runner_used(args, tmp_path):
 
 
 def test_a_single_target_build_still_uses_the_live_display(tmp_path):
-    # The scheduler owns the display, and the serial runner dumps raw cmake output. A one-dep
-    # graph must NOT fall back to it just because there is nothing to overlap.
+    # The scheduler owns the display and the serial runner dumps raw cmake output: a one-dep graph must not fall back to it.
     assert _runner_used(['build', 'protobuf'], tmp_path) == 'parallel'
 
 
@@ -169,8 +161,7 @@ def test_serial_flag_still_opts_out(tmp_path):
 
 
 def test_mamabuild_actually_revives_an_unbuilt_dep(tmp_path):
-    # Regression: mark_unbuilt_target_deps() was imported but never called, so this whole behavior was
-    # dead code - and the unit tests above passed because they call it directly. Drive mamabuild instead.
+    # the unit tests above call mark_unbuilt_target_deps directly, so only driving mamabuild proves the wiring exists
     (tmp_path / 'CMakeLists.txt').write_text('project(dummy)\n')
     protobuf = _dep('protobuf', usable=False)
     rpc = _dep('rpclib', [protobuf])
@@ -183,8 +174,7 @@ def test_mamabuild_actually_revives_an_unbuilt_dep(tmp_path):
 
 
 def test_has_usable_artifacts_survives_a_dep_whose_target_never_loaded(tmp_path):
-    # a dep can sit in the tree with target=None (mamafile failed to parse, clone interrupted); the
-    # scoping pass walks every child, so an unguarded self.target.build_products crashed the whole run
+    # a dep can sit in the tree with target=None (mamafile failed to parse), and the scoping pass walks every child
     from pathlib import Path
     dep = _artifact_dep(tmp_path)
     dep.target = None

--- a/tests/test_target_scoped_build/test_target_scoped_build.py
+++ b/tests/test_target_scoped_build/test_target_scoped_build.py
@@ -29,7 +29,7 @@ def _mark(root, target='X'):
 def test_an_unbuilt_dep_of_the_target_is_revived():
     root, _, a, _, _ = _tree()
     _mark(root)
-    assert a.should_rebuild      # else X compiles against an include dir that doesn't exist
+    assert a.should_rebuild      # else X compiles against an include dir that does not exist
 
 
 def test_an_unbuilt_dep_outside_the_target_subtree_is_left_alone():
@@ -123,7 +123,7 @@ def test_building_one_target_does_not_execute_unrelated_targets(tmp_path):
 
 def test_building_a_mid_tree_target_still_includes_what_it_needs(tmp_path):
     names = _executed_deps(['build', 'rpclib'], tmp_path)
-    assert set(names) == {'rpclib', 'protobuf'}   # its own dep comes along, its dependents don't
+    assert set(names) == {'rpclib', 'protobuf'}   # its own dep comes along, its dependents do not
 
 
 def test_uploading_one_target_does_not_execute_unrelated_targets(tmp_path):
@@ -136,7 +136,7 @@ def test_uploading_one_target_does_not_execute_unrelated_targets(tmp_path):
 
 def test_deploying_a_mid_tree_target_scopes_to_its_subtree(tmp_path):
     names = _executed_deps(['deploy', 'rpclib'], tmp_path)
-    assert set(names) == {'rpclib', 'protobuf'}   # deps come along to be packaged; dependents don't
+    assert set(names) == {'rpclib', 'protobuf'}   # deps come along to be packaged, dependents do not
 
 
 def test_an_untargeted_build_still_runs_the_whole_tree(tmp_path):
@@ -159,8 +159,8 @@ def _runner_used(args, tmp_path):
 
 
 def test_a_single_target_build_still_uses_the_live_display(tmp_path):
-    # the scheduler owns the display; the serial runner dumps raw cmake output, so a one-dep graph
-    # must NOT fall back to it just because there's nothing to overlap
+    # The scheduler owns the display, and the serial runner dumps raw cmake output. A one-dep
+    # graph must NOT fall back to it just because there is nothing to overlap.
     assert _runner_used(['build', 'protobuf'], tmp_path) == 'parallel'
 
 
@@ -169,7 +169,7 @@ def test_serial_flag_still_opts_out(tmp_path):
 
 
 def test_mamabuild_actually_revives_an_unbuilt_dep(tmp_path):
-    # Regression: mark_unbuilt_target_deps() was imported but never called, so this whole behaviour was
+    # Regression: mark_unbuilt_target_deps() was imported but never called, so this whole behavior was
     # dead code - and the unit tests above passed because they call it directly. Drive mamabuild instead.
     (tmp_path / 'CMakeLists.txt').write_text('project(dummy)\n')
     protobuf = _dep('protobuf', usable=False)
@@ -179,7 +179,7 @@ def test_mamabuild_actually_revives_an_unbuilt_dep(tmp_path):
          patch('mama.main.execute_unified'), \
          patch('mama.main.print_build_banner'):
         mamabuild(['build', 'rpclib'], source_dir=str(tmp_path))
-    assert protobuf.should_rebuild     # else rpclib compiles against an include dir that isn't there
+    assert protobuf.should_rebuild     # else rpclib compiles against an include dir that is not there
 
 
 def test_has_usable_artifacts_survives_a_dep_whose_target_never_loaded(tmp_path):

--- a/tests/test_toolchain_change_wipe/test_toolchain_change_wipe.py
+++ b/tests/test_toolchain_change_wipe/test_toolchain_change_wipe.py
@@ -28,7 +28,7 @@ def _read_fp(build_dir):
 
 
 def _run(t, dep, fingerprint='FP', configure_raises=False):
-    """run_config with the cmake call + seed coordinator stubbed and the fingerprint pinned; returns the
+    """run_config with the cmake call + seed coordinator stubbed and the fingerprint pinned. Returns the
     recorded conf calls (['conf'] => reconfigured, [] => skipped)."""
     calls = []
     def conf(*a, **k):
@@ -45,7 +45,7 @@ def _run(t, dep, fingerprint='FP', configure_raises=False):
     return calls
 
 
-# ── _cache_entry (CMakeCache line parser) ────────────────────────────────────
+# -- _cache_entry (CMakeCache line parser) ------------------------------------
 
 def test_cache_entry_parses_typed_untyped_and_missing():
     text = 'CMAKE_CXX_COMPILER:FILEPATH=/opt/clang++\nBARE=value\nCMAKE_C_COMPILER=/no/type\n'
@@ -55,7 +55,7 @@ def test_cache_entry_parses_typed_untyped_and_missing():
     assert cc._cache_entry(text, 'CMAKE_ABSENT') == ''
 
 
-# ── _toolchain_moved_unfingerprinted (bootstrap heal for pre-fingerprint dirs) ─
+# -- _toolchain_moved_unfingerprinted (bootstrap heal for pre-fingerprint dirs) -
 
 def test_moved_unfingerprinted_true_when_compiler_path_changed(tmp_path):
     t, dep = make_configured_target(tmp_path, compiler=('/opt/ndk-B/clang', '/opt/ndk-B/clang++', '21'))
@@ -91,7 +91,7 @@ def test_moved_unfingerprinted_false_when_no_explicit_compiler(tmp_path):
     assert cc._toolchain_moved_unfingerprinted(t.build_dir(), t) is False
 
 
-# ── run_config: recorded-fingerprint path ────────────────────────────────────
+# -- run_config: recorded-fingerprint path ------------------------------------
 
 def test_changed_fingerprint_wipes_and_reconfigures(tmp_path):
     t, dep = make_configured_target(tmp_path)
@@ -109,7 +109,7 @@ def test_matching_fingerprint_skips_without_touching_the_dir(tmp_path):
     assert _read_fp(t.build_dir()) == 'SAME'
 
 
-# ── run_config: unfingerprinted (pre-feature) dirs ───────────────────────────
+# -- run_config: unfingerprinted (pre-feature) dirs ---------------------------
 
 def test_unfingerprinted_moved_compiler_heals_once(tmp_path):
     t, dep = make_configured_target(tmp_path, compiler=('/opt/ndk-B/clang', '/opt/ndk-B/clang++', '21'))
@@ -130,7 +130,7 @@ def test_unfingerprinted_unchanged_compiler_is_adopted_not_wiped(tmp_path):
     assert _read_fp(t.build_dir()) == 'FP'
 
 
-# ── run_config: fresh dir + one-shot + flip-flop + failure ───────────────────
+# -- run_config: fresh dir + one-shot + flip-flop + failure -------------------
 
 def test_fresh_dir_configures_and_records_fingerprint(tmp_path):
     t, dep = make_configured_target(tmp_path)   # no cache at all
@@ -152,7 +152,7 @@ def test_wipe_is_one_shot_not_repeating(tmp_path):
     t, dep = make_configured_target(tmp_path)
     _valid_cache(t.build_dir()); _write_fp(t.build_dir(), 'OLD')
     assert _run(t, dep, fingerprint='NEW') == ['conf']
-    _valid_cache(t.build_dir())                          # emulate the reconfigure the stub didn't rerun
+    _valid_cache(t.build_dir())                          # emulate the reconfigure the stub did not rerun
     assert _run(t, dep, fingerprint='NEW') == []         # fingerprint now matches -> no second wipe
     assert os.path.exists(t.build_dir('CMakeCache.txt'))
 
@@ -164,7 +164,7 @@ def test_failed_configure_records_no_fingerprint_baseline(tmp_path):
     assert _read_fp(t.build_dir()) == ''        # a broken configure must not leave a false baseline
 
 
-# ── the wrapper itself is a pure hash of _seed_inputs (no wrapper-level drift) ─
+# -- the wrapper itself is a pure hash of _seed_inputs (no wrapper-level drift) -
 
 def test_toolchain_fingerprint_is_a_pure_hash_of_seed_inputs():
     with patch('mama.buildsys.cmake.configure._seed_inputs', return_value={'cc': {'path': '/a'}}):

--- a/tests/test_toolchain_change_wipe/test_toolchain_change_wipe.py
+++ b/tests/test_toolchain_change_wipe/test_toolchain_change_wipe.py
@@ -120,8 +120,7 @@ def test_unfingerprinted_moved_compiler_heals_once(tmp_path):
 
 
 def test_unfingerprinted_unchanged_compiler_is_adopted_not_wiped(tmp_path):
-    # THE anti-mass-invalidation guarantee: a warm dir with an unchanged toolchain and no fingerprint yet is
-    # adopted (fingerprint recorded), never wiped.
+    # THE anti-mass-invalidation guarantee: a warm dir with an unchanged toolchain and no fingerprint is adopted, never wiped.
     cxx = tmp_path / 'clang++'; cxx.write_text('#!/bin/sh\n')
     t, dep = make_configured_target(tmp_path, compiler=(str(cxx), str(cxx), '21'))
     _valid_cache(t.build_dir(), cxx=str(cxx))

--- a/tests/test_unshallow_shim/test_unshallow_shim.py
+++ b/tests/test_unshallow_shim/test_unshallow_shim.py
@@ -40,7 +40,7 @@ def test_unshallow_converts_shim_to_clone_without_refetch(tmp_path):
     assert dep.is_artifactory_shim()
     clone_mock, fetch_mock = _load_unshallow_target(dep)
     clone_mock.assert_called_once()
-    fetch_mock.assert_not_called()    # the bug: post-clone probe re-fetched the pkg, making the clone moot
+    fetch_mock.assert_not_called()    # a post-clone pkg re-fetch would make the clone moot
     assert not dep.is_artifactory_shim()
     assert not dep.from_artifactory
 

--- a/tests/test_unshallow_shim/test_unshallow_shim.py
+++ b/tests/test_unshallow_shim/test_unshallow_shim.py
@@ -56,7 +56,7 @@ def test_unshallow_already_clone_target_skips_artifactory(tmp_path):
 
 
 def test_limbo_dir_is_wiped_and_recloned(tmp_path):
-    # A dropped shim leaves a non-.git dir (e.g. mama.cmake proxy): it can't be pulled, must reclone.
+    # A dropped shim leaves a non-.git dir (e.g. mama.cmake proxy): it cannot be pulled, must reclone.
     dep = make_mock_dep(tmp_path)
     os.makedirs(dep.src_dir, exist_ok=True)
     with open(f'{dep.src_dir}/mama.cmake', 'w') as f: f.write('# proxy stub\n')

--- a/tests/test_update_stats/test_update_stats.py
+++ b/tests/test_update_stats/test_update_stats.py
@@ -25,7 +25,6 @@ class TestCounters:
         assert s.total == 6
 
     def test_thread_safety(self):
-        """100 threads each incrementing all three counters must produce exact totals."""
         s = UpdateStats()
         def worker():
             for _ in range(100):
@@ -104,13 +103,12 @@ class TestSummaryLine:
         assert 'ms' in line or 's' in line  # either is valid depending on timing
 
     def test_kinds_order_is_shim_pull_clone(self):
-        """Stable ordering keeps the summary readable; shim is cheapest, clone is slowest."""
+        """Stable ordering keeps the summary readable. Shim is cheapest, clone is slowest."""
         s = UpdateStats()
         s.record_clone()
         s.record_pull()
         s.record_shim()
         line = s.summary_line()
-        # shim-fetched should appear before pulled, which appears before cloned
         i_shim = line.index('shim-fetched')
         i_pull = line.index('pulled')
         i_clone = line.index('cloned')
@@ -121,5 +119,4 @@ class TestSummaryLine:
         s.record_pull()
         line = s.summary_line()
         assert '1 pulled' in line
-        # zero counts should not appear
         assert '0 ' not in line

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -13,13 +13,13 @@ import pytest
 from mama.platforms.platform import Platform
 from mama.platforms.linux import Linux
 
-_ANSI = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')  # SGR colours + cursor moves
+_ANSI = re.compile(r'\x1b\[[0-9;]*[A-Za-z]')  # SGR colors + cursor moves
 def strip_ansi(s: str) -> str: return _ANSI.sub('', s)
 
 
 class FakeBuildTarget:
     """Base for the runner-test target fakes: the build-weight stubs the parallel runners call on
-    every dep (configure/build phase bodies and event recording stay specialised per test)."""
+    every dep (configure/build phase bodies and event recording stay specialized per test)."""
     _build_jobs = None
     def _has_custom_build(self): return False
     def _reserved_cores(self): return 4
@@ -40,7 +40,7 @@ class FakeUnifiedTarget(FakeBuildTarget):
 
 class FakeUnifiedDep:
     """Dep half of the execute_unified fakes: load() discovers `child_specs` (name, grandchild-specs)
-    on the spot, so the scheduler grows the graph the way a real clone does. Pass `shared_children`
+    at load time, so the scheduler grows the graph the way a real clone does. Pass `shared_children`
     instead to hand two parents the SAME instance and form a diamond."""
     def __init__(self, name, config, ev, lock, child_specs=(), shared_children=None):
         self.name = name; self.config = config; self._ev = ev; self._lock = lock
@@ -282,7 +282,7 @@ def make_load_root(name='mylib', **config_overrides):
 
 def make_mock_local_dep(tmp_path, src_dir, name='libfoo', always_build=False, **config_overrides):
     """Real BuildDependency wired to a mock BuildConfig + a LocalSource pointing at an existing
-    on-disk `src_dir`. build_dir is materialised so src_status round-trips."""
+    on-disk `src_dir`. build_dir is materialized so src_status round-trips."""
     from mama.build_dependency import BuildDependency
     from mama.types.local_source import LocalSource
     config = make_mock_config(tmp_path, **config_overrides)


### PR DESCRIPTION
Improve readability and consistency across the codebase by refining comments, docstrings, and documentation. This is a documentation-focused pass that clarifies intent, fixes grammar, and standardizes phrasing without changing functionality.

**Key changes:**

- **Docstring improvements**: Reworded class and function docstrings for clarity. Examples:
  - `BuildTarget`: "Describes one configurable build target" (more concise)
  - `_get_exported_libs`: Simplified explanation of versioned ELF names
  - `_get_hierarchical_libs`: Restructured for better flow and readability

- **Comment refinements**: Enhanced inline comments for precision:
  - Removed redundant or overly verbose explanations
  - Standardized phrasing (e.g., "a Unix linker needs" instead of "have to be sorted")
  - Fixed grammar and punctuation throughout

- **Documentation consistency**: 
  - Replaced em-dashes with ASCII dashes per project style
  - Changed "behaviour" to "behavior" (American English)
  - Updated section references from `§N` to `section N` in markdown

- **Removed or condensed verbose docstrings**: Several module-level docstrings were condensed to focus on essential information while preserving key details.

- **Minor wording updates**: 
  - "force delete" → "delete" (simpler)
  - "how we performed" → "result of" (clearer)
  - "the caller drops it" → "the caller drops it" (clarified with dash)

No functional changes. All modifications are to comments, docstrings, and documentation text.

https://claude.ai/code/session_017tz49YD7vSFUSLp11CpP4a