### PR TITLE
fix: mama init crash, is_file_unmodified rename, STE cleanup of over-long code lines

### DIFF
--- a/mama/artifactory.py
+++ b/mama/artifactory.py
@@ -219,7 +219,8 @@ def artifactory_upload_ftp(target:BuildTarget, file_path:str) -> bool:
             artifactory_ftp_login(ftp, config, url)
             if config.if_needed and artifact_already_exists(ftp, target, file_path):
                 if config.print:
-                    console(f'  - Artifactory Upload skipped: artifact already exists: {target.name}/{os.path.basename(file_path)}', color=Color.GREEN)
+                    console(f'  - Artifactory Upload skipped: artifact already exists: ' + \
+                            f'{target.name}/{os.path.basename(file_path)}', color=Color.GREEN)
                 return False # skip upload
             artifactory_upload(ftp, target.name, file_path)
             return True

--- a/mama/build_config.py
+++ b/mama/build_config.py
@@ -778,7 +778,8 @@ class BuildConfig:
         execute(f'sudo update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-{clang_major}   100')
         execute(f'sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-{clang_major} 100')
         execute(f'sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-{clang_major} 100')
-        execute(f'sudo update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/lib/llvm-{clang_major}/bin/run-clang-tidy 100')
+        execute(f'sudo update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy' + \
+                f' /usr/lib/llvm-{clang_major}/bin/run-clang-tidy 100')
         execute(f'sudo update-alternatives --set clang   /usr/bin/clang-{clang_major}')
         execute(f'sudo update-alternatives --set clang++ /usr/bin/clang++-{clang_major}')
         execute(f'sudo update-alternatives --set clang-tidy /usr/bin/clang-tidy-{clang_major}')
@@ -812,7 +813,8 @@ class BuildConfig:
 
         execute('curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg')
         execute('sudo mv /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg')
-        execute(f"sudo sh -c 'echo \"deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-{codename}-prod {codename} main\" > /etc/apt/sources.list.d/dotnetdev.list'")
+        execute(f"sudo sh -c 'echo \"deb [arch=amd64] https://packages.microsoft.com/repos/" + \
+                f"microsoft-ubuntu-{codename}-prod {codename} main\" > /etc/apt/sources.list.d/dotnetdev.list'")
         execute('sudo apt-get install apt-transport-https')
         execute('sudo apt-get update')
         execute('sudo apt-get install dotnet-sdk-2.1')
@@ -870,7 +872,7 @@ class BuildConfig:
         else:
             raise RuntimeError(f'Failed to install NDK to {final_dest}')
 
-        console(f'Adding ANDROID_NDK_HOME={final_dest} to ~/.bashrc, run source ~/.bashrc or restart terminal to populate your env.')
+        console(f'Added ANDROID_NDK_HOME={final_dest} to ~/.bashrc. Run source ~/.bashrc or restart the terminal.')
         # remove existing ANDROID_NDK_HOME from bashrc if exists
         execute('sed -i "/export ANDROID_NDK_HOME/d" ~/.bashrc')
         # add new ANDROID_NDK_HOME to bashrc

--- a/mama/build_dependency.py
+++ b/mama/build_dependency.py
@@ -700,7 +700,8 @@ class BuildDependency:
 
     def ensure_cmakelists_exists(self):
         if not os.path.exists(self.cmakelists_path()):
-            raise IOError(f'Could not find {self.cmakelists_path()}! Add a CMakelists.txt, or add `self.nothing_to_build()` to configuration step. Also note that filename CMakeLists.txt is case sensitive.')
+            raise IOError(f'{self.cmakelists_path()} not found. Add a CMakeLists.txt (the file name is case' + \
+                          ' sensitive), or call `self.nothing_to_build()` in the configure step.')
 
 
     def mamafile_path(self):

--- a/mama/build_target.py
+++ b/mama/build_target.py
@@ -258,7 +258,8 @@ class BuildTarget:
         return self.dep.add_child(LocalSource(name, source_dir, mamafile, always_build, args))
 
 
-    def add_git(self, name, git_url, git_branch='', git_tag='', git_commit='', mamafile=None, shallow=True, args=[]) -> BuildDependency:
+    def add_git(self, name, git_url, git_branch='', git_tag='', git_commit='',
+                mamafile=None, shallow=True, args=[]) -> BuildDependency:
         """
         Add a remote GIT dependency. Mama clones it and updates it during builds.
         Use `mama update` to force update the git repositories.
@@ -1515,7 +1516,8 @@ class BuildTarget:
             e_config = util.get_time_str(config_stop - config_start)
             e_build = util.get_time_str(build_stop - build_start)
             e_total = util.get_time_str(build_stop - config_start)
-            console(f"CMakeBuild {self.name} ({self.cmake_build_type}) config {e_config} build {e_build} total {e_total}", color=Color.GREEN)
+            console(f'CMakeBuild {self.name} ({self.cmake_build_type}) config {e_config}' + \
+                    f' build {e_build} total {e_total}', color=Color.GREEN)
 
 
     def is_test_target(self):

--- a/mama/init_project.py
+++ b/mama/init_project.py
@@ -30,7 +30,7 @@ class {project_name}(mama.BuildTarget):
         self.enable_cxx20()
         #self.add_cmake_options('BUILD_TESTS=ON', 'USE_SSE2=ON')
 
-    ## optional: customize package exports if repository doesn't have `include` or `src`
+    ## optional: customize package exports if the repository has no `include` or `src`
     ##           default include and lib export works for most common static libs
     #def package(self):
     #    self.export_libs('.', ['.lib', '.a']) # export any .lib or .a from build folder
@@ -123,7 +123,7 @@ def patch_existing_cmakelists(project_name, cmakefile):
             break
 
     if not inserted_link_lib:
-        console(f'  Could not find suitable target_link_libraries() for ${{MAMA_LIBS}}. Please insert one manually to your CMakeLists.txt')
+        console(f'  No target_link_libraries() suits ${{MAMA_LIBS}}. Insert one manually into your CMakeLists.txt')
 
     contents = ''.join(lines)
     write_text_to(cmakefile, contents)

--- a/mama/init_project.py
+++ b/mama/init_project.py
@@ -130,6 +130,7 @@ def patch_existing_cmakelists(project_name, cmakefile):
 
 
 def find_cpp_main(src_dir):
+    if not os.path.isdir(src_dir): return None
     # match any top-level src/ file with "main" in the name and a .cpp extension
     for entry in os.listdir(src_dir):
         if entry.endswith('.cpp') and 'main' in entry.lower():
@@ -169,7 +170,7 @@ def mama_init_project(root: BuildDependency):
     cmakelists = root.cmakelists_path()
     if not os.path.exists(cmakelists):
         console(f'{root.name} Creating new CMakeLists.txt: {cmakelists}')
-        write_default_cmakelists(root.name, cmakelists, cpp_main)
+        write_default_cmakelists(root.name, cmakelists)
     else:
         console(f'{root.name} Patching existing CMakeLists.txt: {cmakelists}')
         patch_existing_cmakelists(root.name, cmakelists)

--- a/mama/main.py
+++ b/mama/main.py
@@ -98,7 +98,7 @@ def print_usage():
     console('    mama build                     Update and build main project only. This only clones, but does not update!')
     console('    mama build x86 opencv          Cross compile build target opencv to x86 architecture')
     console('    mama build android             Cross compile to arm64 android NDK')
-    console('    mama build ndk-28              Cross compile specifically with Android NDK 28 (substring match, so 28.2 will also work)')
+    console('    mama build ndk-28              Cross compile with Android NDK 28 (substring match, 28.2 also works)')
     console('    mama build android-26 arm      Cross compile to armv7 android NDK API level 26')
     console('    mama update                    Update all dependencies by doing git pull and build.')
     console('    mama clean                     Cleans main project only.')

--- a/mama/package.py
+++ b/mama/package.py
@@ -194,7 +194,8 @@ def export_asset(target: BuildTarget, asset: str, category=None, build_dir=False
 
 def export_assets(target: BuildTarget, assets_path: str, pattern_substrings: list, category=None, build_dir=True):
     assets_path += '/'
-    assets = glob_with_name_match(target_root_path(target, assets_path, build_dir=build_dir), pattern_substrings, match_dirs=False)
+    assets = glob_with_name_match(target_root_path(target, assets_path, build_dir=build_dir),
+                                  pattern_substrings, match_dirs=False)
     if assets:
         for full_asset in assets:
             target.exported_assets.append(Asset(assets_path, full_asset, category))

--- a/mama/platforms/android.py
+++ b/mama/platforms/android.py
@@ -180,16 +180,14 @@ class Android(Platform):
                 for subdir in subdirs:
                     if self.ndk_version and not subdir.startswith(self.ndk_version):
                         if self.config.verbose:
-                            warning(f'Skipping NDK version {subdir} since it does not match the requested version {self.ndk_version}')
+                            warning(f'Skipping NDK {subdir}: does not match the requested version {self.ndk_version}')
                         continue
                     if os.path.exists(f'{sdk_path}/ndk/{subdir}/{ndk_build}'):
                         self.ndk_version = subdir
                         self._set_ndk_sdk_paths(f'{sdk_path}/ndk/{subdir}', sdk_path)
                         return
-        raise EnvironmentError(f'''Could not detect any Android NDK installations.
-Default search paths: {ndk_paths+sdk_paths}
-Define env ANDROID_NDK_HOME with path to the preferred NDK installation
-Or define env ANDROID_HOME with path to Android SDK root with valid NDK-s.''')
+        raise EnvironmentError(f'No Android NDK found. Searched: {ndk_paths+sdk_paths}. Set env' + \
+                               ' ANDROID_NDK_HOME to an NDK, or ANDROID_HOME to an SDK root that holds one.')
 
 
     def _build_toolchain(self) -> Toolchain:

--- a/mama/platforms/generic_yocto.py
+++ b/mama/platforms/generic_yocto.py
@@ -161,9 +161,8 @@ class GenericYocto(Platform):
         if self.config.print: self._print_toolchain_status()
 
         if not os.path.exists(self.compilers):
-            raise EnvironmentError(f'''No {self.name} toolchain compilers detected!
-    Default search paths: {paths}
-    Define env {envs[0]} with path to {self.name} tools.''')
+            raise EnvironmentError(f'No {self.name} toolchain compilers found. Searched: {paths}.' + \
+                                   f' Set env {envs[0]} to the {self.name} tools path.')
 
 
     def _print_toolchain_status(self):

--- a/mama/types/local_source.py
+++ b/mama/types/local_source.py
@@ -12,7 +12,8 @@ class LocalSource(DepSource):
         self.always_build = always_build
         self.args = args
 
-    def __str__(self):  return f'DepSource LocalSource {self.name} {self.rel_path} {self.mamafile} always_build={self.always_build}'
+    def __str__(self):
+        return f'DepSource LocalSource {self.name} {self.rel_path} {self.mamafile} always_build={self.always_build}'
     def __repr__(self): return self.__str__()
 
     # A local dep has no git_status of its own. The working-tree state of the enclosing repo gates

--- a/mama/util.py
+++ b/mama/util.py
@@ -14,7 +14,7 @@ def has_shim_marker(directory: str) -> bool:
     return os.path.exists(os.path.join(directory, MAMA_SHIM_FILENAME))
 
 
-def is_file_modified(src: str, dst: str):
+def is_file_unmodified(src: str, dst: str):
     return os.path.getmtime(src) == os.path.getmtime(dst) and\
            os.path.getsize(src) == os.path.getsize(dst)
 
@@ -36,7 +36,7 @@ def copy_files(fromFolder: str, toFolder: str, fileNames: List[str]):
             continue
         destFile = path_join(toFolder, os.path.basename(file))
         destFileExists = os.path.exists(destFile)
-        if destFileExists and is_file_modified(sourceFile, destFile):
+        if destFileExists and is_file_unmodified(sourceFile, destFile):
             console(f"skipping copy '{destFile}'")
             continue
         console(f"copyto '{toFolder}'  '{sourceFile}'")

--- a/tests/test_init_project/test_init_project.py
+++ b/tests/test_init_project/test_init_project.py
@@ -1,0 +1,32 @@
+"""Pins the mama init file-generation path."""
+import os
+from unittest.mock import Mock
+from mama.init_project import mama_init_project
+
+
+def _root(tmp_path, name='myproj'):
+    root = Mock()
+    root.name = name
+    root.src_dir = str(tmp_path)
+    root.mamafile_path = lambda: str(tmp_path / 'mamafile.py')
+    root.cmakelists_path = lambda: str(tmp_path / 'CMakeLists.txt')
+    return root
+
+
+def test_init_on_an_empty_dir_generates_all_three_files(tmp_path):
+    mama_init_project(_root(tmp_path))
+    assert (tmp_path / 'mamafile.py').exists()
+    assert (tmp_path / 'CMakeLists.txt').exists()
+    assert (tmp_path / 'src' / 'myproj_main.cpp').exists()
+
+
+def test_init_keeps_an_existing_cpp_main(tmp_path):
+    (tmp_path / 'src').mkdir()
+    (tmp_path / 'src' / 'my_main.cpp').write_text('int main() { return 0; }\n')
+    mama_init_project(_root(tmp_path))
+    assert not (tmp_path / 'src' / 'myproj_main.cpp').exists()
+
+
+def test_generated_cmakelists_names_the_project(tmp_path):
+    mama_init_project(_root(tmp_path))
+    assert 'project(myproj)' in (tmp_path / 'CMakeLists.txt').read_text()

--- a/tests/test_util/test_util.py
+++ b/tests/test_util/test_util.py
@@ -1,0 +1,19 @@
+"""Pins mama.util file helpers."""
+import os
+from mama.util import is_file_unmodified
+
+
+def _pair(tmp_path, a_text, b_text):
+    a, b = tmp_path / 'a', tmp_path / 'b'
+    a.write_text(a_text); b.write_text(b_text)
+    t = os.path.getmtime(a)
+    os.utime(b, (t, t))
+    return str(a), str(b)
+
+
+def test_is_file_unmodified_true_for_equal_mtime_and_size(tmp_path):
+    assert is_file_unmodified(*_pair(tmp_path, 'xx', 'yy'))
+
+
+def test_is_file_unmodified_false_on_size_change(tmp_path):
+    assert not is_file_unmodified(*_pair(tmp_path, 'xx', 'yyy'))


### PR DESCRIPTION
Three post-audit fixes, one commit each.

## Changes

1. **fix: `mama init` crashed on a fresh project.** `write_default_cmakelists` was called with three arguments but takes two, and `find_cpp_main` raised on a missing `src/` dir. The generated CMakeLists globs `src/*.cpp`, so it never needs the main file by name. New `tests/test_init_project/` pins the empty-dir run, the existing-main case, and the generated project name.
2. **refactor: rename `is_file_modified` to `is_file_unmodified`.** The function returns True when mtime and size are EQUAL, so the old name stated the opposite of the behavior. The one caller, `copy_files`, keeps its skip-the-copy semantics. New `tests/test_util/` pins it.
3. **cleanup: STE exception and console strings, wrap over-130-column code lines.** The two multi-line `EnvironmentError` blocks in `android.py` and `generic_yocto.py` are now single short sentences. All 12 over-130-column code lines are fixed by a shorter message or a 2-line wrap. The generated mamafile template loses its one contraction.

Resolves #36
Resolves #37

## Testing

Full suite green: 1408 passed, 4 skipped (5 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tz49YD7vSFUSLp11CpP4a

---
_Generated by [Claude Code](https://claude.ai/code/session_017tz49YD7vSFUSLp11CpP4a)_